### PR TITLE
refactor(core): replace console.log/warn/error with structured logger utility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,1 +1,23 @@
-{"extends": "next/core-web-vitals", "rules": {"react/no-unescaped-entities": "off", "@next/next/no-html-link-for-pages": "off", "react/display-name": "off"}}
+{
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unescaped-entities": "off",
+    "@next/next/no-html-link-for-pages": "off",
+    "react/display-name": "off",
+    "no-console": ["error", { "allow": ["debug", "info"] }]
+  },
+  "overrides": [
+    {
+      "files": ["src/utils/logger.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
+      "files": ["**/__tests__/**", "**/*.test.*", "**/*.spec.*"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,9 @@ import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import { AnalyticsProvider } from '../src/providers/AnalyticsProvider'
 import { isMarketingHostname } from '../src/config/surfaceConfig'
+import { createLogger } from '@/utils/logger'
+
+const log = createLogger('App')
 
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -10,7 +13,7 @@ export default function App({ Component, pageProps }: AppProps) {
     if (typeof window !== 'undefined') {
       const hostname = window.location.hostname
       const isMarketing = isMarketingHostname(hostname)
-      console.log(`🌍 _app.tsx: hostname=${hostname}, isMarketing=${isMarketing}`)
+      log.info(`_app.tsx: hostname=${hostname}, isMarketing=${isMarketing}`)
     }
   }, [])
 

--- a/pages/api/analytics/webhook.ts
+++ b/pages/api/analytics/webhook.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
+import { createLogger } from '@/utils/logger';
+
+const log = createLogger('AnalyticsWebhook');
 
 // Supabase 客户端配置  
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -130,13 +133,13 @@ async function processAndStoreEvent(event: RudderStackEvent) {
 
   try {
     // 1. 总是存储到主事件表
-    console.log('Inserting event data:', baseEventData);
+    log.debug('Inserting event data:', baseEventData);
     const { error: eventError } = await supabase
       .from('user_events')
       .insert(baseEventData);
 
     if (eventError) {
-      console.error('Error inserting user event:', eventError);
+      log.error('Error inserting user event:', eventError);
       throw eventError;
     }
 
@@ -158,7 +161,7 @@ async function processAndStoreEvent(event: RudderStackEvent) {
 
     return { success: true };
   } catch (error) {
-    console.error('Error processing event:', error);
+    log.error('Error processing event:', error);
     return { success: false, error };
   }
 }
@@ -189,7 +192,7 @@ async function handleTrackEvent(event: RudderStackEvent, baseData: any) {
       .from('chat_interactions')
       .insert(chatData);
 
-    if (error) console.error('Error inserting chat interaction:', error);
+    if (error) log.error('Error inserting chat interaction:', error);
   }
 
   // Widget 相关事件
@@ -216,7 +219,7 @@ async function handleTrackEvent(event: RudderStackEvent, baseData: any) {
       .from('widget_analytics')
       .insert(widgetData);
 
-    if (error) console.error('Error inserting widget analytics:', error);
+    if (error) log.error('Error inserting widget analytics:', error);
   }
 
   // 性能相关事件
@@ -241,7 +244,7 @@ async function handleTrackEvent(event: RudderStackEvent, baseData: any) {
       .from('performance_metrics')
       .insert(performanceData);
 
-    if (error) console.error('Error inserting performance metrics:', error);
+    if (error) log.error('Error inserting performance metrics:', error);
   }
 }
 
@@ -287,7 +290,7 @@ async function updateSessionInfo(event: RudderStackEvent, baseData: any) {
     });
 
   if (error) {
-    console.error('Error upserting session:', error);
+    log.error('Error upserting session:', error);
   }
 
   // 更新消息计数（对于 track 事件）
@@ -341,14 +344,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const errorCount = results.filter(r => r.status === 'rejected').length;
 
     // 记录处理结果
-    console.log(`Analytics webhook processed: ${successCount} success, ${errorCount} errors`);
+    log.info(`Analytics webhook processed: ${successCount} success, ${errorCount} errors`);
 
     if (errorCount > 0) {
       const errors = results
         .filter(r => r.status === 'rejected')
         .map(r => (r as PromiseRejectedResult).reason);
       
-      console.error('Webhook processing errors:', errors);
+      log.error('Webhook processing errors:', errors);
     }
 
     return res.status(200).json({
@@ -359,7 +362,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
   } catch (error) {
-    console.error('Webhook handler error:', error);
+    log.error('Webhook handler error:', error);
     return res.status(500).json({ 
       error: 'Internal server error',
       message: error instanceof Error ? error.message : 'Unknown error'

--- a/pages/api/rudderstack/sourceConfig.ts
+++ b/pages/api/rudderstack/sourceConfig.ts
@@ -1,4 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { createLogger } from '@/utils/logger';
+
+const log = createLogger('RudderstackSourceConfig');
 
 /**
  * RudderStack Source Configuration API
@@ -81,7 +84,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
     res.status(200).json(sourceConfig);
   } catch (error) {
-    console.error('Error serving source config:', error);
+    log.error('Error serving source config:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,9 @@ import {
   isMarketingHostname,
   surfaceLinks,
 } from '../src/config/surfaceConfig';
+import { createLogger } from '@/utils/logger';
+
+const log = createLogger('IndexPage');
 
 interface IndexPageProps {
   isMarketingSite: boolean;
@@ -23,12 +26,12 @@ interface IndexPageProps {
 const IndexPage: React.FC<IndexPageProps> = ({ isMarketingSite, hostname }) => {
   const router = useRouter();
   
-  console.log(`🌐 Index page rendering for hostname: ${hostname}, isMarketingSite: ${isMarketingSite}`);
+  log.info(`Index page rendering for hostname: ${hostname}, isMarketingSite: ${isMarketingSite}`);
   
   useEffect(() => {
     // 如果不是营销站点，重定向到 /app 页面
     if (!isMarketingSite) {
-      console.log('🔄 Redirecting to /app for main application');
+      log.info('Redirecting to /app for main application');
       // 保留URL参数（包括Auth0回调参数）
       const redirectTarget = appendSearchParams(surfaceLinks.appEntry, window.location.search);
 
@@ -44,7 +47,7 @@ const IndexPage: React.FC<IndexPageProps> = ({ isMarketingSite, hostname }) => {
   
   // 营销页面直接返回
   if (isMarketingSite) {
-    console.log('🏠 Rendering marketing home page');
+    log.info('Rendering marketing home page');
     return <MarketingHome />;
   }
   
@@ -66,7 +69,7 @@ export const getServerSideProps: GetServerSideProps<IndexPageProps> = async (con
   const isMarketingSite = isMarketingHostname(hostname);
   
   // 详细日志记录
-  console.log(`🔍 Server-side detection:`, {
+  log.info(`Server-side detection:`, {
     hostname,
     rawHost,
     allHeaders: context.req.headers,

--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -3,6 +3,9 @@ import Head from 'next/head'
 import MarketingHeader from '../src/components/marketing/MarketingHeader'
 import MarketingFooter from '../src/components/marketing/MarketingFooter'
 import { GATEWAY_CONFIG } from '../src/config/gatewayConfig'
+import { createLogger } from '@/utils/logger'
+
+const log = createLogger('PricingPage')
 
 // Define pricing plans
 const pricingPlans = [
@@ -160,7 +163,7 @@ export default function PricingPage() {
       const { url } = await response.json()
       window.location.href = url
     } catch (error) {
-      console.error('Error creating checkout session:', error)
+      log.error('Error creating checkout session:', error)
       alert('Error creating checkout session. Please try again.')
     } finally {
       setIsLoading(false)

--- a/src/api/BaseApiService.ts
+++ b/src/api/BaseApiService.ts
@@ -40,6 +40,9 @@ import axios, {
   AxiosError 
 } from 'axios';
 import { config } from '../config';
+import { createLogger, LogCategory } from '../utils/logger';
+
+const log = createLogger('BaseApiService', LogCategory.API_REQUEST);
 
 // ================================================================================
 // 类型定义
@@ -142,7 +145,7 @@ export class BaseApiService {
       (response: AxiosResponse) => {
         const endTime = Date.now();
         const startTime = (response.config as any).metadata?.startTime || endTime;
-        console.log(`API Request took ${endTime - startTime}ms`);
+        log.debug(`API Request took ${endTime - startTime}ms`);
         return response;
       },
       (error: AxiosError) => {
@@ -214,7 +217,7 @@ export class BaseApiService {
       try {
         authHeaders = await this.getAuthHeaders();
       } catch (error) {
-        console.warn('Failed to get auth headers:', error);
+        log.warn('Failed to get auth headers', error);
       }
     }
     
@@ -268,7 +271,7 @@ export class BaseApiService {
       try {
         authHeaders = await this.getAuthHeaders();
       } catch (error) {
-        console.warn('Failed to get auth headers:', error);
+        log.warn('Failed to get auth headers', error);
       }
     }
     
@@ -439,7 +442,7 @@ export class BaseApiService {
         if (retryCount < config.maxRetries!) {
           setTimeout(() => {
             retryCount++;
-            console.log(`SSE reconnect attempt ${retryCount}`);
+            log.info(`SSE reconnect attempt ${retryCount}`);
           }, config.retryInterval);
         }
         
@@ -483,7 +486,7 @@ export class BaseApiService {
         if (event.code !== 1000 && retryCount < config.maxRetries!) {
           setTimeout(() => {
             retryCount++;
-            console.log(`WebSocket reconnect attempt ${retryCount}`);
+            log.info(`WebSocket reconnect attempt ${retryCount}`);
             return this.createWebSocketConnection(endpoint, config);
           }, config.retryInterval);
         }
@@ -559,7 +562,7 @@ export class BaseApiService {
   }
 
   private handleRequestError(error: any): ApiResponse {
-    console.error('API Request Error:', error);
+    log.error('API Request Error', error);
     
     let errorMessage = 'Unknown error';
     let statusCode = 0;

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -18,6 +18,9 @@
 import { createSSETransport } from './transport/SSETransport';
 import { createAGUIEventParser } from './parsing/AGUIEventParser';
 import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { createLogger, LogCategory } from '../utils/logger';
+
+const log = createLogger('ChatService', LogCategory.CHAT_FLOW);
 
 // 定义标准的回调接口 - 扩展支持所有事件类型
 export interface ChatServiceCallbacks {
@@ -198,16 +201,16 @@ export class ChatService {
                     this.handleAGUIEvent(aguiEvent, callbacks);
                     
                   } catch (parseError) {
-                    console.warn('🔗 CHAT_SERVICE: Failed to parse event:', parseError);
+                    log.warn('Failed to parse event', parseError);
                   }
                 }
               }
             }
           } catch (error) {
             if (error instanceof Error && error.name === 'AbortError') {
-              console.log('🔗 CHAT_SERVICE: Data processing aborted normally');
+              log.debug('Data processing aborted normally');
             } else {
-              console.error('🔗 CHAT_SERVICE: Data processing error:', error);
+              log.error('Data processing error', error);
               await handleError(error instanceof Error ? error : new Error(String(error)));
             }
           }
@@ -218,7 +221,7 @@ export class ChatService {
       });
       
     } catch (error) {
-      console.error('🚀 CHAT_SERVICE: Failed to initialize:', error);
+      log.error('Failed to initialize', error);
       callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
@@ -230,7 +233,7 @@ export class ChatService {
   private handleAGUIEvent(event: any, callbacks: ChatServiceCallbacks): void {
     // 记录事件处理（开发模式）
     if (process.env.NODE_ENV === 'development') {
-      console.log('🎯 CHAT_SERVICE: Processing AGUI event:', event.type, event);
+      log.debug('Processing AGUI event', { type: event.type, event });
     }
     
     switch (event.type) {
@@ -241,7 +244,7 @@ export class ChatService {
         
       case 'text_message_start':
         // 只是标记开始，不创建消息。实际内容由 token 事件处理
-        console.log('🎬 CHAT_SERVICE: Message generation started', event.message_id || event.run_id);
+        log.debug('Message generation started', { messageId: event.message_id || event.run_id });
         break;
         
       case 'text_message_end':
@@ -393,7 +396,7 @@ export class ChatService {
         break;
         
       default:
-        console.warn('🚨 CHAT_SERVICE: Unhandled AGUI event type:', event.type, event);
+        log.warn('Unhandled AGUI event type', { type: event.type, event });
         break;
     }
   }
@@ -411,7 +414,7 @@ export class ChatService {
         if (event.metadata?.content || customData.content) {
           const content = event.metadata?.content || customData.content;
           callbacks.onStreamContent?.(content);
-          console.log('🎯 CHAT_SERVICE: Streaming content forwarded to callbacks:', content.substring(0, 50) + '...');
+          log.debug('Streaming content forwarded to callbacks', { preview: content.substring(0, 50) });
         }
         break;
         
@@ -431,7 +434,7 @@ export class ChatService {
         break;
         
       default:
-        console.log('🔍 CHAT_SERVICE: Custom event:', customType, customData);
+        log.debug('Custom event', { customType, customData });
         break;
     }
   }
@@ -455,7 +458,7 @@ export class ChatService {
     callbacks: ChatServiceCallbacks,
     files?: File[]
   ): Promise<void> {
-    console.log('🖼️ CHAT_SERVICE: Starting multimodal message', {
+    log.info('Starting multimodal message', {
       hasFiles: !!files,
       fileCount: files?.length || 0
     });
@@ -483,7 +486,7 @@ export class ChatService {
     token: string,
     callbacks: ChatServiceCallbacks
   ): Promise<void> {
-    console.log('⏭️ CHAT_SERVICE: Resuming HIL session');
+    log.info('Resuming HIL session');
     
     // HIL恢复使用相同的架构模式
     return this.sendMessage(message, metadata, token, callbacks);

--- a/src/api/parsing/AGUIEventParser.ts
+++ b/src/api/parsing/AGUIEventParser.ts
@@ -19,6 +19,9 @@
  */
 
 import { BaseParser, ParseError, ParserOptions } from './Parser';
+import { createLogger, LogCategory } from '../../utils/logger';
+
+const log = createLogger('AGUIEventParser', LogCategory.API_REQUEST);
 
 // ================================================================================
 // AGUI Event Types - 基于现有 aguiTypes.ts
@@ -397,7 +400,7 @@ export class AGUIEventParser extends BaseParser<string | LegacySSEEvent, AGUIEve
       return aguiEvent;
       
     } catch (error) {
-      console.error('🎯 AGUI_EVENT_PARSER: Parse error:', error);
+      log.error('Parse error', error);
       
       if (error instanceof ParseError) {
         throw error;
@@ -1102,7 +1105,7 @@ export class AGUIEventParser extends BaseParser<string | LegacySSEEvent, AGUIEve
       try {
         return JSON.parse(toolMessageMatch[1]);
       } catch (e) {
-        console.warn('🎯 AGUI_EVENT_PARSER: Failed to parse tool result JSON:', e);
+        log.warn('Failed to parse tool result JSON', e);
       }
     }
     return null;
@@ -1134,7 +1137,7 @@ export class AGUIEventParser extends BaseParser<string | LegacySSEEvent, AGUIEve
     try {
       return this.validateEventStructure(data);
     } catch (error) {
-      console.error('🎯 AGUI_EVENT_PARSER: Validation error:', error);
+      log.error('Validation error', error);
       return false;
     }
   }

--- a/src/api/parsing/ContentParser.ts
+++ b/src/api/parsing/ContentParser.ts
@@ -17,6 +17,9 @@
  */
 
 import { BaseParser, ParseResult } from './Parser';
+import { createLogger, LogCategory } from '../../utils/logger';
+
+const log = createLogger('ContentParser', LogCategory.API_REQUEST);
 
 // ================================================================================
 // 类型定义
@@ -239,7 +242,7 @@ export class ContentParser extends BaseParser<string, ParsedContent> {
       };
       
     } catch (error) {
-      console.warn('ContentParser: Parse failed:', error);
+      log.warn('Parse failed', error);
       // 回退到纯文本
       return {
         raw: content,

--- a/src/api/parsing/RealAPIEventMapping.ts
+++ b/src/api/parsing/RealAPIEventMapping.ts
@@ -2,10 +2,14 @@
  * ============================================================================
  * 基于真实测试数据的API事件映射 - Real API Event Mapping
  * ============================================================================
- * 
+ *
  * 根据2025-09-14真实测试结果重新设计的事件映射关系
  * 测试场景包括: simple2, weather, autonomous, billing, mixed_operations
  */
+
+import { createLogger, LogCategory } from '../../utils/logger';
+
+const log = createLogger('RealAPIEventMapping', LogCategory.API_REQUEST);
 
 // ================================================================================
 // 真实API事件类型定义 - 基于实际测试数据
@@ -141,7 +145,7 @@ class RealAPIEventMapper {
       try {
         return JSON.parse(toolMessageMatch[1]);
       } catch (e) {
-        console.warn('Failed to parse tool result JSON:', e);
+        log.warn('Failed to parse tool result JSON', e);
       }
     }
     

--- a/src/api/transport/SSETransport.ts
+++ b/src/api/transport/SSETransport.ts
@@ -12,6 +12,10 @@
  * ✅ Types: SDK-provided type safety
  */
 
+import { createLogger, LogCategory } from '../../utils/logger';
+
+const log = createLogger('SSETransport', LogCategory.API_REQUEST);
+
 // Re-export compatibility types
 export enum ConnectionState {
   IDLE = 'idle',
@@ -126,7 +130,7 @@ export class SSEConnection {
       if (error instanceof Error && error.name === 'AbortError') {
         // Normal abort
       } else {
-        console.warn('SSE_CONNECTION: Error during close:', error);
+        log.warn('Error during close', error);
       }
       this.setState(ConnectionState.CLOSED);
     }
@@ -216,7 +220,7 @@ export class SSEConnection {
       if (error instanceof Error && error.name === 'AbortError') {
         // Stream was aborted
       } else {
-        console.error('SSE_CONNECTION: Stream reading error:', error);
+        log.error('Stream reading error', error);
         const streamError = error instanceof Error ? error : new Error(String(error));
         this.emit('error', { error: streamError, timestamp: Date.now() });
         throw streamError;
@@ -285,7 +289,7 @@ export class SSEConnection {
       try {
         listener(connectionEvent);
       } catch (error) {
-        console.error(`Connection ${this.id}: Event listener error:`, error);
+        log.error(`Connection ${this.id}: Event listener error`, error);
       }
     }
   }

--- a/src/api/userService.ts
+++ b/src/api/userService.ts
@@ -34,7 +34,9 @@ import {
   HealthCheckResult,
   UserServiceCallbacks
 } from '../types/userTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('UserService', LogCategory.API_REQUEST);
 
 // ================================================================================
 // UserService Class
@@ -308,7 +310,7 @@ export const ensureExternalUserExists = async (
   userData: CreateExternalUserData,
   accessToken: string
 ): Promise<ExternalUser> => {
-  console.warn('ensureExternalUserExists is deprecated, use UserService class');
+  log.warn('ensureExternalUserExists is deprecated, use UserService class');
   throw new Error('This function is deprecated, please use UserService class with proper authentication');
 };
 
@@ -316,7 +318,7 @@ export const ensureExternalUserExists = async (
  * @deprecated Use UserService class instead
  */
 export const getCurrentExternalUser = async (accessToken: string): Promise<ExternalUser> => {
-  console.warn('getCurrentExternalUser is deprecated, use UserService class');
+  log.warn('getCurrentExternalUser is deprecated, use UserService class');
   throw new Error('This function is deprecated, please use UserService class with proper authentication');
 };
 
@@ -329,7 +331,7 @@ export const consumeCredits = async (
   reason: string,
   accessToken: string
 ): Promise<CreditConsumptionResult> => {
-  console.warn('consumeCredits is deprecated, use UserService class');
+  log.warn('consumeCredits is deprecated, use UserService class');
   // Authentication handled in UserService constructor
   return userService.consumeCredits(auth0_id, { amount, reason });
 };
@@ -341,7 +343,7 @@ export const getUserExternalSubscription = async (
   auth0_id: string,
   accessToken: string
 ): Promise<ExternalSubscription | null> => {
-  console.warn('getUserExternalSubscription is deprecated, use UserService class');
+  log.warn('getUserExternalSubscription is deprecated, use UserService class');
   // Authentication handled in UserService constructor
   return userService.getUserSubscription(auth0_id);
 };
@@ -353,7 +355,7 @@ export const createExternalCheckoutSession = async (
   planType: string,
   accessToken: string
 ): Promise<CheckoutSession> => {
-  console.warn('createExternalCheckoutSession is deprecated, use UserService class');
+  log.warn('createExternalCheckoutSession is deprecated, use UserService class');
   // Authentication handled in UserService constructor
   return userService.createCheckoutSession(planType);
 };
@@ -364,7 +366,7 @@ export const createExternalCheckoutSession = async (
 export const checkExternalServiceHealth = async (
   accessToken?: string
 ): Promise<HealthCheckResult> => {
-  console.warn('checkExternalServiceHealth is deprecated, use UserService class');
+  log.warn('checkExternalServiceHealth is deprecated, use UserService class');
   if (accessToken) {
     // Authentication handled in UserService constructor
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,7 +20,10 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { createLogger } from './utils/logger';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
+
+const log = createLogger('App');
 import { AuthProvider } from './providers/AuthProvider';
 import { SessionProvider } from './providers/SessionProvider';
 import { AIProvider } from './providers/AIProvider';
@@ -36,7 +39,7 @@ const InitializationTracker: React.FC<{ children: React.ReactNode }> = ({ childr
   const [initSteps, setInitSteps] = useState<string[]>([]);
 
   useEffect(() => {
-    console.log('🚀 MainAppContainer: Starting application initialization');
+    log.info('Starting application initialization');
     setInitSteps(prev => [...prev, 'App component mounted']);
     
     // Initialize language settings
@@ -44,7 +47,7 @@ const InitializationTracker: React.FC<{ children: React.ReactNode }> = ({ childr
     setInitSteps(prev => [...prev, 'Language initialized']);
     
     return () => {
-      console.log('🏁 MainAppContainer: Application unmounting');
+      log.info('Application unmounting');
     };
   }, []);
 
@@ -77,12 +80,12 @@ export const MainAppContainer: React.FC = () => {
     <InitializationTracker>
       <ErrorBoundary
         onError={(error, errorInfo) => {
-          console.error('💥 MainAppContainer: Global error caught by ErrorBoundary:', error, errorInfo);
+          log.error('Global error caught by ErrorBoundary', { error, errorInfo });
           // Could add error reporting service here
           
           // Log component stack for debugging
           if (errorInfo.componentStack) {
-            console.error('🔍 MainAppContainer: Component stack:', errorInfo.componentStack);
+            log.error('Component stack:', errorInfo.componentStack);
           }
         }}
         fallback={(error, errorInfo) => (

--- a/src/components/core/ChatInputHandler.tsx
+++ b/src/components/core/ChatInputHandler.tsx
@@ -26,7 +26,8 @@
  */
 import React, { useCallback } from 'react';
 import { useChatActions, useHILStatus, useCurrentHILInterrupt, useHILActions } from '../../stores/useChatStore';
-import { logger, LogCategory } from '../../utils/logger';
+import { logger, LogCategory, createLogger } from '../../utils/logger';
+const log = createLogger('ChatInputHandler');
 
 interface ChatInputHandlerProps {
   children: (handlers: {
@@ -48,7 +49,7 @@ export const ChatInputHandler: React.FC<ChatInputHandlerProps> = ({
   const onBeforeSend = useCallback((message: string): string | null => {
     const traceId = logger.startTrace('USER_INPUT_PROCESSING');
     logger.trackUserInput(message, {});
-    console.log('🚀 ChatInputHandler: Processing user input:', message);
+    log.info('Processing user input', message);
     
     // HIL行为监控：检查是否是对HIL中断的响应
     const isHILResponse = hilStatus === 'waiting_for_human' && currentHILInterrupt;
@@ -58,7 +59,7 @@ export const ChatInputHandler: React.FC<ChatInputHandlerProps> = ({
         interruptType: currentHILInterrupt?.type,
         responseLength: message.length
       });
-      console.log('🤖 HIL_MONITORING: User providing response to HIL interrupt', {
+      log.info('HIL_MONITORING: User providing response to HIL interrupt', {
         threadId: currentHILInterrupt?.thread_id,
         responseLength: message.length
       });
@@ -120,7 +121,7 @@ export const ChatInputHandler: React.FC<ChatInputHandlerProps> = ({
       fileCount: files.length,
       fileNames: Array.from(files).map(f => f.name)
     });
-    console.log('📎 ChatInputHandler: Files selected:', Array.from(files).map(f => f.name));
+    log.info('Files selected', Array.from(files).map(f => f.name));
     
     // HIL行为监控：文件上传在HIL上下文中的处理
     const isFileUploadDuringHIL = hilStatus !== 'idle';
@@ -131,7 +132,7 @@ export const ChatInputHandler: React.FC<ChatInputHandlerProps> = ({
         threadId: currentHILInterrupt?.thread_id,
         fileCount: files.length
       });
-      console.log('🤖 HIL_MONITORING: File upload during HIL session', {
+      log.info('HIL_MONITORING: File upload during HIL session', {
         hilStatus,
         fileCount: files.length
       });

--- a/src/components/core/WidgetHandler.tsx
+++ b/src/components/core/WidgetHandler.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useDreamWidgetStore, useHuntWidgetStore, useOmniWidgetStore, useDataScientistWidgetStore, useKnowledgeWidgetStore, useCustomAutomationWidgetStore } from '../../stores/useWidgetStores';
-import { logger, LogCategory } from '../../utils/logger';
+import { logger, LogCategory, createLogger } from '../../utils/logger';
+const log = createLogger('WidgetHandler');
 import { OutputHistoryItem, EditAction, ManagementAction } from '../ui/widgets/BaseWidget';
 import { WidgetType } from '../../types/widgetTypes';
 
@@ -67,7 +68,7 @@ export class WidgetHandler {
   setPluginMode(eventEmitter: PluginEventEmitter) {
     this.mode = 'plugin';
     this.eventEmitter = eventEmitter;
-    console.log('🔌 WIDGET_HANDLER: Switched to Plugin mode');
+    log.info('Switched to Plugin mode');
   }
 
   /**
@@ -76,7 +77,7 @@ export class WidgetHandler {
   setIndependentMode() {
     this.mode = 'independent';
     this.eventEmitter = null;
-    console.log('🔧 WIDGET_HANDLER: Switched to Independent mode');
+    log.info('Switched to Independent mode');
   }
 
   /**
@@ -94,7 +95,7 @@ export class WidgetHandler {
     try {
       if (this.mode === 'plugin' && this.eventEmitter) {
         // 🔌 Plugin模式：发出事件给ChatModule处理并等待结果
-        console.log('🔌 WIDGET_HANDLER: Emitting plugin event for ChatModule:', request);
+        log.info('Emitting plugin event for ChatModule', request);
         
         const requestId = `${request.type}_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
         
@@ -102,17 +103,17 @@ export class WidgetHandler {
         return new Promise((resolve, reject) => {
           // 监听结果事件
           const resultHandler = (eventData: any) => {
-            console.log('🔌 WIDGET_HANDLER: Received widget:result event:', eventData);
+            log.info('Received widget:result event', eventData);
             if (eventData.requestId === requestId) {
               clearTimeout(timeout);
               // Clean up listener after use
               this.eventEmitter!.off('widget:result', resultHandler);
               
               if (eventData.success) {
-                console.log('✅ WIDGET_HANDLER: Widget request succeeded, resolving promise');
+                log.info('Widget request succeeded, resolving promise');
                 resolve(eventData.result);
               } else {
-                console.error('❌ WIDGET_HANDLER: Widget request failed:', eventData.error);
+                log.error('Widget request failed', eventData.error);
                 reject(new Error(eventData.error || 'Plugin execution failed'));
               }
             }
@@ -127,7 +128,7 @@ export class WidgetHandler {
           this.eventEmitter!.on('widget:result', resultHandler);
           
           // 发出请求事件
-          console.log('🔌 WIDGET_HANDLER: Emitting widget:request with requestId:', requestId);
+          log.info('Emitting widget:request with requestId', requestId);
           this.eventEmitter!.emit('widget:request', {
             widgetType: request.type,
             action: 'process',
@@ -141,7 +142,7 @@ export class WidgetHandler {
       }
 
       // 🔧 Independent模式：直接路由到store
-      console.log('🔧 WIDGET_HANDLER: Processing in Independent mode');
+      log.info('Processing in Independent mode');
       
       switch (request.type) {
         case 'dream':
@@ -307,7 +308,7 @@ export class WidgetHandler {
    * Process edit actions (copy, download, share, etc.)
    */
   private async processEditAction(request: WidgetUIActionRequest): Promise<void> {
-    console.log(`📝 ${request.type.toUpperCase()}: Processing edit action '${request.actionId}'`, request.content);
+    log.info(`${request.type.toUpperCase()}: Processing edit action '${request.actionId}'`, request.content);
     
     // Default edit actions that work across all widgets
     switch (request.actionId) {
@@ -323,7 +324,7 @@ export class WidgetHandler {
         break;
       default:
         // Widget-specific edit actions would be handled here
-        console.log(`🔧 ${request.type.toUpperCase()}: Custom edit action '${request.actionId}' - implement in widget-specific handler`);
+        log.info(`${request.type.toUpperCase()}: Custom edit action '${request.actionId}' - implement in widget-specific handler`);
     }
   }
 
@@ -331,7 +332,7 @@ export class WidgetHandler {
    * Process management actions (refresh, clear, custom actions)
    */
   private async processManagementAction(request: WidgetUIActionRequest): Promise<void> {
-    console.log(`⚙️ ${request.type.toUpperCase()}: Processing management action '${request.actionId}'`);
+    log.info(`${request.type.toUpperCase()}: Processing management action '${request.actionId}'`);
     
     switch (request.actionId) {
       case 'refresh':
@@ -348,7 +349,7 @@ export class WidgetHandler {
         break;
       default:
         // Widget-specific management actions would be handled here
-        console.log(`🔧 ${request.type.toUpperCase()}: Custom management action '${request.actionId}' - implement in widget-specific handler`);
+        log.info(`${request.type.toUpperCase()}: Custom management action '${request.actionId}' - implement in widget-specific handler`);
     }
   }
 
@@ -401,7 +402,7 @@ export class WidgetHandler {
           customAutomationStore.clearData?.();
           break;
         default:
-          console.log(`⚠️ Clear operation not implemented for widget type: ${type}`);
+          log.warn(`Clear operation not implemented for widget type: ${type}`);
       }
     } catch (error) {
       logger.error(LogCategory.ARTIFACT_CREATION, 'Failed to clear widget data', { type, error });
@@ -439,7 +440,7 @@ export class WidgetHandler {
       await navigator.share(shareData);
     } else {
       await navigator.clipboard.writeText(textContent);
-      console.log('📋 Content copied to clipboard (Web Share API not available)');
+      log.info('Content copied to clipboard (Web Share API not available)');
     }
   }
 }

--- a/src/components/core/WidgetTrigger.tsx
+++ b/src/components/core/WidgetTrigger.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useAppStore } from '../../stores/useAppStore';
 import { AppId } from '../../types/appTypes';
-import { logger, LogCategory } from '../../utils/logger';
+import { logger, LogCategory, createLogger } from '../../utils/logger';
+const log = createLogger('AppTriggerHandler');
 
 interface AppTriggerHandlerProps {
   availableApps: Array<{
@@ -33,17 +34,17 @@ export const AppTriggerHandler: React.FC<AppTriggerHandlerProps> = ({
       const matchingTrigger = app.triggers.find(trigger => lowerMessage.includes(trigger));
       if (matchingTrigger) {
         logger.trackAppTrigger(app.id, matchingTrigger, message);
-        console.log('🎯 App trigger detected!', { 
-          app: app.name, 
-          trigger: matchingTrigger, 
-          currentApp, 
-          showRightSidebar 
+        log.info('App trigger detected', {
+          app: app.name,
+          trigger: matchingTrigger,
+          currentApp,
+          showRightSidebar
         });
         
         // If the app is already open, let chat send normally
         if (currentApp === app.id && showRightSidebar) {
           logger.info(LogCategory.USER_INPUT, 'App already open, chat sends to API', { appId: app.id });
-          console.log('✅ App already open, chat will send to API');
+          log.info('App already open, chat will send to API');
           return null;
         }
         
@@ -52,14 +53,14 @@ export const AppTriggerHandler: React.FC<AppTriggerHandlerProps> = ({
           appId: app.id, 
           trigger: matchingTrigger 
         });
-        console.log('📱 Opening app, blocking chat API request - app will handle');
+        log.info('Opening app, blocking chat API request - app will handle');
         
         setTimeout(() => {
           setCurrentApp(app.id as AppId);
           setShowRightSidebar(true);
           setTriggeredAppInput(message);
           logger.info(LogCategory.APP_TRIGGER, 'App opened successfully', { appId: app.id });
-          console.log('✨ App opened and will handle API request:', app.id);
+          log.info('App opened and will handle API request', app.id);
         }, 1000);
         
         onAppTriggered?.(app.id, message);

--- a/src/components/debug/PluginSystemTester.tsx
+++ b/src/components/debug/PluginSystemTester.tsx
@@ -12,13 +12,16 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { 
+import { createLogger } from '../../utils/logger';
+import {
   getAvailablePlugins, 
   getPluginStats, 
   detectPluginTrigger, 
   executePlugin 
 } from '../../plugins';
 import { PluginInput } from '../../types/pluginTypes';
+
+const log = createLogger('PluginSystemTester');
 
 export const PluginSystemTester: React.FC = () => {
   const [pluginStats, setPluginStats] = useState<any>(null);
@@ -40,7 +43,7 @@ export const PluginSystemTester: React.FC = () => {
   const handleTestTrigger = () => {
     const result = detectPluginTrigger(testMessage);
     setTriggerResult(result);
-    console.log('🧪 Trigger Test Result:', result);
+    log.debug('Trigger Test Result:', result);
   };
 
   const handleTestExecution = async () => {
@@ -63,13 +66,13 @@ export const PluginSystemTester: React.FC = () => {
         }
       };
 
-      console.log('🧪 Executing plugin with input:', input);
+      log.debug('Executing plugin with input:', input);
       const result = await executePlugin(triggerResult.pluginId, input);
       setExecutionResult(result);
-      console.log('🧪 Execution Result:', result);
+      log.debug('Execution Result:', result);
 
     } catch (error) {
-      console.error('🧪 Execution Error:', error);
+      log.error('Execution Error:', error);
       setExecutionResult({
         success: false,
         error: error instanceof Error ? error.message : String(error),

--- a/src/components/examples/MobileOptimizationDemo.tsx
+++ b/src/components/examples/MobileOptimizationDemo.tsx
@@ -3,7 +3,10 @@
  * Demonstrates the new mobile-optimized task progress, loading, and status components
  */
 import React, { useState, useEffect } from 'react';
+import { createLogger } from '../../utils/logger';
 import { MobileTaskBar } from '../ui/mobile/MobileTaskBar';
+
+const log = createLogger('MobileOptimizationDemo');
 import { MobileTaskProgress, MobileTypingIndicator, MobileLoadingState } from '../ui/mobile/MobileTaskProgress';
 import { MobileStatusBar, MobileConnectionStatus, MobileNetworkQuality } from '../ui/mobile/MobileStatusBar';
 
@@ -144,7 +147,7 @@ export const MobileOptimizationDemo: React.FC = () => {
               taskTitle="Mobile UI Optimization"
               progress={progress}
               isStreaming={demoState === 'processing'}
-              onTap={() => console.log('Task tapped')}
+              onTap={() => log.debug('Task tapped')}
               compact={false}
             />
 
@@ -173,9 +176,9 @@ export const MobileOptimizationDemo: React.FC = () => {
               position="top"
               compact={false}
               autoCollapse={false}
-              onTaskClick={(taskId) => console.log('Task clicked:', taskId)}
-              onClearCompleted={() => console.log('Clear completed tasks')}
-              onRetryFailed={() => console.log('Retry failed tasks')}
+              onTaskClick={(taskId) => log.debug('Task clicked:', taskId)}
+              onClearCompleted={() => log.debug('Clear completed tasks')}
+              onRetryFailed={() => log.debug('Retry failed tasks')}
             />
           </div>
         </div>

--- a/src/components/examples/OrganizationFeatureShowcase.tsx
+++ b/src/components/examples/OrganizationFeatureShowcase.tsx
@@ -15,7 +15,10 @@
  */
 
 import React, { useState } from 'react';
+import { createLogger } from '../../utils/logger';
 import UserButtonContainer from '../ui/user/UserButtonContainer';
+
+const log = createLogger('OrganizationFeatureShowcase');
 import OrganizationMembersPanel from '../ui/organization/OrganizationMembersPanel';
 import PermissionGuard, { 
   OwnerOnly, 
@@ -73,28 +76,28 @@ export const OrganizationFeatureShowcase: React.FC = () => {
 
   // Mock handlers (in real app, these come from modules)
   const handleInviteMember = async (data: any) => {
-    console.log('Inviting member:', data);
+    log.info('Inviting member:', data);
     // Would call organizationModule.inviteMember(organizationId, data)
   };
 
   const handleUpdateMemberRole = async (userId: string, role: string) => {
-    console.log('Updating member role:', { userId, role });
+    log.info('Updating member role:', { userId, role });
   };
 
   const handleRemoveMember = async (userId: string) => {
-    console.log('Removing member:', userId);
+    log.info('Removing member:', userId);
   };
 
   const handleCancelInvitation = async (invitationId: string) => {
-    console.log('Cancelling invitation:', invitationId);
+    log.info('Cancelling invitation:', invitationId);
   };
 
   const handleResendInvitation = async (invitationId: string) => {
-    console.log('Resending invitation:', invitationId);
+    log.info('Resending invitation:', invitationId);
   };
 
   const handleRefresh = async () => {
-    console.log('Refreshing data...');
+    log.info('Refreshing data...');
   };
 
   return (

--- a/src/components/shared/demo/ComponentDemo.tsx
+++ b/src/components/shared/demo/ComponentDemo.tsx
@@ -8,7 +8,8 @@
  */
 
 import React, { useState } from 'react';
-import { 
+import { createLogger } from '../../../utils/logger';
+import {
   ContentRenderer, 
   StatusRenderer, 
   Button,
@@ -40,6 +41,8 @@ import {
   GlassMessageBubble,
   GlassChatInput
 } from '../index';
+
+const log = createLogger('ComponentDemo');
 
 // 内部组件，使用Toast
 const ComponentDemoContent: React.FC = () => {
@@ -237,7 +240,7 @@ console.log(fibonacci(10));`
                         imagePreview: true,
                         truncate: contentType === 'text' ? 100 : undefined
                       }}
-                      onAction={(action, data) => console.log('Chat action:', action, data)}
+                      onAction={(action, data) => log.debug('Chat action', { action, data })}
                     />
                   </div>
                 </div>
@@ -255,7 +258,7 @@ console.log(fibonacci(10));`
                       saveButton: contentType === 'image',
                       imagePreview: true
                     }}
-                    onAction={(action, data) => console.log('Widget action:', action, data)}
+                    onAction={(action, data) => log.debug('Widget action', { action, data })}
                   />
                 </div>
 
@@ -273,7 +276,7 @@ console.log(fibonacci(10));`
                       expandButton: true,
                       truncate: 200
                     }}
-                    onAction={(action, data) => console.log('Artifact action:', action, data)}
+                    onAction={(action, data) => log.debug('Artifact action', { action, data })}
                   />
                 </div>
 

--- a/src/components/shared/ui/FileUploader.tsx
+++ b/src/components/shared/ui/FileUploader.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useState, useCallback, useRef } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { Button } from './Button';
+
+const log = createLogger('FileUploader');
 
 export interface FileUploadResult {
   file: File;
@@ -377,7 +380,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
                       variant="ghost"
                       size="xs"
                       icon="👁️"
-                      onClick={() => console.log('Preview data:', fileResult.data)}
+                      onClick={() => log.debug('Preview data:', fileResult.data)}
                       tooltipText="Preview processed data"
                     />
                   )}

--- a/src/components/shared/ui/Modal.tsx
+++ b/src/components/shared/ui/Modal.tsx
@@ -17,7 +17,10 @@
  */
 
 import React, { memo, useEffect, useRef, useCallback, forwardRef, useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { createPortal } from 'react-dom';
+
+const log = createLogger('Modal');
 import { Button, PrimaryButton, SecondaryButton } from './Button';
 
 // ================================================================================
@@ -404,7 +407,7 @@ export const ConfirmModal: React.FC<ModalProps & ConfirmModalProps> = ({
       await onOk();
       modalProps.onClose();
     } catch (error) {
-      console.error('确认操作失败:', error);
+      log.error('确认操作失败:', error);
     } finally {
       setLoading(false);
     }

--- a/src/components/shared/widgets/ScrollFollowUpActions.tsx
+++ b/src/components/shared/widgets/ScrollFollowUpActions.tsx
@@ -12,6 +12,9 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { createLogger } from '../../../utils/logger';
+
+const log = createLogger('ScrollFollowUpActions');
 
 // ================================================================================
 // 类型定义
@@ -261,7 +264,7 @@ export const MinimalScrollActions: React.FC<ScrollFollowUpActionsProps> = (props
       variant: 'secondary',
       onClick: () => {
         // 可以触发更多选项的显示
-        console.log('Show more options');
+        log.debug('Show more options');
       },
     }
   ];

--- a/src/components/ui/AssistantToolbar.tsx
+++ b/src/components/ui/AssistantToolbar.tsx
@@ -16,8 +16,10 @@
  * - Simple, focused interface for productivity
  */
 import React, { useState, useRef, useEffect } from 'react';
+import { createLogger } from '../../utils/logger';
 import { GATEWAY_CONFIG, GATEWAY_ENDPOINTS } from '../../config/gatewayConfig';
 import { authTokenStore } from '../../stores/authTokenStore';
+const log = createLogger('AssistantToolbar');
 
 // Glass Button Style Creator
 const createGlassButtonStyle = (color: string, size: 'sm' | 'md' = 'md', isDisabled: boolean = false) => ({
@@ -203,7 +205,7 @@ export const AssistantToolbar: React.FC<AssistantToolbarProps> = ({
                   completeResponse = response;
                 });
               } catch (e) {
-                console.error('Failed to parse SSE data:', e);
+                log.error('Failed to parse SSE data', e);
               }
             }
           }
@@ -221,7 +223,7 @@ export const AssistantToolbar: React.FC<AssistantToolbarProps> = ({
         }
       }
     } catch (error) {
-      console.error('Failed to send message:', error);
+      log.error('Failed to send message', error);
       const errorMessage: ChatMessage = {
         id: `error_${Date.now()}`,
         role: 'system',
@@ -486,7 +488,7 @@ const handleSSEEvent = (
 ) => {
   switch (event.type) {
     case 'start':
-      console.log('Chat processing started');
+      log.info('Chat processing started');
       break;
     
     case 'custom_stream':
@@ -499,7 +501,7 @@ const handleSSEEvent = (
       
       // Handle tool execution progress
       if (event.content?.type === 'progress') {
-        console.log('Tool progress:', event.content.data);
+        log.debug('Tool progress', event.content.data);
       }
       break;
     
@@ -516,23 +518,23 @@ const handleSSEEvent = (
       break;
     
     case 'billing':
-      console.log('Billing info:', event.data);
+      log.debug('Billing info', event.data);
       break;
     
     case 'memory_update':
-      console.log('Memory updated:', event.content);
+      log.debug('Memory updated', event.content);
       break;
     
     case 'end':
-      console.log('Chat processing completed');
+      log.info('Chat processing completed');
       break;
     
     case 'error':
-      console.error('Chat error:', event.content);
+      log.error('Chat error', event.content);
       break;
     
     default:
-      console.log('Unknown event type:', event);
+      log.debug('Unknown event type', event);
   }
 };
 

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { logger, LogCategory } from '../../utils/logger';
+import { logger, LogCategory, createLogger } from '../../utils/logger';
+
+const log = createLogger('ErrorBoundary');
 import { GlassButton } from '../shared';
 
 interface ErrorBoundaryState {
@@ -139,7 +141,7 @@ export const useErrorHandler = () => {
     }
 
     // 生产环境中只记录错误，不中断用户体验
-    console.error('Error handled:', error);
+    log.error('Error handled:', error);
   }, []);
 
   return { handleError };

--- a/src/components/ui/NotificationToolbar.tsx
+++ b/src/components/ui/NotificationToolbar.tsx
@@ -16,6 +16,8 @@
  * - Non-intrusive but informative
  */
 import React, { useState, useRef, useEffect } from 'react';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('NotificationToolbar');
 
 // Glass Button Style Creator for Notification Toolbar
 const createGlassButtonStyle = (color: string, size: 'sm' | 'md' = 'md', isDisabled: boolean = false) => ({
@@ -87,8 +89,8 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
       read: false,
       actionable: true,
       actions: [
-        { id: 'complete', label: 'Mark Done', action: () => console.log('Mark done') },
-        { id: 'snooze', label: 'Snooze', action: () => console.log('Snooze') }
+        { id: 'complete', label: 'Mark Done', action: () => log.info('Mark done') },
+        { id: 'snooze', label: 'Snooze', action: () => log.info('Snooze') }
       ]
     },
     {
@@ -100,8 +102,8 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
       read: false,
       actionable: true,
       actions: [
-        { id: 'accept', label: 'Accept', action: () => console.log('Accept suggestion') },
-        { id: 'dismiss', label: 'Dismiss', action: () => console.log('Dismiss') }
+        { id: 'accept', label: 'Accept', action: () => log.info('Accept suggestion') },
+        { id: 'dismiss', label: 'Dismiss', action: () => log.info('Dismiss') }
       ]
     },
     {

--- a/src/components/ui/adaptive/ResponsiveChatLayout.tsx
+++ b/src/components/ui/adaptive/ResponsiveChatLayout.tsx
@@ -10,7 +10,10 @@
  * - Native app context
  */
 import React, { useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatLayout, ChatLayoutProps } from '../chat/ChatLayout';
+
+const log = createLogger('ResponsiveChatLayout');
 import { ModernMobileChatLayout } from '../mobile/ModernMobileChatLayout';
 import { useDeviceType } from '../../../hooks/useDeviceType';
 
@@ -66,13 +69,13 @@ export const ResponsiveChatLayout: React.FC<ResponsiveChatLayoutProps> = ({
 
     // Check for native app context
     if (isNativeApp) {
-      console.log('📱 Native app detected, using mobile layout');
+      log.info('Native app detected, using mobile layout');
       return 'mobile';
     }
 
     // Check screen width
     if (screenWidth <= mobileBreakpoint) {
-      console.log('📱 Screen width <= breakpoint, using mobile layout');
+      log.info('Screen width <= breakpoint, using mobile layout');
       return 'mobile';
     }
 
@@ -118,7 +121,7 @@ export const ResponsiveChatLayout: React.FC<ResponsiveChatLayoutProps> = ({
       onNewChat();
     } else {
       // Default fallback - refresh the page to create new chat
-      console.log('📱 New chat requested - no onNewChat handler, refreshing');
+      log.info('New chat requested - no onNewChat handler, refreshing');
       window.location.reload();
     }
   }, [onNewChat]);

--- a/src/components/ui/chat/AutonomousTaskDisplay.tsx
+++ b/src/components/ui/chat/AutonomousTaskDisplay.tsx
@@ -15,6 +15,8 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
+const log = createLogger('AutonomousTaskDisplay');
 
 // ================================================================================
 // 基于SSE事件的任务数据接口
@@ -106,7 +108,7 @@ export const AutonomousTaskDisplay: React.FC<AutonomousTaskDisplayProps> = ({
             });
           });
         } catch (error) {
-          console.error('解析工具调用失败:', error);
+          log.error('Failed to parse tool calls', error);
         }
       }
     }

--- a/src/components/ui/chat/ChatWelcome.tsx
+++ b/src/components/ui/chat/ChatWelcome.tsx
@@ -17,7 +17,9 @@
  */
 
 import React, { useEffect } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useAppStore } from '../../../stores/useAppStore';
+const log = createLogger('ChatWelcome');
 import { WidgetType } from '../../../types/widgetTypes';
 import { 
   useOmniActions,
@@ -53,15 +55,15 @@ export const ChatWelcome: React.FC<ChatWelcomeProps> = ({
   useEffect(() => {
     const isValid = validateWelcomeConfig();
     if (!isValid) {
-      console.error('🎯 CHAT_WELCOME: Invalid welcome configuration detected');
+      log.error('Invalid welcome configuration detected');
     } else {
-      console.log('🎯 CHAT_WELCOME: Welcome configuration loaded successfully', { language: currentLanguage });
+      log.info('Welcome configuration loaded successfully', { language: currentLanguage });
     }
   }, [currentLanguage]);
 
   // 处理widget卡片点击
   const handleWidgetClick = async (widget: typeof welcomeConfig.widgets[0]) => {
-    console.log(`🎯 CHAT_WELCOME: Widget clicked - ${widget.title} (${widget.id})`);
+    log.info(`Widget clicked - ${widget.title} (${widget.id})`);
     
     try {
       // 1. 打开对应widget的侧边栏
@@ -89,18 +91,18 @@ export const ChatWelcome: React.FC<ChatWelcomeProps> = ({
           await triggerKnowledgeAnalysis(params);
           break;
         default:
-          console.warn(`🎯 CHAT_WELCOME: Unknown widget type - ${widget.id}`);
+          log.warn(`Unknown widget type - ${widget.id}`);
       }
       
-      console.log(`🎯 CHAT_WELCOME: Widget ${widget.title} activated successfully`);
+      log.info(`Widget ${widget.title} activated successfully`);
     } catch (error) {
-      console.error(`🎯 CHAT_WELCOME: Failed to activate widget ${widget.title}:`, error);
+      log.error(`Failed to activate widget ${widget.title}`, error);
     }
   };
 
   // 处理示例提示词点击
   const handlePromptClick = (prompt: string) => {
-    console.log(`💬 CHAT_WELCOME: Example prompt clicked - ${prompt}`);
+    log.info(`Example prompt clicked - ${prompt}`);
     if (onSendMessage) {
       onSendMessage(prompt);
     }

--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useRef, KeyboardEvent, useEffect } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { FileUpload } from './FileUpload';
 import { GlassChatInput, GlassCard, GlassButton, IntelligentModeSettings } from '../../shared';
 import { useTranslation } from '../../../hooks/useTranslation';
+const log = createLogger('InputAreaLayout');
 
 export interface InputAreaLayoutProps {
   placeholder?: string;
@@ -71,7 +73,7 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
     try {
       audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
     } catch (e) {
-      console.log('Audio not supported');
+      log.debug('Audio not supported');
     }
   }, []);
 
@@ -128,7 +130,7 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
   // File handling functions
   const handleFileSelection = (files: FileList) => {
     // Temporarily disabled - return early
-    console.log('📎 File upload temporarily disabled');
+    log.info('File upload temporarily disabled');
     return;
   };
 
@@ -162,7 +164,7 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
       setIsRecording(true);
       playAudioFeedback('click');
     } catch (error) {
-      console.error('录音失败:', error);
+      log.error('Recording failed', error);
       playAudioFeedback('error');
       if (onError) {
         onError(new Error('无法访问麦克风，请检查权限设置'));
@@ -202,7 +204,7 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
       const scrollHeight = textarea.scrollHeight;
       const newHeight = Math.min(Math.max(scrollHeight, 40), 150); // Min 40px, max 150px
       textarea.style.height = newHeight + 'px';
-      console.log('Textarea resized:', { scrollHeight, newHeight });
+      log.debug('Textarea resized', { scrollHeight, newHeight });
     }, 0);
   };
 

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -21,7 +21,9 @@
  * - 不处理业务逻辑，只负责消息的视觉呈现
  */
 import React, { memo, useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatMessage, ArtifactMessage } from '../../../types/chatTypes';
+const log = createLogger('MessageList');
 import { ArtifactComponent } from './ArtifactComponent';
 import { ArtifactMessageComponent } from './ArtifactMessageComponent';
 import { ContentType } from '../../../types/appTypes';
@@ -345,7 +347,7 @@ export const MessageList = memo<MessageListProps>(({
                 }}
                 onReopen={() => {
                   // Handle artifact reopening - could emit an event or callback
-                  console.log('Artifact reopened:', message.id);
+                  log.info('Artifact reopened', message.id);
                 }}
               />
             </div>

--- a/src/components/ui/chat/RightSidebarLayout.tsx
+++ b/src/components/ui/chat/RightSidebarLayout.tsx
@@ -41,7 +41,8 @@ import { DataScientistWidget } from '../widgets/DataScientistWidget';
 import { KnowledgeWidget } from '../widgets/KnowledgeWidget';
 import { CustomAutomationWidget } from '../widgets/CustomAutomationWidget';
 
-import { logger, LogCategory } from '../../../utils/logger';
+import { createLogger, logger, LogCategory } from '../../../utils/logger';
+const log = createLogger('RightSidebarLayout');
 
 interface RightSidebarLayoutProps {
   currentApp: string | null;
@@ -80,13 +81,13 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
     hasTriggeredInput: !!triggeredAppInput
   });
   
-  console.log('📱 RIGHT_SIDEBAR: Rendering right sidebar', { currentApp, showRightSidebar });
+  log.debug('Rendering right sidebar', { currentApp, showRightSidebar });
   
   // Use useMemo to cache widget content and prevent unnecessary re-renders
   const widgetContent = useMemo(() => {
     if (!currentApp) return null;
     
-    console.log('📱 RIGHT_SIDEBAR: Creating widget content for app:', currentApp);
+    log.debug('Creating widget content for app', currentApp);
     
     // Use Widget Modules that manage business logic + UI
     switch (currentApp) {
@@ -131,7 +132,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
           <HuntWidgetModule 
             triggeredInput={triggeredAppInput}
             onSearchCompleted={(result) => {
-              console.log('🔍 RIGHT_SIDEBAR: Hunt search completed:', result);
+              log.info('Hunt search completed', result);
             }}
           >
             <HuntWidget 
@@ -156,7 +157,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
           <OmniWidgetModule 
             triggeredInput={triggeredAppInput}
             onContentGenerated={(result) => {
-              console.log('⚡ RIGHT_SIDEBAR: Omni content generated:', result);
+              log.info('Omni content generated', result);
             }}
           >
             <OmniWidget 
@@ -180,7 +181,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
           <KnowledgeWidgetModule 
             triggeredInput={triggeredAppInput}
             onAnalysisCompleted={(result) => {
-              console.log('🧠 RIGHT_SIDEBAR: Knowledge analysis completed:', result);
+              log.info('Knowledge analysis completed', result);
             }}
           >
             <KnowledgeWidget 
@@ -204,7 +205,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
           <DataScientistWidgetModule 
             triggeredInput={triggeredAppInput}
             onAnalysisCompleted={(result) => {
-              console.log('📊 RIGHT_SIDEBAR: DataScientist analysis completed:', result);
+              log.info('DataScientist analysis completed', result);
             }}
           >
             <DataScientistWidget 
@@ -228,7 +229,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
           <CustomAutomationWidgetModule 
             triggeredInput={triggeredAppInput}
             onAutomationCompleted={(result) => {
-              console.log('🤖 RIGHT_SIDEBAR: Custom Automation completed:', result);
+              log.info('Custom Automation completed', result);
             }}
           >
             {(moduleProps: any) => (
@@ -352,7 +353,7 @@ export const RightSidebarLayout: React.FC<RightSidebarLayoutProps> = ({
                 key={appId}
                 onClick={() => {
                   logger.trackSidebarInteraction('widget_selected_from_list', appId);
-                  console.log('🚀 Widget selected:', appId);
+                  log.info('Widget selected', appId);
                   onAppSelect?.(appId);
                 }}
                 className={`border rounded-xl transition-all text-left group overflow-hidden ${

--- a/src/components/ui/chat/ThreeColumnLayout.tsx
+++ b/src/components/ui/chat/ThreeColumnLayout.tsx
@@ -11,11 +11,13 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatContentLayout } from './ChatContentLayout';
 import { InputAreaLayout } from './InputAreaLayout';
 import { RightPanel } from './RightPanel';
 import { SmartWidgetSelector } from '../widgets/SmartWidgetSelector';
 import { ChatMessage } from '../../../types/chatTypes';
+const log = createLogger('ThreeColumnLayout');
 
 export interface ThreeColumnLayoutProps {
   // Header
@@ -92,8 +94,8 @@ export const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({
 }) => {
   // 计算布局尺寸
   const layoutConfig = useMemo(() => {
-    console.log('🔧 ThreeColumnLayout: Computing layout config', { 
-      showSidebar, showRightPanel, showRightSidebar 
+    log.debug('Computing layout config', {
+      showSidebar, showRightPanel, showRightSidebar
     });
     // Widget半屏模式时的特殊处理
     if (showRightSidebar) {
@@ -121,7 +123,7 @@ export const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({
       rightPanelWidth: `${rightWidth}%`
     };
     
-    console.log('🔧 ThreeColumnLayout: Final layout config', config);
+    log.debug('Final layout config', config);
     return config;
   }, [showSidebar, showRightPanel, showRightSidebar, rightSidebarWidth]);
 

--- a/src/components/ui/hil/HILAuthorizationDialog.tsx
+++ b/src/components/ui/hil/HILAuthorizationDialog.tsx
@@ -17,7 +17,10 @@
  */
 
 import React, { useState, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useHILActions, useCurrentHILInterrupt } from '../../../stores/useChatStore';
+
+const log = createLogger('HILAuthorizationDialog');
 import { useSessionStore } from '../../../stores/useSessionStore';
 import { useAuthToken } from '../../../hooks/useAuthToken';
 
@@ -100,7 +103,7 @@ export const HILAuthorizationDialog: React.FC<HILAuthorizationDialogProps> = ({
       await resumeHILExecution(sessionId, resumeValue, authToken);
       onClose();
     } catch (error) {
-      console.error('❌ Authorization approval failed:', error);
+      log.error('Authorization approval failed:', error);
     } finally {
       setIsProcessing(false);
     }
@@ -126,7 +129,7 @@ export const HILAuthorizationDialog: React.FC<HILAuthorizationDialogProps> = ({
       await resumeHILExecution(sessionId, resumeValue, authToken);
       onClose();
     } catch (error) {
-      console.error('❌ Authorization rejection failed:', error);
+      log.error('Authorization rejection failed:', error);
     } finally {
       setIsProcessing(false);
     }

--- a/src/components/ui/hil/HILInputDialog.tsx
+++ b/src/components/ui/hil/HILInputDialog.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useState, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useHILActions, useCurrentHILInterrupt } from '../../../stores/useChatStore';
+
+const log = createLogger('HILInputDialog');
 import { useSessionStore } from '../../../stores/useSessionStore';
 import { useAuthToken } from '../../../hooks/useAuthToken';
 
@@ -71,7 +74,7 @@ export const HILInputDialog: React.FC<HILInputDialogProps> = ({
       await resumeHILExecution(sessionId, resumeValue, authToken);
       onClose();
     } catch (error) {
-      console.error('❌ HIL input submission failed:', error);
+      log.error('HIL input submission failed:', error);
     } finally {
       setIsProcessing(false);
     }

--- a/src/components/ui/hil/HILInteractionManager.tsx
+++ b/src/components/ui/hil/HILInteractionManager.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useHILStatus, useCurrentHILInterrupt } from '../../../stores/useChatStore';
+
+const log = createLogger('HILInteractionManager');
 import { HILAuthorizationDialog } from './HILAuthorizationDialog';
 import { HILInputDialog } from './HILInputDialog';
 
@@ -46,7 +49,7 @@ export const HILInteractionManager: React.FC<HILInteractionManagerProps> = ({
     if (hilStatus === 'waiting_for_human' && currentInterrupt) {
       const interruptType = currentInterrupt.interrupt?.data?.raw_interrupt?.type || currentInterrupt.interrupt?.interrupt_type;
       
-      console.log('🤖 HIL_MANAGER: HIL interrupt detected:', {
+      log.info('HIL interrupt detected:', {
         type: interruptType,
         hilStatus,
         interruptData: currentInterrupt
@@ -61,7 +64,7 @@ export const HILInteractionManager: React.FC<HILInteractionManagerProps> = ({
         setIsDialogOpen(true);
       } else {
         // 未知类型，默认使用输入对话框
-        console.warn('🤖 HIL_MANAGER: Unknown interrupt type, defaulting to input dialog:', interruptType);
+        log.warn('Unknown interrupt type, defaulting to input dialog:', interruptType);
         setDialogType('input');
         setIsDialogOpen(true);
       }
@@ -102,7 +105,7 @@ export const HILInteractionManager: React.FC<HILInteractionManagerProps> = ({
         );
         
       default:
-        console.warn('🤖 HIL_MANAGER: Unknown dialog type:', dialogType);
+        log.warn('Unknown dialog type:', dialogType);
         return null;
     }
   };

--- a/src/components/ui/mobile/MobileChatLayout.tsx
+++ b/src/components/ui/mobile/MobileChatLayout.tsx
@@ -11,7 +11,10 @@
  * - Optimized performance for mobile devices
  */
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatMessage } from '../chat/ChatLayout';
+
+const log = createLogger('MobileChatLayout');
 import { ModernMobileMessageList } from './ModernMobileMessageList';
 import { ModernMobileInputArea } from './ModernMobileInputArea';
 import { ModernMobileHeader } from './ModernMobileHeader';
@@ -136,7 +139,7 @@ export const MobileChatLayout: React.FC<MobileChatLayoutProps> = ({
         onMenuClick={onToggleLeftSidebar}
         onNewChatClick={() => {
           // Reset chat logic would go here
-          console.log('New chat clicked');
+          log.info('New chat clicked');
         }}
         onUserAvatarClick={onToggleRightSidebar}
         isNativeApp={isNativeApp}

--- a/src/components/ui/mobile/MobileInputArea.tsx
+++ b/src/components/ui/mobile/MobileInputArea.tsx
@@ -3,6 +3,9 @@
  * Touch-optimized input area with keyboard handling
  */
 import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { createLogger } from '../../../utils/logger';
+
+const log = createLogger('MobileInputArea');
 
 // Simple SVG icon components
 const Send = ({ className }: { className?: string }) => (
@@ -93,7 +96,7 @@ export const MobileInputArea: React.FC<MobileInputAreaProps> = ({
       setAttachedFiles([]);
       setShowActions(false);
     } catch (error) {
-      console.error('Failed to send message:', error);
+      log.error('Failed to send message:', error);
     }
   }, [inputValue, attachedFiles, isLoading, onSendMessage, onSendMultimodalMessage]);
 

--- a/src/components/ui/mobile/ModernMobileChatLayout.tsx
+++ b/src/components/ui/mobile/ModernMobileChatLayout.tsx
@@ -3,7 +3,10 @@
  * Following ChatGPT, Claude, Gemini, Grok mobile UX/UI patterns
  */
 import React, { useState, useCallback, useMemo } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { THEME_COLORS } from '../../../constants/theme';
+
+const log = createLogger('ModernMobileChatLayout');
 import { ChatMessage } from '../chat/ChatLayout';
 import { ModernMobileHeader } from './ModernMobileHeader';
 import { ModernMobileMessageList } from './ModernMobileMessageList';
@@ -51,22 +54,22 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
   const [isInitialLoad, setIsInitialLoad] = useState(false); // Temporarily disabled for debugging
 
   const handleMenuClick = useCallback(() => {
-    console.log('🔥🔥🔥 MODERNMOBILECHATLAYOUT - Menu button clicked! showMenu was:', showMenu);
+    log.debug('Menu button clicked! showMenu was:', showMenu);
     setShowMenu(prev => {
       const newValue = !prev;
-      console.log('🔥🔥🔥 MODERNMOBILECHATLAYOUT - Setting showMenu to:', newValue);
+      log.debug('Setting showMenu to:', newValue);
       return newValue;
     });
   }, [showMenu]);
 
   const handleNewChat = useCallback(() => {
-    console.log('🔥🔥🔥 MODERNMOBILECHATLAYOUT - New chat button clicked! onNewChat function:', onNewChat);
+    log.debug('New chat button clicked! onNewChat function:', onNewChat);
     onNewChat?.();
     setShowMenu(false);
   }, [onNewChat]);
 
   const handleUserClick = useCallback(() => {
-    console.log('🔥🔥🔥 MODERNMOBILECHATLAYOUT - User profile clicked!');
+    log.debug('User profile clicked!');
     setShowUserProfile(true);
   }, []);
 
@@ -228,7 +231,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
               {/* Chat History */}
               <button
                 onClick={() => {
-                  console.log('🔥 Chat History clicked');
+                  log.debug('Chat History clicked');
                   setShowMenu(false);
                 }}
                 className="w-full flex items-center gap-3 px-4 py-3 text-gray-800 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-white/10 transition-all duration-200 backdrop-blur-sm rounded-lg mx-2"
@@ -244,7 +247,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
               {/* Settings */}
               <button
                 onClick={() => {
-                  console.log('🔥 Settings clicked');
+                  log.debug('Settings clicked');
                   setShowMenu(false);
                 }}
                 className="w-full flex items-center gap-3 px-4 py-3 text-gray-800 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-white/10 transition-all duration-200 backdrop-blur-sm rounded-lg mx-2"
@@ -334,7 +337,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
               <div className="space-y-2">
                 <button
                   onClick={() => {
-                    console.log('🔥 Edit Profile clicked');
+                    log.debug('Edit Profile clicked');
                     setShowUserProfile(false);
                   }}
                   className="w-full flex items-center gap-3 px-4 py-3 text-gray-800 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-white/10 rounded-lg transition-all duration-200 backdrop-blur-sm"
@@ -347,7 +350,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
 
                 <button
                   onClick={() => {
-                    console.log('🔥 Account Settings clicked');
+                    log.debug('Account Settings clicked');
                     setShowUserProfile(false);
                   }}
                   className="w-full flex items-center gap-3 px-4 py-3 text-gray-800 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-white/10 rounded-lg transition-all duration-200 backdrop-blur-sm"
@@ -361,7 +364,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
 
                 <button
                   onClick={() => {
-                    console.log('🔥 Privacy clicked');
+                    log.debug('Privacy clicked');
                     setShowUserProfile(false);
                   }}
                   className="w-full flex items-center gap-3 px-4 py-3 text-gray-800 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-white/10 rounded-lg transition-all duration-200 backdrop-blur-sm"
@@ -375,7 +378,7 @@ export const ModernMobileChatLayout: React.FC<ModernMobileChatLayoutProps> = ({
                 <div className="border-t border-white/20 dark:border-white/10 pt-2 mt-2">
                   <button
                     onClick={() => {
-                      console.log('🔥 Sign Out clicked');
+                      log.debug('Sign Out clicked');
                       setShowUserProfile(false);
                     }}
                     className="w-full flex items-center gap-3 px-4 py-3 text-red-600 dark:text-red-400 hover:bg-red-500/10 dark:hover:bg-red-500/20 rounded-lg transition-all duration-200 backdrop-blur-sm"

--- a/src/components/ui/mobile/ModernMobileHeader.tsx
+++ b/src/components/ui/mobile/ModernMobileHeader.tsx
@@ -3,7 +3,10 @@
  * Ultra-modern glass effects inspired by ChatGPT, Claude, Gemini, and Grok
  */
 import React from 'react';
+import { createLogger } from '../../../utils/logger';
 import { GlassButton, GlassCard } from '../../shared';
+
+const log = createLogger('ModernMobileHeader');
 
 // Simple SVG icon components
 const Menu = ({ className }: { className?: string }) => (
@@ -75,7 +78,7 @@ export const ModernMobileHeader: React.FC<ModernMobileHeaderProps> = ({
           {/* Menu Button */}
           <button
             onClick={() => {
-              console.log('🔥🔥🔥 GLASS MENU CLICKED');
+              log.debug('Glass menu clicked');
               onMenuClick?.();
             }}
             className="w-9 h-9 rounded-xl flex items-center justify-center bg-white/10 hover:bg-white/15 border border-white/20 transition-all duration-200"
@@ -114,7 +117,7 @@ export const ModernMobileHeader: React.FC<ModernMobileHeaderProps> = ({
           {showUserAvatar && (
             <button
               onClick={() => {
-                console.log('🔥🔥🔥 GLASS USER AVATAR CLICKED');
+                log.debug('Glass user avatar clicked');
                 onUserAvatarClick?.();
               }}
               className="w-8 h-8 rounded-full flex items-center justify-center overflow-hidden bg-gradient-to-br from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 border border-white/20 transition-all duration-200 shadow-lg"

--- a/src/components/ui/mobile/ModernMobileInputArea.tsx
+++ b/src/components/ui/mobile/ModernMobileInputArea.tsx
@@ -3,7 +3,10 @@
  * Ultra-modern glass effects with ChatGPT, Claude, Gemini design patterns
  */
 import React, { useState, useRef, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { GlassChatInput, GlassCard, GlassButton } from '../../shared';
+
+const log = createLogger('ModernMobileInputArea');
 
 export interface ModernMobileInputAreaProps {
   onSendMessage?: (content: string, metadata?: Record<string, any>) => Promise<void>;
@@ -48,7 +51,7 @@ export const ModernMobileInputArea: React.FC<ModernMobileInputAreaProps> = ({
       setInputValue('');
       setAttachedFiles([]);
     } catch (error) {
-      console.error('Failed to send message:', error);
+      log.error('Failed to send message:', error);
     }
   }, [attachedFiles, onSendMessage, onSendMultimodalMessage]);
 
@@ -63,11 +66,11 @@ export const ModernMobileInputArea: React.FC<ModernMobileInputAreaProps> = ({
   }, []);
 
   const handleVoiceRecord = useCallback(() => {
-    console.log('Voice recording - coming soon in glassmorphism!');
+    log.info('Voice recording - coming soon in glassmorphism!');
   }, []);
 
   const handleMagicAction = useCallback(() => {
-    console.log('Magic AI actions - enhanced with glass effects!');
+    log.info('Magic AI actions - enhanced with glass effects!');
   }, []);
 
 

--- a/src/components/ui/mobile/ModernMobileMessageList.tsx
+++ b/src/components/ui/mobile/ModernMobileMessageList.tsx
@@ -3,7 +3,10 @@
  * Ultra-modern glass effects with ChatGPT, Claude, Gemini design patterns
  */
 import React, { useRef, useEffect, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatMessage } from '../chat/ChatLayout';
+
+const log = createLogger('ModernMobileMessageList');
 import { GlassMessageBubble, EmptyState, TypingIndicator, GlassCard } from '../../shared';
 
 export interface ModernMobileMessageListProps {
@@ -109,13 +112,13 @@ export const ModernMobileMessageList: React.FC<ModernMobileMessageListProps> = (
             navigator.clipboard?.writeText(message.content);
           }}
           onLike={() => {
-            console.log('Message liked:', message.id);
+            log.debug('Message liked:', message.id);
           }}
           onDislike={() => {
-            console.log('Message disliked:', message.id);
+            log.debug('Message disliked:', message.id);
           }}
           onRegenerate={() => {
-            console.log('Message regenerate:', message.id);
+            log.debug('Message regenerate:', message.id);
           }}
         />
       ))}

--- a/src/components/ui/organization/CreateOrganizationModal.tsx
+++ b/src/components/ui/organization/CreateOrganizationModal.tsx
@@ -15,6 +15,9 @@
  */
 
 import React, { useState, useCallback } from 'react';
+import { createLogger } from '../../../utils/logger';
+
+const log = createLogger('CreateOrganizationModal');
 
 export interface CreateOrganizationData {
   name: string;
@@ -123,7 +126,7 @@ export const CreateOrganizationModal: React.FC<CreateOrganizationModalProps> = (
       
     } catch (error) {
       // Error is handled by parent component
-      console.error('Create organization error:', error);
+      log.error('Create organization error:', error);
     }
   }, [name, domain, plan, billingEmail, description, validateName, validateEmail, onCreate]);
 

--- a/src/components/ui/permissions/PermissionGuard.tsx
+++ b/src/components/ui/permissions/PermissionGuard.tsx
@@ -16,7 +16,10 @@
  */
 
 import React from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useContextModule } from '../../../modules/ContextModule';
+
+const log = createLogger('PermissionGuard');
 
 export type PermissionLevel = 'owner' | 'admin' | 'member' | 'any';
 export type ContextRequirement = 'personal' | 'organization' | 'any';
@@ -149,7 +152,7 @@ export const PermissionGuard: React.FC<PermissionGuardProps> = ({
     ];
 
     if (debugMode) {
-      console.log('PermissionGuard checks:', {
+      log.debug('PermissionGuard checks:', {
         requirements: {
           requiredRole,
           requiredPermission,

--- a/src/components/ui/session/SessionHistory.tsx
+++ b/src/components/ui/session/SessionHistory.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ChatSession } from '../../../hooks/useSession';
+
+const log = createLogger('SessionHistory');
 import { GlassButton } from '../../shared';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -163,7 +166,7 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
                               }
                               return t('sessions.noMessages');
                             } catch (error) {
-                              console.error('Error rendering session message:', error);
+                              log.error('Error rendering session message:', error);
                               return t('sessions.errorLoadingMessage');
                             }
                           })()}

--- a/src/components/ui/user/UserPortal.tsx
+++ b/src/components/ui/user/UserPortal.tsx
@@ -8,7 +8,10 @@
  */
 
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { useUserModule, PRICING_PLANS, formatCredits } from '../../../modules/UserModule';
+
+const log = createLogger('UserPortal');
 import { useContextModule } from '../../../modules/ContextModule';
 import { useOrganizationModule } from '../../../modules/OrganizationModule';
 import { useTranslation } from '../../../hooks/useTranslation';
@@ -102,7 +105,7 @@ export const UserPortal: React.FC<UserPortalProps> = ({ isOpen, onClose }) => {
         window.location.href = checkoutUrl;
       }
     } catch (error) {
-      console.error('Upgrade failed:', error);
+      log.error('Upgrade failed:', error);
     } finally {
       setUpgradingPlan(null);
     }
@@ -113,7 +116,7 @@ export const UserPortal: React.FC<UserPortalProps> = ({ isOpen, onClose }) => {
     try {
       await userModule.refreshUser();
     } catch (error) {
-      console.error('Refresh failed:', error);
+      log.error('Refresh failed:', error);
     }
   };
 
@@ -141,13 +144,13 @@ export const UserPortal: React.FC<UserPortalProps> = ({ isOpen, onClose }) => {
     
     try {
       const newOrganization = await organizationModule.createOrganization(data);
-      console.log('Organization created successfully:', newOrganization);
+      log.info('Organization created successfully:', newOrganization);
       
       setShowCreateOrgModal(false);
       await contextModule.refreshContext();
       
     } catch (error) {
-      console.error('Failed to create organization:', error);
+      log.error('Failed to create organization:', error);
       setCreateError(error instanceof Error ? error.message : 'Failed to create organization');
     } finally {
       setCreateLoading(false);

--- a/src/components/ui/widgets/BaseWidget.tsx
+++ b/src/components/ui/widgets/BaseWidget.tsx
@@ -16,10 +16,12 @@
  * 4. Management Area: Quick action menu (optional)
  */
 import React, { useState, ReactNode, useRef } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { ScrollFollowUpActions } from '../../shared/widgets/ScrollFollowUpActions';
 import { Button } from '../../shared/ui/Button';
 import { Dropdown } from '../../shared/widgets/Dropdown';
 import { ContentRenderer, ContentType } from '../../shared/content/ContentRenderer';
+const log = createLogger('BaseWidget');
 
 // Compact Dropdown components for title bar
 const CompactArtifactDropdown: React.FC<{
@@ -449,7 +451,7 @@ export const BaseWidget: React.FC<BaseWidgetProps> = ({
     ? widgetSession.title
     : 'Widget Session';
     
-  console.log('🔧 BASEWIDGET: Mode detection:', {
+  log.debug('Mode detection', {
     mode,
     isPluginMode,
     isIndependentMode,
@@ -687,7 +689,7 @@ export const BaseWidget: React.FC<BaseWidgetProps> = ({
                 }}
                 maxHeight={400}
                 onAction={(action, data) => {
-                  console.log('🎬 BASEWIDGET: Content action:', action, data);
+                  log.debug('Content action', { action, data });
                 }}
               />
             </div>
@@ -708,7 +710,7 @@ export const BaseWidget: React.FC<BaseWidgetProps> = ({
                 }}
                 maxHeight={400}
                 onAction={(action, data) => {
-                  console.log('🎬 BASEWIDGET: Content action:', action, data);
+                  log.debug('Content action', { action, data });
                 }}
               />
             </div>
@@ -729,7 +731,7 @@ export const BaseWidget: React.FC<BaseWidgetProps> = ({
                 }}
                 maxHeight={400}
                 onAction={(action, data) => {
-                  console.log('🎬 BASEWIDGET: Content action:', action, data);
+                  log.debug('Content action', { action, data });
                 }}
               />
             </div>

--- a/src/components/ui/widgets/DataScientistWidget.tsx
+++ b/src/components/ui/widgets/DataScientistWidget.tsx
@@ -17,7 +17,9 @@
  * - Data-specific actions (export, visualize, share)
  */
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { BaseWidget, OutputHistoryItem, EditAction, ManagementAction, EmptyStateConfig } from './BaseWidget';
+const log = createLogger('DataScientistWidget');
 
 // Data analysis modes
 interface DataMode {
@@ -145,7 +147,7 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
       const bestMode = detectBestMode(query);
       if (bestMode.id !== selectedMode.id) {
         setSelectedMode(bestMode);
-        console.log('🔬 Mode recommendation updated:', bestMode.id);
+        log.debug('Mode recommendation updated', bestMode.id);
       }
     }
   }, [query, selectedMode.id]);
@@ -154,7 +156,7 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      console.log('🔬 Data file uploaded:', file.name);
+      log.info('Data file uploaded', file.name);
       setUploadedFile(file);
     }
   };
@@ -163,7 +165,7 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
   const handleDataAnalysis = async () => {
     if (!query.trim() || !onAnalyzeData || isAnalyzing) return;
     
-    console.log('🔬 Starting data analysis with mode:', selectedMode.name);
+    log.info('Starting data analysis with mode', selectedMode.name);
     
     try {
       const params: DataScientistWidgetParams = {
@@ -175,9 +177,9 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
       
       await onAnalyzeData(params);
       
-      console.log('🚀 Data analysis request sent with mode:', selectedMode.name);
+      log.info('Data analysis request sent with mode', selectedMode.name);
     } catch (error) {
-      console.error('Data analysis failed:', error);
+      log.error('Data analysis failed', error);
     }
   };
 
@@ -203,7 +205,7 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
             onChange={(e) => {
               const newValue = e.target.value;
               if (newValue !== query) {
-                console.log('🔬 Query changed');
+                log.debug('Query changed');
               }
               setQuery(newValue);
             }}
@@ -253,9 +255,9 @@ const DataScientistInputArea: React.FC<DataScientistWidgetProps> = ({
               onClick={() => {
                 if (mode.isActive) {
                   setSelectedMode(mode);
-                  console.log('🔬 Mode selected:', mode.name);
+                  log.debug('Mode selected', mode.name);
                 } else {
-                  console.log('🔬 Mode disabled:', mode.name);
+                  log.debug('Mode disabled', mode.name);
                 }
               }}
               disabled={!mode.isActive}
@@ -364,7 +366,7 @@ export const DataScientistWidget: React.FC<DataScientistWidgetProps> = ({
       icon: '📊',
       onClick: (content) => {
         // Open visualization for data
-        console.log('Opening visualization for data:', content);
+        log.info('Opening visualization for data', content);
       }
     }
   ];
@@ -386,21 +388,21 @@ export const DataScientistWidget: React.FC<DataScientistWidgetProps> = ({
       id: 'db',
       label: 'DB',
       icon: '🗋',
-      onClick: () => console.log('🗋 Database mode - coming soon'),
+      onClick: () => log.info('Database mode - coming soon'),
       disabled: true
     },
     {
       id: 'url',
       label: 'URL',
       icon: '🔗',
-      onClick: () => console.log('🔗 URL mode - coming soon'),
+      onClick: () => log.info('URL mode - coming soon'),
       disabled: true
     },
     {
       id: 'other',
       label: 'Other',
       icon: '📄',
-      onClick: () => console.log('📄 Other mode - coming soon'),
+      onClick: () => log.info('Other mode - coming soon'),
       disabled: true
     }
   ];

--- a/src/components/ui/widgets/DreamWidget.tsx
+++ b/src/components/ui/widgets/DreamWidget.tsx
@@ -17,9 +17,11 @@
  * - Image-specific actions (download, share, transform)
  */
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { DreamWidgetParams } from '../../../types/widgetTypes';
 import { BaseWidget, OutputHistoryItem, EditAction, ManagementAction, EmptyStateConfig } from './BaseWidget';
 import { useTranslation } from '../../../hooks/useTranslation';
+const log = createLogger('DreamWidget');
 
 // Atomic Image Intelligence Service modes (copied from dream_sidebar.tsx)
 interface ImageMode {
@@ -206,7 +208,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
       const bestMode = detectBestMode(prompt, !!uploadedImage, imageModes);
       if (bestMode.id !== selectedMode.id) {
         setSelectedMode(bestMode);
-        console.log('🎨 Mode recommendation updated:', bestMode.id);
+        log.debug('Mode recommendation updated', bestMode.id);
       }
     }
   }, [prompt, uploadedImage, selectedMode.id]);
@@ -221,7 +223,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
       return;
     }
 
-    console.log('🎨 Starting image processing with mode:', selectedMode.name);
+    log.info('Starting image processing with mode', selectedMode.name);
     
     try {
       const params: DreamWidgetParams = {
@@ -243,9 +245,9 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
       
       await onGenerateImage(params);
       
-      console.log('🚀 Image processing request sent with mode:', selectedMode.name);
+      log.info('Image processing request sent with mode', selectedMode.name);
     } catch (error) {
-      console.error('Image processing failed:', error);
+      log.error('Image processing failed', error);
     }
   };
 
@@ -253,7 +255,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file && file.type.startsWith('image/')) {
-      console.log('🎨 Image file uploaded:', file.name);
+      log.info('Image file uploaded', file.name);
       
       const reader = new FileReader();
       reader.onload = (e) => {
@@ -264,7 +266,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
         if (prompt.trim()) {
           const bestMode = detectBestMode(prompt, true, imageModes);
           setSelectedMode(bestMode);
-          console.log('🎨 Mode updated after image upload:', bestMode.id);
+          log.debug('Mode updated after image upload', bestMode.id);
         }
       };
       reader.readAsDataURL(file);
@@ -295,7 +297,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
           onChange={(e) => {
             const newValue = e.target.value;
             if (newValue !== prompt) {
-              console.log('🎨 Prompt text changed');
+              log.debug('Prompt text changed');
             }
             setPrompt(newValue);
           }}
@@ -341,7 +343,7 @@ const DreamInputArea: React.FC<DreamWidgetProps> = ({
                   document.getElementById('image-upload')?.click();
                 }
                 setSelectedMode(mode);
-                console.log('🎨 Mode selected:', mode.name);
+                log.debug('Mode selected', mode.name);
               }}
               className={`p-1.5 rounded border transition-all text-center cursor-pointer ${
                 selectedMode.id === mode.id
@@ -658,7 +660,7 @@ export const DreamWidget: React.FC<DreamWidgetProps> = ({
       label: 'Image',
       icon: '🖼️',
       onClick: () => {
-        console.log('🖼️ Image mode selected (already active)');
+        log.info('Image mode selected (already active)');
       },
       variant: 'primary' as const,
       disabled: false // Current active mode
@@ -668,7 +670,7 @@ export const DreamWidget: React.FC<DreamWidgetProps> = ({
       label: 'Video',
       icon: '🎬',
       onClick: () => {
-        console.log('🎬 Video mode - not implemented yet');
+        log.info('Video mode - not implemented yet');
       },
       disabled: true // Not yet implemented
     },
@@ -677,7 +679,7 @@ export const DreamWidget: React.FC<DreamWidgetProps> = ({
       label: 'Audio',
       icon: '🎵',
       onClick: () => {
-        console.log('🎵 Audio mode - not implemented yet');
+        log.info('Audio mode - not implemented yet');
       },
       disabled: true // Not yet implemented
     },
@@ -686,7 +688,7 @@ export const DreamWidget: React.FC<DreamWidgetProps> = ({
       label: 'Others',
       icon: '📄',
       onClick: () => {
-        console.log('📄 Others mode - not implemented yet');
+        log.info('Others mode - not implemented yet');
       },
       disabled: true // Not yet implemented
     }

--- a/src/components/ui/widgets/HuntWidget.tsx
+++ b/src/components/ui/widgets/HuntWidget.tsx
@@ -17,8 +17,10 @@
  * - Search-specific actions (bookmark, share, analyze)
  */
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { HuntWidgetParams } from '../../../types/widgetTypes';
 import { BaseWidget, OutputHistoryItem, EditAction, ManagementAction, EmptyStateConfig } from './BaseWidget';
+const log = createLogger('HuntWidget');
 
 // AI Search Intelligence Service modes (based on admin categories)
 interface SearchMode {
@@ -143,7 +145,7 @@ const HuntInputArea: React.FC<{
       const bestMode = detectBestMode(query);
       if (bestMode.id !== selectedMode.id) {
         setRecommendedMode(bestMode);
-        console.log('🔍 Mode recommendation available:', bestMode.id);
+        log.debug('Mode recommendation available', bestMode.id);
       } else {
         setRecommendedMode(null);
       }
@@ -162,7 +164,7 @@ const HuntInputArea: React.FC<{
       return;
     }
 
-    console.log('🔍 Starting search processing with mode:', selectedMode.name);
+    log.info('Starting search processing with mode', selectedMode.name);
     
     try {
       const params: HuntWidgetParams = {
@@ -174,16 +176,16 @@ const HuntInputArea: React.FC<{
       
       // Use Module's onSearch - no fallback needed
       if (onSearch) {
-        console.log('🔍 HUNT_WIDGET: Using module onSearch function');
+        log.info('Using module onSearch function');
         await onSearch(params);
       } else {
-        console.error('🔍 HUNT_WIDGET: No onSearch prop provided - widget not properly configured');
+        log.error('No onSearch prop provided - widget not properly configured');
         return;
       }
       
-      console.log('🚀 Search processing request sent with mode:', selectedMode.name);
+      log.info('Search processing request sent with mode', selectedMode.name);
     } catch (error) {
-      console.error('Search processing failed:', error);
+      log.error('Search processing failed', error);
     }
   };
 
@@ -208,7 +210,7 @@ const HuntInputArea: React.FC<{
           onChange={(e) => {
             const newValue = e.target.value;
             if (newValue !== query) {
-              console.log('🔍 Search query changed');
+              log.debug('Search query changed');
             }
             setQuery(newValue);
           }}
@@ -231,7 +233,7 @@ const HuntInputArea: React.FC<{
             onClick={() => {
               setSelectedMode(recommendedMode);
               setRecommendedMode(null);
-              console.log('🔍 Accepted recommendation:', recommendedMode.name);
+              log.debug('Accepted recommendation', recommendedMode.name);
             }}
             className="px-2 py-1 bg-blue-500/20 text-white rounded text-xs hover:bg-blue-500/30"
           >
@@ -255,7 +257,7 @@ const HuntInputArea: React.FC<{
               key={mode.id}
               onClick={() => {
                 setSelectedMode(mode);
-                console.log('🔍 Mode selected:', mode.name);
+                log.debug('Mode selected', mode.name);
               }}
               className={`p-1.5 rounded border transition-all text-center cursor-pointer ${
                 selectedMode.id === mode.id
@@ -377,7 +379,7 @@ export const HuntWidget: React.FC<HuntWidgetProps> = ({
       id: 'search',
       label: 'Search',
       icon: '🔍',
-      onClick: () => console.log('🔍 Search mode active'),
+      onClick: () => log.info('Search mode active'),
       variant: 'primary' as const,
       disabled: false
     },
@@ -385,21 +387,21 @@ export const HuntWidget: React.FC<HuntWidgetProps> = ({
       id: 'crawler',
       label: 'Crawler',
       icon: '🕷️',
-      onClick: () => console.log('🕷️ Crawler mode - coming soon'),
+      onClick: () => log.info('Crawler mode - coming soon'),
       disabled: true
     },
     {
       id: 'automation',
       label: 'Automation', 
       icon: '🤖',
-      onClick: () => console.log('🤖 Automation mode - coming soon'),
+      onClick: () => log.info('Automation mode - coming soon'),
       disabled: true
     },
     {
       id: 'other',
       label: 'Other',
       icon: '⚙️',
-      onClick: () => console.log('⚙️ Other tools - coming soon'),
+      onClick: () => log.info('Other tools - coming soon'),
       disabled: true
     }
   ];

--- a/src/components/ui/widgets/KnowledgeWidget.tsx
+++ b/src/components/ui/widgets/KnowledgeWidget.tsx
@@ -17,8 +17,10 @@
  * - Knowledge-specific actions (export, summarize, share)
  */
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { KnowledgeWidgetParams } from '../../../types/widgetTypes';
 import { BaseWidget, OutputHistoryItem, EditAction, ManagementAction, EmptyStateConfig } from './BaseWidget';
+const log = createLogger('KnowledgeWidget');
 
 // Knowledge processing modes
 interface KnowledgeMode {
@@ -119,7 +121,7 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
       const bestMode = detectBestMode(query);
       if (bestMode.id !== selectedMode.id) {
         setSelectedMode(bestMode);
-        console.log('🧠 Mode recommendation updated:', bestMode.id);
+        log.debug('Mode recommendation updated', bestMode.id);
       }
     }
   }, [query, selectedMode.id]);
@@ -136,7 +138,7 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
     const files = event.target.files;
     if (files) {
       const fileArray = Array.from(files);
-      console.log('🧠 Files uploaded:', fileArray.length);
+      log.info('Files uploaded', fileArray.length);
       setUploadedFiles(fileArray);
     }
   };
@@ -157,7 +159,7 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
       return;
     }
 
-    console.log('🧠 Starting knowledge processing with mode:', selectedMode.name);
+    log.info('Starting knowledge processing with mode', selectedMode.name);
     
     try {
       const params: KnowledgeWidgetParams = {
@@ -170,9 +172,9 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
       
       await onProcess(params);
       
-      console.log('🚀 Knowledge processing request sent with mode:', selectedMode.name);
+      log.info('Knowledge processing request sent with mode', selectedMode.name);
     } catch (error) {
-      console.error('Knowledge processing failed:', error);
+      log.error('Knowledge processing failed', error);
     }
   };
 
@@ -199,7 +201,7 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
             onChange={(e) => {
               const newValue = e.target.value;
               if (newValue !== query) {
-                console.log('🧠 Query changed');
+                log.debug('Query changed');
               }
               setQuery(newValue);
             }}
@@ -255,9 +257,9 @@ const KnowledgeInputArea: React.FC<KnowledgeWidgetProps> = ({
               onClick={() => {
                 if (mode.isActive) {
                   setSelectedMode(mode);
-                  console.log('🧠 Mode selected:', mode.name);
+                  log.debug('Mode selected', mode.name);
                 } else {
-                  console.log('🧠 Mode disabled:', mode.name);
+                  log.debug('Mode disabled', mode.name);
                 }
               }}
               disabled={!mode.isActive}
@@ -348,7 +350,7 @@ export const KnowledgeWidget: React.FC<KnowledgeWidgetProps> = ({
       icon: '📄',
       onClick: (content) => {
         // Generate summary of the knowledge content
-        console.log('Generating summary for:', content);
+        log.info('Generating summary for', content);
       }
     },
     {
@@ -398,21 +400,21 @@ export const KnowledgeWidget: React.FC<KnowledgeWidgetProps> = ({
       id: 'search',
       label: 'Search',
       icon: '🔎',
-      onClick: () => console.log('🔎 Search mode - coming soon'),
+      onClick: () => log.info('Search mode - coming soon'),
       disabled: true
     },
     {
       id: 'manage',
       label: 'Manage',
       icon: '📚',
-      onClick: () => console.log('📚 Manage mode - coming soon'),
+      onClick: () => log.info('Manage mode - coming soon'),
       disabled: true
     },
     {
       id: 'other',
       label: 'Other',
       icon: '📄',
-      onClick: () => console.log('📄 Other mode - coming soon'),
+      onClick: () => log.info('Other mode - coming soon'),
       disabled: true
     }
   ];

--- a/src/components/ui/widgets/OmniWidget.tsx
+++ b/src/components/ui/widgets/OmniWidget.tsx
@@ -17,8 +17,10 @@
  * - Content-specific actions (export, refine, share)
  */
 import React, { useState } from 'react';
+import { createLogger } from '../../../utils/logger';
 import { OmniWidgetParams } from '../../../types/widgetTypes';
 import { BaseWidget, OutputHistoryItem, EditAction, ManagementAction, EmptyStateConfig } from './BaseWidget';
+const log = createLogger('OmniWidget');
 
 interface OmniWidgetProps {
   // Props provided by OmniWidgetModule via React.cloneElement (optional for typing)
@@ -177,7 +179,7 @@ const OmniInputArea: React.FC<OmniWidgetProps> = ({
 
   const handleGenerate = async () => {
     if (!args.subject.trim() || !onGenerateContent || isGenerating) {
-      console.log('⚡ OMNI: Aborting generation - invalid input');
+      log.info('Aborting generation - invalid input');
       return;
     }
 
@@ -197,10 +199,10 @@ const OmniInputArea: React.FC<OmniWidgetProps> = ({
         }
       };
       
-      console.log('⚡ OMNI: Sending request to handler:', params);
+      log.info('Sending request to handler', params);
       await onGenerateContent(params);
     } catch (error) {
-      console.error('Generation failed:', error);
+      log.error('Generation failed', error);
     }
   };
 
@@ -356,7 +358,7 @@ export const OmniWidget: React.FC<OmniWidgetProps> = ({
       icon: '✨',
       onClick: (content) => {
         // Trigger content refinement
-        console.log('Refining content:', content);
+        log.info('Refining content', content);
       }
     },
     {
@@ -382,7 +384,7 @@ export const OmniWidget: React.FC<OmniWidgetProps> = ({
       icon: '📈',
       onClick: (content) => {
         // Expand content with more details
-        console.log('Expanding content:', content);
+        log.info('Expanding content', content);
       }
     }
   ];

--- a/src/components/ui/widgets/customAutomation/ResultsPanel.tsx
+++ b/src/components/ui/widgets/customAutomation/ResultsPanel.tsx
@@ -8,12 +8,14 @@
  */
 
 import React, { useState, useMemo } from 'react';
+import { createLogger } from '../../../../utils/logger';
 import { Button } from '../../../shared/ui/Button';
 import { GlassCard } from '../../../shared/ui/GlassCard';
 import { DataTable } from '../../../shared/ui/DataTable';
 import OCRResultViewer from '../../../shared/ui/OCRResultViewer';
 import ImageAnalysisViewer from '../../../shared/ui/ImageAnalysisViewer';
 import { AutomationTemplate } from './types';
+const log = createLogger('ResultsPanel');
 
 export interface ExecutionResult {
   id: string;
@@ -512,7 +514,7 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
                       showConfidence={true}
                       onExport={(format) => {
                         // Handle OCR export
-                        console.log('Export OCR result as', format);
+                        log.info('Export OCR result as', format);
                       }}
                     />
                   )}
@@ -524,7 +526,7 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
                       showHeatmap={false}
                       onExportReport={(format) => {
                         // Handle image analysis export
-                        console.log('Export image analysis as', format);
+                        log.info('Export image analysis as', format);
                       }}
                     />
                   )}

--- a/src/components/ui/widgets/demos/AutomationDemoShowcase.tsx
+++ b/src/components/ui/widgets/demos/AutomationDemoShowcase.tsx
@@ -7,11 +7,13 @@
  */
 
 import React, { useState } from 'react';
+import { createLogger } from '../../../../utils/logger';
 import { BaseWidget } from '../BaseWidget';
 import { Button } from '../../../shared/ui/Button';
 import ClassicAutomationDemo from './CustomAutomationWidget_Classic';
 import ModernAutomationDemo from './CustomAutomationWidget_Modern';
 import MinimalAutomationDemo from './CustomAutomationWidget_Minimal';
+const log = createLogger('AutomationDemoShowcase');
 
 type DemoStyle = 'showcase' | 'classic' | 'modern' | 'minimal';
 
@@ -132,28 +134,28 @@ const AutomationDemoShowcase: React.FC = () => {
       id: 'compare',
       label: '功能对比',
       icon: '📊',
-      onClick: () => console.log('Compare features'),
+      onClick: () => log.info('Compare features'),
       variant: 'secondary' as const
     },
     {
       id: 'customize',
       label: '自定义风格',
       icon: '🎨',
-      onClick: () => console.log('Customize'),
+      onClick: () => log.info('Customize'),
       variant: 'secondary' as const
     },
     {
       id: 'export',
       label: '导出配置',
       icon: '📤',
-      onClick: () => console.log('Export'),
+      onClick: () => log.info('Export'),
       variant: 'secondary' as const
     },
     {
       id: 'docs',
       label: '开发文档',
       icon: '📚',
-      onClick: () => console.log('Docs'),
+      onClick: () => log.info('Docs'),
       variant: 'secondary' as const
     }
   ];

--- a/src/components/ui/widgets/demos/CustomAutomationWidget_Classic.tsx
+++ b/src/components/ui/widgets/demos/CustomAutomationWidget_Classic.tsx
@@ -10,9 +10,11 @@
  */
 
 import React, { useState } from 'react';
+import { createLogger } from '../../../../utils/logger';
 import { BaseWidget } from '../BaseWidget';
 import { Button } from '../../../shared/ui/Button';
 import { Dropdown } from '../../../shared/widgets/Dropdown';
+const log = createLogger('ClassicAutomationDemo');
 
 interface AutomationField {
   id: string;
@@ -189,21 +191,21 @@ const ClassicAutomationDemo: React.FC = () => {
       id: 'schedule',
       label: '定时执行',
       icon: '⏰',
-      onClick: () => console.log('Schedule'),
+      onClick: () => log.info('Schedule'),
       variant: 'secondary' as const
     },
     {
       id: 'test',
       label: '测试运行',
       icon: '🧪',
-      onClick: () => console.log('Test'),
+      onClick: () => log.info('Test'),
       variant: 'secondary' as const
     },
     {
       id: 'history',
       label: '执行历史',
       icon: '📊',
-      onClick: () => console.log('History'),
+      onClick: () => log.info('History'),
       variant: 'secondary' as const
     }
   ];

--- a/src/components/ui/widgets/demos/CustomAutomationWidget_Minimal.tsx
+++ b/src/components/ui/widgets/demos/CustomAutomationWidget_Minimal.tsx
@@ -10,8 +10,10 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
+import { createLogger } from '../../../../utils/logger';
 import { BaseWidget } from '../BaseWidget';
 import { Button } from '../../../shared/ui/Button';
+const log = createLogger('MinimalAutomationDemo');
 
 interface ChatMessage {
   id: string;
@@ -182,7 +184,7 @@ const MinimalAutomationDemo: React.FC = () => {
         break;
 
       default:
-        console.log('Action not handled:', action.id);
+        log.debug('Action not handled', action.id);
     }
   };
 
@@ -231,7 +233,7 @@ const MinimalAutomationDemo: React.FC = () => {
       id: 'export-config',
       label: '导出配置',
       icon: '📤',
-      onClick: () => console.log('Export config'),
+      onClick: () => log.info('Export config'),
       variant: 'secondary' as const,
       disabled: !context.isComplete
     },
@@ -239,14 +241,14 @@ const MinimalAutomationDemo: React.FC = () => {
       id: 'templates',
       label: '模板库',
       icon: '📚',
-      onClick: () => console.log('Templates'),
+      onClick: () => log.info('Templates'),
       variant: 'secondary' as const
     },
     {
       id: 'help',
       label: '帮助',
       icon: '❓',
-      onClick: () => console.log('Help'),
+      onClick: () => log.info('Help'),
       variant: 'secondary' as const
     }
   ];

--- a/src/components/ui/widgets/demos/CustomAutomationWidget_Modern.tsx
+++ b/src/components/ui/widgets/demos/CustomAutomationWidget_Modern.tsx
@@ -10,8 +10,10 @@
  */
 
 import React, { useState } from 'react';
+import { createLogger } from '../../../../utils/logger';
 import { BaseWidget } from '../BaseWidget';
 import { Button } from '../../../shared/ui/Button';
+const log = createLogger('ModernAutomationDemo');
 
 interface FlowStep {
   id: string;
@@ -138,21 +140,21 @@ const ModernAutomationDemo: React.FC = () => {
       id: 'customize',
       label: '自定义流程',
       icon: '⚙️',
-      onClick: () => console.log('Customize'),
+      onClick: () => log.info('Customize'),
       variant: 'secondary' as const
     },
     {
       id: 'templates',
       label: '模板库',
       icon: '📚',
-      onClick: () => console.log('Templates'),
+      onClick: () => log.info('Templates'),
       variant: 'secondary' as const
     },
     {
       id: 'monitor',
       label: '执行监控',
       icon: '📊',
-      onClick: () => console.log('Monitor'),
+      onClick: () => log.info('Monitor'),
       variant: 'secondary' as const
     }
   ];

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,6 +17,8 @@
  */
 
 import { GATEWAY_CONFIG } from './gatewayConfig';
+import { createLogger } from '../utils/logger';
+const log = createLogger('Config');
 
 // ================================================================================
 // 环境变量接口定义
@@ -73,7 +75,7 @@ export interface AppConfiguration {
 const getEnvVar = (key: string, defaultValue?: string): string => {
   const value = process.env[key] || defaultValue;
   if (!value) {
-    console.warn(`⚠️  Environment variable ${key} is not set`);
+    log.warn(`Environment variable ${key} is not set`);
     return '';
   }
   return value.trim();
@@ -194,19 +196,19 @@ export const getUserServiceUrl = (endpoint: string = '') => {
 // ================================================================================
 
 if (isDevelopment()) {
-  console.group('🔧 Application Configuration');
-  console.log('API Base URL:', config.api.baseUrl);
-  console.log('Environment:', config.app.environment);
-  console.log('Debug Mode:', config.app.debugMode);
-  console.log('Features:', config.features);
-  
+  log.info('Application Configuration', {
+    apiBaseUrl: config.api.baseUrl,
+    environment: config.app.environment,
+    debugMode: config.app.debugMode,
+    features: config.features
+  });
+
   const validation = validateConfig();
   if (!validation.isValid) {
-    console.warn('⚠️  Configuration Issues:', validation.errors);
+    log.warn('Configuration Issues', { errors: validation.errors });
   } else {
-    console.log('✅ Configuration is valid');
+    log.info('Configuration is valid');
   }
-  console.groupEnd();
 }
 
 export default config;

--- a/src/config/runtimeEnv.ts
+++ b/src/config/runtimeEnv.ts
@@ -3,6 +3,9 @@
  * Avoid hardcoded service URLs in application code.
  */
 
+import { createLogger } from '../utils/logger';
+const log = createLogger('RuntimeEnv');
+
 const DEFAULT_GATEWAY_URL = 'http://localhost:9080';
 
 export const getRequiredPublicEnv = (key: string): string => {
@@ -21,7 +24,7 @@ export const getGatewayUrl = (): string => {
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof console !== 'undefined') {
-      console.warn(
+      log.warn(
         `Missing NEXT_PUBLIC_GATEWAY_URL, falling back to ${DEFAULT_GATEWAY_URL} for local development.`
       );
     }

--- a/src/config/welcomeConfig.ts
+++ b/src/config/welcomeConfig.ts
@@ -11,6 +11,8 @@ import React from 'react';
 import { WidgetType } from '../types/widgetTypes';
 import { getTranslation } from '../locales/translations';
 import { SupportedLanguage } from '../stores/useLanguageStore';
+import { createLogger } from '../utils/logger';
+const log = createLogger('WelcomeConfig');
 
 export interface WelcomeWidget {
   id: WidgetType;
@@ -144,18 +146,18 @@ export const validateWelcomeConfig = (): boolean => {
   
   for (const field of requiredFields) {
     if (!(field in welcomeConfig)) {
-      console.error(`WelcomeConfig missing required field: ${field}`);
+      log.error(`WelcomeConfig missing required field: ${field}`);
       return false;
     }
   }
   
   if (!Array.isArray(welcomeConfig.widgets) || welcomeConfig.widgets.length === 0) {
-    console.error('WelcomeConfig widgets must be a non-empty array');
+    log.error('WelcomeConfig widgets must be a non-empty array');
     return false;
   }
   
   if (!Array.isArray(welcomeConfig.examplePrompts) || welcomeConfig.examplePrompts.length === 0) {
-    console.error('WelcomeConfig examplePrompts must be a non-empty array');
+    log.error('WelcomeConfig examplePrompts must be a non-empty array');
     return false;
   }
   

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,7 +14,9 @@
 
 import { useCallback, useMemo } from 'react';
 import { useAuthContext } from '../providers/AuthProvider';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('useAuth');
 
 // ================================================================================
 // Auth Hook Interface
@@ -173,9 +175,9 @@ export const useAuthLegacy = () => {
     currentPlan: 'unknown',
     hasCredits: false,
     isPremium: false,
-    refreshUser: async () => { console.warn('refreshUser is deprecated, use UserModule instead'); },
-    initializeUser: async () => { console.warn('initializeUser is deprecated, use UserModule instead'); },
-    checkHealth: async () => { console.warn('checkHealth is deprecated, use UserModule instead'); }
+    refreshUser: async () => { log.warn('refreshUser is deprecated, use UserModule instead'); },
+    initializeUser: async () => { log.warn('initializeUser is deprecated, use UserModule instead'); },
+    checkHealth: async () => { log.warn('checkHealth is deprecated, use UserModule instead'); }
   };
 };
 

--- a/src/hooks/useChatService.ts
+++ b/src/hooks/useChatService.ts
@@ -8,7 +8,10 @@
  */
 
 import { useChatService as useAIChatService } from '../providers/AIProvider';
+import { createLogger } from '../utils/logger';
 import { ChatService } from '../api/chatService';
+
+const log = createLogger('useChatService');
 
 // 创建一个全局变量来存储当前的 ChatService 实例
 let globalChatServiceInstance: ChatService | null = null;
@@ -18,9 +21,9 @@ let globalChatServiceInstance: ChatService | null = null;
  * 由 AIProvider 调用
  */
 export const setChatServiceInstance = (instance: ChatService | null) => {
-  console.log('🔧 setChatServiceInstance called:', { 
-    hasInstance: !!instance, 
-    instanceType: instance?.constructor?.name 
+  log.debug('setChatServiceInstance called:', {
+    hasInstance: !!instance,
+    instanceType: instance?.constructor?.name
   });
   globalChatServiceInstance = instance;
 };

--- a/src/hooks/useCreditMonitor.ts
+++ b/src/hooks/useCreditMonitor.ts
@@ -10,7 +10,10 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import { createLogger } from '../utils/logger';
 import { creditMonitor, CreditChangeEvent, CreditAlert } from '../utils/creditMonitor';
+
+const log = createLogger('useCreditMonitor');
 
 export interface UseCreditMonitorReturn {
   // 当前状态
@@ -45,7 +48,7 @@ export const useCreditMonitor = (): UseCreditMonitorReturn => {
   // 📡 订阅信用变化事件
   useEffect(() => {
     const unsubscribe = creditMonitor.addListener((change) => {
-      console.log('🎯 useCreditMonitor: Credit change received', {
+      log.info('Credit change received', {
         credits: change.newCredits,
         difference: change.difference,
         source: change.source

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -10,6 +10,9 @@
  */
 
 import { useState, useEffect } from 'react';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useTheme');
 
 export type Theme = 'light' | 'dark';
 
@@ -34,7 +37,7 @@ export const useTheme = () => {
         applyTheme(initialTheme);
         setIsLoading(false);
       } catch (error) {
-        console.warn('Failed to initialize theme:', error);
+        log.warn('Failed to initialize theme:', error);
         setTheme('dark'); // 默认深色主题
         applyTheme('dark');
         setIsLoading(false);
@@ -82,7 +85,7 @@ export const useTheme = () => {
     try {
       localStorage.setItem('theme', newTheme);
     } catch (error) {
-      console.warn('Failed to save theme to localStorage:', error);
+      log.warn('Failed to save theme to localStorage:', error);
     }
   };
 
@@ -93,7 +96,7 @@ export const useTheme = () => {
     try {
       localStorage.setItem('theme', newTheme);
     } catch (error) {
-      console.warn('Failed to save theme to localStorage:', error);
+      log.warn('Failed to save theme to localStorage:', error);
     }
   };
 

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -12,7 +12,10 @@
  */
 
 import { useCallback, useMemo } from 'react';
+import { createLogger } from '../utils/logger';
 import { useLanguageStore } from '../stores/useLanguageStore';
+
+const log = createLogger('useTranslation');
 import { translations, Translations } from '../locales/translations';
 
 // ================================================================================
@@ -82,13 +85,13 @@ export const useTranslation = (): UseTranslationReturn => {
         if (value && typeof value === 'object' && k in value) {
           value = value[k];
         } else {
-          console.warn(`Translation key not found: ${key} for language ${currentLanguage}`);
+          log.warn(`Translation key not found: ${key} for language ${currentLanguage}`);
           return key; // Return the key itself as fallback
         }
       }
       
       if (typeof value !== 'string') {
-        console.warn(`Translation value is not a string: ${key} for language ${currentLanguage}`);
+        log.warn(`Translation value is not a string: ${key} for language ${currentLanguage}`);
         return key;
       }
       
@@ -101,7 +104,7 @@ export const useTranslation = (): UseTranslationReturn => {
       
       return value;
     } catch (error) {
-      console.error(`Error translating key ${key}:`, error);
+      log.error(`Error translating key ${key}:`, error);
       return key;
     }
   }, [currentTranslations, currentLanguage]);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -33,7 +33,9 @@
 import React, { useCallback } from 'react';
 import { useUserStore } from '../stores/useUserStore';
 import { UserService } from '../api/userService';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('useUser');
 import { 
   ExternalUser, 
   CreateExternalUserData, 
@@ -123,7 +125,7 @@ export const useUser = (): UseUserReturn => {
     const used = total - remaining;
     const usageRatio = total > 0 ? used / total : 0;
     
-    console.log('💳 useUser: Credit insights computed', {
+    log.debug('Credit insights computed', {
       remaining,
       total,
       used,
@@ -174,7 +176,7 @@ export const useUser = (): UseUserReturn => {
       setLoading(true);
       setUserError(null);
       
-      console.log('📡 useUser: Fetching current user data with auth token...');
+      log.info('Fetching current user data with auth token...');
       logger.info(LogCategory.USER_AUTH, 'Fetching current user');
       
       // 🔑 创建带认证的userService实例
@@ -186,7 +188,7 @@ export const useUser = (): UseUserReturn => {
         })
       );
       
-      console.log('🔑 useUser: Using authenticated userService with token:', {
+      log.debug('Using authenticated userService with token:', {
         tokenLength: accessToken?.length,
         tokenStart: accessToken?.substring(0, 20) + '...',
         timestamp: new Date().toISOString()
@@ -200,7 +202,7 @@ export const useUser = (): UseUserReturn => {
         const previousCredits = externalUser?.credits ?? -1;
         const newCredits = user.credits;
         
-        console.log('📡 useUser: ✅ User data fetched successfully', {
+        log.info('User data fetched successfully', {
           auth0_id: user.auth0_id,
           creditsChange: {
             from: previousCredits,
@@ -217,13 +219,13 @@ export const useUser = (): UseUserReturn => {
           credits: user.credits
         });
       } else {
-        console.warn('📡 useUser: No current user data returned from service');
+        log.warn('No current user data returned from service');
         logger.warn(LogCategory.USER_AUTH, 'No current user found');
       }
       
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to fetch user';
-      console.error('📡 useUser: ❌ Failed to fetch current user', {
+      log.error('Failed to fetch current user', {
         error: errorMessage,
         executionTime: Date.now() - startTime + 'ms',
         hasAccessToken: !!accessToken,

--- a/src/locales/translations.ts
+++ b/src/locales/translations.ts
@@ -11,6 +11,8 @@
  */
 
 import { SupportedLanguage } from '../stores/useLanguageStore';
+import { createLogger } from '../utils/logger';
+const log = createLogger('Translations');
 
 // ================================================================================
 // Translation Types
@@ -1953,7 +1955,7 @@ export const getTranslation = (
   try {
     const translation = translations[language];
     if (!translation) {
-      console.warn(`Translation for language "${language}" not found, falling back to zh-CN`);
+      log.warn(`Translation for language "${language}" not found, falling back to zh-CN`);
       return getTranslation(key, 'zh-CN', variables);
     }
 
@@ -1965,13 +1967,13 @@ export const getTranslation = (
       if (value && typeof value === 'object' && k in value) {
         value = value[k];
       } else {
-        console.warn(`Translation key "${key}" not found in language "${language}"`);
+        log.warn(`Translation key "${key}" not found in language "${language}"`);
         return key; // Return the key as fallback
       }
     }
 
     if (typeof value !== 'string') {
-      console.warn(`Translation value for key "${key}" is not a string`);
+      log.warn(`Translation value for key "${key}" is not a string`);
       return key;
     }
 
@@ -1984,7 +1986,7 @@ export const getTranslation = (
 
     return value;
   } catch (error) {
-    console.error(`Error getting translation for key "${key}":`, error);
+    log.error(`Error getting translation for key "${key}"`, error);
     return key; // Return the key as fallback
   }
 };

--- a/src/main_app.tsx
+++ b/src/main_app.tsx
@@ -45,7 +45,9 @@ import { useAI } from './providers/AIProvider';
 import { UserButton } from './components/ui/user/UserButton';
 import { LoginScreen } from './components/ui/LoginScreen';
 import { AppArtifact, AppId } from './types/appTypes';
-import { logger, LogCategory } from './utils/logger';
+import { logger, LogCategory, createLogger } from './utils/logger';
+
+const log = createLogger('MainApp');
 
 /**
  * Main App Content Component (inside provider)
@@ -162,10 +164,10 @@ const MainAppContent: React.FC = () => {
   // New chat (now handled by Zustand)
   const handleNewChat = () => {
     logger.info(LogCategory.CHAT_FLOW, 'Starting new chat session');
-    console.log('🔄 Starting new chat...');
+    log.info('Starting new chat...');
     startNewChat();
     logger.info(LogCategory.CHAT_FLOW, 'New chat session started', { chatKey });
-    console.log('✅ New chat session started');
+    log.info('New chat session started');
   };
 
   // 🆕 Enhanced task control handlers with real task state
@@ -176,7 +178,8 @@ const MainAppContent: React.FC = () => {
       isExecutingPlan,
       hasTaskProgress: !!taskProgress
     });
-    console.log('🎛️ Task control action:', action, {
+    log.info('Task control action', {
+      action,
       currentTasks: currentTasks.length,
       executing: isExecutingPlan,
       progress: taskProgress?.toolName
@@ -184,27 +187,27 @@ const MainAppContent: React.FC = () => {
     
     switch (action) {
       case 'pause_all':
-        console.log('⏸️ Pausing all tasks');
+        log.info('Pausing all tasks');
         // 这里可以发送暂停信号给chat service
         // 或者使用useTaskActions来暂停任务
         if (isExecutingPlan) {
-          console.log('  📊 Current execution:', taskProgress?.toolName || 'Processing...');
+          log.info('Current execution:', taskProgress?.toolName || 'Processing...');
           // TODO: Implement pause logic via chat service or task handler
         }
         break;
       case 'resume_all':
-        console.log('▶️ Resuming all tasks');
+        log.info('Resuming all tasks');
         // 恢复任务执行
         if (currentTasks.some(task => task.status === 'pending')) {
-          console.log('  📋 Resuming', currentTasks.filter(t => t.status === 'pending').length, 'pending tasks');
+          log.info('Resuming pending tasks', { count: currentTasks.filter(t => t.status === 'pending').length });
           // TODO: Implement resume logic
         }
         break;
       case 'show_details':
-        console.log('📋 Showing task details');
-        console.log('  📊 Current Tasks:', currentTasks.map(t => `${t.title} (${t.status})`));
-        console.log('  🚀 Progress:', taskProgress ? `${taskProgress.toolName}: ${taskProgress.description}` : 'No active progress');
-        console.log('  🎯 Execution Plan:', isExecutingPlan ? 'Active' : 'Idle');
+        log.info('Showing task details');
+        log.info('Current Tasks:', currentTasks.map(t => `${t.title} (${t.status})`));
+        log.info('Progress:', taskProgress ? `${taskProgress.toolName}: ${taskProgress.description}` : 'No active progress');
+        log.info('Execution Plan:', isExecutingPlan ? 'Active' : 'Idle');
         // TODO: Open detailed task management UI
         break;
     }
@@ -275,7 +278,7 @@ const MainAppContent: React.FC = () => {
 
   // Handle image generation from Dream app
   const handleDreamImageGenerated = (imageUrl: string, prompt: string) => {
-    console.log('🎨 Dream image generated:', { imageUrl, prompt });
+    log.info('Dream image generated:', { imageUrl, prompt });
     
     // Create artifact for the generated image
     const timestamp = Date.now();
@@ -374,7 +377,7 @@ const MainAppContent: React.FC = () => {
                     currentApp,
                     showRightSidebar
                   });
-                  console.log('🔍 Custom renderer called:', { role: message.role, content: message.content?.substring(0, 50) + '...', currentApp, showRightSidebar });
+                  log.debug('Custom renderer called:', { role: message.role, content: message.content?.substring(0, 50) + '...', currentApp, showRightSidebar });
                   
                   return null; // ArtifactModule is now a hook, UI handled elsewhere
                 }
@@ -399,7 +402,7 @@ export const MainApp: React.FC = () => {
     <ErrorBoundary
       onError={(error, errorInfo) => {
         // 发送错误到监控服务（生产环境）
-        console.error('Global error caught:', error, errorInfo);
+        log.error('Global error caught', { error, errorInfo });
       }}
     >
       <AuthProvider>

--- a/src/modules/ArtifactModule.tsx
+++ b/src/modules/ArtifactModule.tsx
@@ -24,6 +24,8 @@ import { useAppStore } from '../stores/useAppStore';
 import { useSessionStore } from '../stores/useSessionStore';
 import { ChatMessage, ArtifactMessage } from '../types/chatTypes';
 import { AppArtifact } from '../types/appTypes';
+import { createLogger } from '../utils/logger';
+const log = createLogger('ArtifactModule');
 
 /**
  * Modern Artifact Business Logic Hook
@@ -50,7 +52,7 @@ export const useArtifactLogic = () => {
     // First try legacy system
     const legacyArtifact = legacyArtifacts?.find(a => a.id === artifactId);
     if (legacyArtifact) {
-      console.log('📱 ARTIFACT_MODULE: Reopening legacy artifact app:', legacyArtifact.appId);
+      log.info('Reopening legacy artifact app', { appId: legacyArtifact.appId });
       setCurrentApp(legacyArtifact.appId);
       setShowRightSidebar(true);
       return;
@@ -59,7 +61,7 @@ export const useArtifactLogic = () => {
     // Then try artifact message system
     const artifactMessage = artifactMessages.find(am => am.artifact.id === artifactId);
     if (artifactMessage) {
-      console.log('📱 ARTIFACT_MODULE: Reopening artifact from message:', artifactMessage.artifact.widgetType);
+      log.info('Reopening artifact from message', { widgetType: artifactMessage.artifact.widgetType });
       // Map widget type to app ID
       const appId = artifactMessage.artifact.widgetType; // 'dream', 'hunt', etc.
       setCurrentApp(appId as any); // TODO: Fix type casting

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -38,7 +38,8 @@ import { useChat } from '../hooks/useChat';
 import { useChatStore } from '../stores/useChatStore';
 import { useAuth } from '../hooks/useAuth';
 import { useCurrentSession, useSessionActions } from '../stores/useSessionStore';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+const log = createLogger('ChatModule');
 import { useUserModule } from './UserModule';
 import { UpgradeModal } from '../components/ui/UpgradeModal';
 import { useAppActions, useAppStore } from '../stores/useAppStore';
@@ -131,12 +132,12 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     
     // 如果 ChatService 不可用，等待一下再重试
     if (!chatService) {
-      console.warn('💬 CHAT_MODULE: ChatService not ready, waiting 500ms...');
+      log.warn('ChatService not ready, waiting 500ms...');
       await new Promise(resolve => setTimeout(resolve, 500));
       chatService = getChatServiceInstance();
       
       if (!chatService) {
-        console.warn('💬 CHAT_MODULE: ChatService still not ready, waiting 1000ms...');
+        log.warn('ChatService still not ready, waiting 1000ms...');
         await new Promise(resolve => setTimeout(resolve, 1000));
         chatService = getChatServiceInstance();
       }
@@ -178,7 +179,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
   }>({
     listeners: {},
     emit: function(event: string, data: any) {
-      console.log(`🔌 EVENT_EMITTER: Emitting ${event} to ${this.listeners[event]?.length || 0} listeners:`, data);
+      log.debug(`Emitting ${event} to ${this.listeners[event]?.length || 0} listeners`, data);
       if (this.listeners[event]) {
         this.listeners[event].forEach(handler => handler(data));
       }
@@ -188,14 +189,14 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         this.listeners[event] = [];
       }
       this.listeners[event].push(handler);
-      console.log(`🔌 EVENT_EMITTER: Added listener for ${event}, total: ${this.listeners[event].length}`);
+      log.debug(`Added listener for ${event}, total: ${this.listeners[event].length}`);
     },
     off: function(event: string, handler: (data: any) => void) {
       if (this.listeners[event]) {
         const index = this.listeners[event].indexOf(handler);
         if (index > -1) {
           this.listeners[event].splice(index, 1);
-          console.log(`🔌 EVENT_EMITTER: Removed listener for ${event}, remaining: ${this.listeners[event].length}`);
+          log.debug(`Removed listener for ${event}, remaining: ${this.listeners[event].length}`);
         }
       }
     }
@@ -220,10 +221,10 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         // 监听Widget请求事件
         eventEmitterRef.current.on('widget:request', handleWidgetRequest);
         
-        console.log('🔌 CHAT_MODULE: Plugin mode initialized, Widget events will be handled by ChatModule');
+        log.info('Plugin mode initialized, Widget events will be handled by ChatModule');
         
       } catch (error) {
-        console.error('❌ CHAT_MODULE: Failed to initialize Plugin mode:', error);
+        log.error('Failed to initialize Plugin mode:', error);
       }
     };
     
@@ -265,11 +266,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         // 检查HIL服务是否可用
         const isServiceAvailable = await executionControlService.isServiceAvailable();
         if (!isServiceAvailable) {
-          console.warn('🔄 CHAT_MODULE: HIL service not available, but HIL interrupt handling enabled for ask_human');
+          log.warn('HIL service not available, but HIL interrupt handling enabled for ask_human');
           return;
         }
 
-        console.log('🚀 CHAT_MODULE: HIL service available, initializing event handlers');
+        log.info('HIL service available, initializing event handlers');
 
         // REMOVED: HIL事件回调注册 - defaultAGUIProcessor已删除
         // defaultAGUIProcessor.registerAGUICallbacks({
@@ -301,7 +302,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         // 这样HIL事件也能通过现有的SSE流处理
         
         setHilMonitoringActive(true);
-        console.log('✅ CHAT_MODULE: HIL system initialized successfully');
+        log.info('HIL system initialized successfully');
         
         // 🧪 测试：添加手动HIL测试功能
         if (typeof window !== 'undefined') {
@@ -320,13 +321,13 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
               }
             };
             handleHILInterrupt(testInterrupt);
-            console.log('🧪 CHAT_MODULE: Test HIL interrupt triggered');
+            log.info('Test HIL interrupt triggered');
           };
-          console.log('🧪 CHAT_MODULE: Test function available at window.testHIL()');
+          log.info('Test function available at window.testHIL()');
         }
 
       } catch (error) {
-        console.error('❌ CHAT_MODULE: Failed to initialize HIL system:', error);
+        log.error('Failed to initialize HIL system:', error);
       }
     };
 
@@ -385,7 +386,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
             }
           });
         } catch (error) {
-          console.error('Failed to start HIL monitoring:', error);
+          log.error('Failed to start HIL monitoring:', error);
         }
       };
 
@@ -402,7 +403,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // 🆕 HIL事件处理函数
   const handleHILInterrupt = useCallback((interrupt: HILInterruptData) => {
-    console.log('⏸️ CHAT_MODULE: HIL interrupt detected:', interrupt);
+    log.info('HIL interrupt detected:', interrupt);
     
     // 🆕 设置正确的thread_id
     const interruptWithThreadId = {
@@ -418,19 +419,19 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     setShowHilStatusPanel(true);
     
     // 🆕 关键：停止当前的SSE流，让HIL接管
-    console.log('🚨 CHAT_MODULE: Stopping current chat stream due to HIL interrupt');
+    log.info('Stopping current chat stream due to HIL interrupt');
     chatStore.finishStreamingMessage(); // 完成当前流式消息，防止卡在processing状态
     
     // 🆕 中断当前的聊天服务流
     try {
       import('../api/chatService').then(({ chatService }) => {
         chatService.cancelAllRequests(); // 取消当前的SSE请求
-        console.log('🚨 CHAT_MODULE: Cancelled current chat service requests');
+        log.info('Cancelled current chat service requests');
       }).catch(error => {
-        console.warn('⚠️ CHAT_MODULE: Failed to cancel chat service requests:', error);
+        log.warn('Failed to cancel chat service requests:', error);
       });
     } catch (error) {
-      console.warn('⚠️ CHAT_MODULE: Failed to import chat service:', error);
+      log.warn('Failed to import chat service:', error);
     }
     
     // 更新聊天状态显示
@@ -443,7 +444,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
   }, []);
 
   const handleHILCheckpoint = useCallback((checkpoint: HILCheckpointData) => {
-    console.log('📍 CHAT_MODULE: HIL checkpoint created:', checkpoint);
+    log.info('HIL checkpoint created:', checkpoint);
     
     setHilCheckpoints(prev => [checkpoint, ...prev.slice(0, 19)]); // 保留最近20个检查点
     
@@ -473,32 +474,32 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
   }, []);
 
   const handleHILApprovalRequired = useCallback((approval: any) => {
-    console.log('✋ CHAT_MODULE: HIL approval required:', approval);
+    log.info('HIL approval required:', approval);
     // 审批请求会通过handleHILInterrupt统一处理
   }, []);
 
   const handleHILReviewRequired = useCallback((review: any) => {
-    console.log('👁️ CHAT_MODULE: HIL review required:', review);
+    log.info('HIL review required:', review);
     // 审查请求会通过handleHILInterrupt统一处理
   }, []);
 
   const handleHILInputRequired = useCallback((input: any) => {
-    console.log('📝 CHAT_MODULE: HIL input required:', input);
+    log.info('HIL input required:', input);
     // 输入请求会通过handleHILInterrupt统一处理
   }, []);
 
   const handleExecutionStarted = useCallback((event: any) => {
-    console.log('🚀 CHAT_MODULE: Execution started:', event);
+    log.info('Execution started:', event);
     chatStore.updateStreamingStatus('🚀 Execution started...');
   }, []);
 
   const handleExecutionFinished = useCallback((event: any) => {
-    console.log('🎉 CHAT_MODULE: Execution finished:', event);
+    log.info('Execution finished:', event);
     chatStore.updateStreamingStatus('🎉 Execution completed');
   }, []);
 
   const handleExecutionError = useCallback((event: any) => {
-    console.log('❌ CHAT_MODULE: Execution error:', event);
+    log.info('Execution error:', event);
     chatStore.updateStreamingStatus(`❌ Execution error: ${event.error?.message || 'Unknown error'}`);
   }, []);
 
@@ -521,10 +522,10 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         }
       };
       
-      console.log('✅ CHAT_MODULE: Approving HIL action:', resumeRequest);
+      log.info('Approving HIL action:', resumeRequest);
       
       // 🆕 使用HIL专用的流式恢复，集成到主聊天流
-      console.log('🔄 CHAT_MODULE: Starting HIL resume stream integration...');
+      log.info('Starting HIL resume stream integration...');
       
       // 重新启动流式消息处理，将HIL恢复流作为新的AI回复
       const resumeMessageId = `resume-${Date.now()}`;
@@ -532,11 +533,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       
       await executionControlService.resumeExecutionStream(resumeRequest, {
         onResumeStart: (data) => {
-          console.log('🔄 HIL_RESUME: Resume started:', data);
+          log.info('Resume started:', data);
           chatStore.updateStreamingStatus('🔄 Processing your input...');
         },
         onMessageStream: (data) => {
-          console.log('📨 HIL_RESUME: Message stream event:', data);
+          log.info('Message stream event:', data);
           
           // 处理消息流事件，提取实际内容
           if (data.content?.raw_message) {
@@ -547,7 +548,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
             if (contentMatch) {
               messageContent = contentMatch[1] || contentMatch[2];
               messageContent = messageContent.replace(/\\\\"/g, '"').replace(/\\\\'/g, "'");
-              console.log('📨 HIL_RESUME: Extracted content:', messageContent.substring(0, 100) + '...');
+              log.info('Extracted content:', messageContent.substring(0, 100) + '...');
               
               // 只有当有实际内容时才添加到流式消息
               if (messageContent && messageContent.trim() && !messageContent.includes('tool_calls')) {
@@ -557,12 +558,12 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           }
         },
         onResumeEnd: (data) => {
-          console.log('✅ HIL_RESUME: Resume completed:', data);
+          log.info('Resume completed:', data);
           chatStore.updateStreamingStatus('✅ Response completed');
           chatStore.finishStreamingMessage(); // 完成流式消息
         },
         onError: (error) => {
-          console.error('❌ HIL_RESUME: Resume failed:', error);
+          log.error('Resume failed:', error);
           chatStore.updateStreamingStatus(`❌ Failed to resume: ${error.message}`);
           chatStore.finishStreamingMessage(); // 即使出错也要完成流式消息
         }
@@ -574,7 +575,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       logger.info(LogCategory.CHAT_FLOW, 'HIL action approved and executed', { interruptId });
       
     } catch (error) {
-      console.error('Failed to approve HIL action:', error);
+      log.error('Failed to approve HIL action:', error);
       chatStore.updateStreamingStatus(`❌ Failed to approve action: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setIsProcessingHilAction(false);
@@ -597,7 +598,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         }
       };
       
-      console.log('❌ CHAT_MODULE: Rejecting HIL action:', resumeRequest);
+      log.info('Rejecting HIL action:', resumeRequest);
       
       const result = await executionControlService.resumeExecution(resumeRequest);
       
@@ -612,7 +613,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
       
     } catch (error) {
-      console.error('Failed to reject HIL action:', error);
+      log.error('Failed to reject HIL action:', error);
       chatStore.updateStreamingStatus(`❌ Failed to reject action: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setIsProcessingHilAction(false);
@@ -633,7 +634,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     if (!currentSession) return;
     
     try {
-      console.log('🔄 CHAT_MODULE: Rolling back to checkpoint:', checkpointId);
+      log.info('Rolling back to checkpoint:', checkpointId);
       
       const result = await executionControlService.rollbackToCheckpoint(currentSession.id, checkpointId);
       
@@ -646,7 +647,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
             // 使用标准转换工具
             setHilStatus(AGUIConverter.toHILExecutionStatusData(status, currentSession.id));
           })
-          .catch(console.error);
+          .catch(err => log.error('Failed to get execution status', err));
         
         logger.info(LogCategory.CHAT_FLOW, 'HIL rollback completed', { 
           checkpointId, 
@@ -657,7 +658,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
       
     } catch (error) {
-      console.error('Failed to rollback:', error);
+      log.error('Failed to rollback:', error);
       chatStore.updateStreamingStatus(`❌ Rollback failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }, [currentSession, executionControlService]);
@@ -667,11 +668,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     
     try {
       // HIL暂停通常通过中断机制实现
-      console.log('⏸️ CHAT_MODULE: Pausing execution for thread:', currentSession.id);
+      log.info('Pausing execution for thread:', currentSession.id);
       chatStore.updateStreamingStatus('⏸️ Execution paused by user');
       
     } catch (error) {
-      console.error('Failed to pause execution:', error);
+      log.error('Failed to pause execution:', error);
     }
   }, [currentSession]);
 
@@ -688,7 +689,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         }
       };
       
-      console.log('▶️ CHAT_MODULE: Resuming execution:', resumeRequest);
+      log.info('Resuming execution:', resumeRequest);
       
       const result = await executionControlService.resumeExecution(resumeRequest);
       
@@ -699,7 +700,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
       
     } catch (error) {
-      console.error('Failed to resume execution:', error);
+      log.error('Failed to resume execution:', error);
       chatStore.updateStreamingStatus(`❌ Resume failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }, [currentSession, executionControlService]);
@@ -724,7 +725,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // 🆕 处理Widget请求事件
   const handleWidgetRequest = useCallback(async (eventData: any) => {
-    console.log('🔌 CHAT_MODULE: Received widget request event:', eventData);
+    log.info('Received widget request event:', eventData);
     
     const { widgetType, params, requestId } = eventData;
     
@@ -732,7 +733,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     chatStore.setChatLoading(true);
     
     // CRITICAL: Check user credits before processing widget request
-    console.log('💳 CHAT_MODULE: Credit check details:', {
+    log.info('Credit check details:', {
       hasCredits: userModule.hasCredits,
       credits: userModule.credits,
       totalCredits: userModule.totalCredits,
@@ -743,7 +744,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     const shouldSkipCreditCheck = process.env.NODE_ENV === 'development';
     
     if (!userModule.hasCredits && !shouldSkipCreditCheck) {
-      console.warn('💳 CHAT_MODULE: User has no credits, blocking widget request');
+      log.warn('User has no credits, blocking widget request');
       
       // 🆕 发出错误事件给Widget
       eventEmitterRef.current.emit('widget:result', {
@@ -758,7 +759,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     }
     
     if (shouldSkipCreditCheck) {
-      console.log('🔓 CHAT_MODULE: Development mode - skipping credit check');
+      log.info('Development mode - skipping credit check');
     }
     
     // 确保有valid session
@@ -769,7 +770,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       sessionActions.selectSession(newSession.id);
       activeSessionId = newSession.id;
       
-      console.log('📝 CHAT_MODULE: Auto-created session for widget request:', {
+      log.info('Auto-created session for widget request:', {
         sessionId: newSession.id,
         widgetType
       });
@@ -790,7 +791,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
     };
     
-    console.log('📨 CHAT_MODULE: Adding widget user message to chat');
+    log.info('Adding widget user message to chat');
     chatStore.addMessage(userMessage);
     
     // 通过PluginManager处理Widget请求
@@ -924,7 +925,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         chatStore.setChatLoading(false);
         
         // 🆕 将结果通过事件系统返回给Widget UI
-        console.log('🔌 CHAT_MODULE: Emitting widget:result event:', {
+        log.info('Emitting widget:result event:', {
           widgetType,
           requestId,
           result: pluginResult.output,
@@ -938,10 +939,10 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           success: true
         });
         
-        console.log('✅ CHAT_MODULE: Widget request processed successfully via Plugin system, artifact created');
+        log.info('Widget request processed successfully via Plugin system, artifact created');
         
       } else {
-        console.error('❌ CHAT_MODULE: Widget plugin execution failed:', pluginResult.error);
+        log.error('Widget plugin execution failed:', pluginResult.error);
         
         // 🆕 清除Chat loading状态
         chatStore.setChatLoading(false);
@@ -956,7 +957,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
       
     } catch (error) {
-      console.error('❌ CHAT_MODULE: Widget request processing failed:', error);
+      log.error('Widget request processing failed:', error);
       
       // 🆕 清除Chat loading状态
       chatStore.setChatLoading(false);
@@ -1000,7 +1001,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     
     // CRITICAL: Check user credits before sending message
     if (!userModule.hasCredits) {
-      console.warn('💳 CHAT_MODULE: User has no credits, blocking message send');
+      log.warn('User has no credits, blocking message send');
       setShowUpgradeModal(true);
       return;
     }
@@ -1048,7 +1049,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     
     if (pluginTrigger.triggered && pluginTrigger.pluginId) {
       // 🔌 PLUGIN ROUTE: Handle via Plugin System
-      console.log('🔌 CHAT_MODULE: Plugin detected, routing to PluginManager:', pluginTrigger);
+      log.info('Plugin detected, routing to PluginManager:', pluginTrigger);
       
       try {
         // Create processing message for plugin
@@ -1100,7 +1101,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           };
           
           chatStore.addMessage(completedMessage);
-          console.log('✅ CHAT_MODULE: Plugin execution completed successfully');
+          log.info('Plugin execution completed successfully');
           
         } else {
           // Handle plugin error
@@ -1116,11 +1117,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           };
           
           chatStore.addMessage(errorMessage);
-          console.error('❌ CHAT_MODULE: Plugin execution failed:', pluginResult.error);
+          log.error('Plugin execution failed:', pluginResult.error);
         }
         
       } catch (error) {
-        console.error('❌ CHAT_MODULE: Plugin system error:', error);
+        log.error('Plugin system error:', error);
         // Handle plugin system error - could still fall back to regular chat
       }
       
@@ -1159,10 +1160,10 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           }
         });
         
-        console.log('✅ CHAT_MODULE: Regular chat message sent successfully via direct ChatService call');
+        log.info('Regular chat message sent successfully via direct ChatService call');
         
       } catch (error) {
-        console.error('❌ CHAT_MODULE: Failed to send regular chat message:', error);
+        log.error('Failed to send regular chat message:', error);
         throw error;
       }
     }
@@ -1171,11 +1172,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // Business logic: Handle multimodal message sending
   const handleSendMultimodal = useCallback(async (content: string, files: File[], metadata?: Record<string, any>) => {
-    console.log('📨 CHAT_MODULE: sendMultimodalMessage called with:', content, files.length, 'files');
+    log.info('sendMultimodalMessage called', { content, fileCount: files.length });
     
     // CRITICAL: Check user credits before sending multimodal message
     if (!userModule.hasCredits) {
-      console.warn('💳 CHAT_MODULE: User has no credits, blocking multimodal message send');
+      log.warn('User has no credits, blocking multimodal message send');
       
       // Show elegant upgrade prompt for multimodal
       const shouldUpgrade = window.confirm(
@@ -1192,7 +1193,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           const checkoutUrl = await userModule.createCheckout('pro');
           window.open(checkoutUrl, '_blank');
         } catch (error) {
-          console.error('Failed to create checkout:', error);
+          log.error('Failed to create checkout:', error);
           // Fallback to pricing page
           window.open('/pricing', '_blank');
         }
@@ -1202,7 +1203,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       return;
     }
     
-    console.log('✅ CHAT_MODULE: Credit check passed for multimodal, proceeding with message send');
+    log.info('Credit check passed for multimodal, proceeding with message send');
     
     // Business logic: Enrich metadata with user and session info
     const enrichedMetadata = {
@@ -1224,17 +1225,17 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       processed: true // Mark as processed since we're handling it directly
     };
     
-    console.log('📨 CHAT_MODULE: Adding multimodal user message to store');
+    log.info('Adding multimodal user message to store');
     chatStore.addMessage(userMessage);
     
     // 直接调用 sendMessage API (multimodal is handled by metadata)
-    console.log('📨 CHAT_MODULE: Calling sendMessage API for multimodal content');
+    log.info('Calling sendMessage API for multimodal content');
     
     try {
       // 获取用户token用于API认证
       const token = await userModule.getAccessToken();
       const chatService = await getChatService();
-      console.log('🔑 CHAT_MODULE: Retrieved access token for multimodal API call');
+      log.info('Retrieved access token for multimodal API call');
       
       // 直接调用 ChatService multimodal 方法
       await chatService.sendMultimodalMessage(content, enrichedMetadata, token, {
@@ -1262,9 +1263,9 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
           chatStore.setExecutingPlan(false);
         }
       }, files);
-      console.log('✅ CHAT_MODULE: Multimodal message sent successfully via direct ChatService call');
+      log.info('Multimodal message sent successfully via direct ChatService call');
     } catch (error) {
-      console.error('❌ CHAT_MODULE: Failed to send multimodal message:', error);
+      log.error('Failed to send multimodal message:', error);
       throw error;
     }
   }, [auth0User, userModule, getChatService]);
@@ -1273,7 +1274,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // Handle message click for artifact navigation
   const handleMessageClick = useCallback((message: any) => {
-    console.log('💬 CHAT_MODULE: Message clicked:', message);
+    log.info('Message clicked:', message);
     
     // Check if this is an artifact message and navigate to the corresponding widget
     if (message.type === 'artifact') {
@@ -1291,7 +1292,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       
       const appId = widgetToAppMap[widgetType as keyof typeof widgetToAppMap];
       if (appId) {
-        console.log(`🔄 CHAT_MODULE: Navigating to ${appId} widget for artifact:`, artifactMessage.artifact.id);
+        log.info(`Navigating to ${appId} widget for artifact`, { artifactId: artifactMessage.artifact.id });
         
         // 🆕 Parse artifact content and set to widget store for display
         const artifactContent = artifactMessage.artifact.content;
@@ -1301,11 +1302,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
             // Parse JSON content and set to hunt store
             const searchResults = typeof artifactContent === 'string' ? JSON.parse(artifactContent) : artifactContent;
             if (Array.isArray(searchResults)) {
-              console.log(`🔍 CHAT_MODULE: Setting hunt search results:`, searchResults.length, 'items');
+              log.info('Setting hunt search results', { count: searchResults.length });
               setHuntSearchResults(searchResults);
             }
           } catch (e) {
-            console.warn('🔍 CHAT_MODULE: Could not parse hunt artifact content:', e);
+            log.warn('Could not parse hunt artifact content:', e);
           }
         }
         
@@ -1313,9 +1314,9 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         setCurrentApp(appId as AppId);
         setShowRightSidebar(true);
         
-        console.log(`✅ CHAT_MODULE: Navigation completed - App: ${appId}, Sidebar: true`);
+        log.info('Navigation completed', { app: appId, sidebar: true });
       } else {
-        console.warn('💬 CHAT_MODULE: Unknown widget type for navigation:', widgetType);
+        log.warn('Unknown widget type for navigation:', widgetType);
       }
     }
   }, [setCurrentApp, setShowRightSidebar, setTriggeredAppInput, setHuntSearchResults]);
@@ -1328,7 +1329,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       window.open(checkoutUrl, '_blank');
       setShowUpgradeModal(false);
     } catch (error) {
-      console.error('Failed to create checkout:', error);
+      log.error('Failed to create checkout:', error);
       // Fallback to pricing page
       window.open('/pricing', '_blank');
       setShowUpgradeModal(false);
@@ -1342,7 +1343,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // Handle widget selection - 打开真正的widget
   const handleWidgetSelect = useCallback((widgetId: string, mode: 'half' | 'full') => {
-    console.log('🔧 CHAT_MODULE: Widget selected:', { widgetId, mode });
+    log.info('Widget selected:', { widgetId, mode });
     
     // ✅ 设置Plugin模式标志，让Widget知道它们正在Chat环境中运行
     if (typeof window !== 'undefined') {
@@ -1380,7 +1381,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     const newMode = currentWidgetMode === 'half' ? 'full' : 'half';
     setCurrentWidgetMode(newMode);
     
-    console.log('🔄 CHAT_MODULE: Widget mode toggled:', { from: currentWidgetMode, to: newMode });
+    log.info('Widget mode toggled:', { from: currentWidgetMode, to: newMode });
   }, [currentWidgetMode]);
 
   // 🆕 监听全局 App Store 状态变化，同步到本地 widget 模式
@@ -1388,7 +1389,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     if (globalCurrentApp && globalShowRightSidebar) {
       // 从artifact打开widget时，默认使用half模式
       if (!currentWidgetMode) {
-        console.log('🔄 CHAT_MODULE: Syncing from global store - setting widget mode to half for app:', globalCurrentApp);
+        log.info('Syncing from global store - setting widget mode to half for app:', globalCurrentApp);
         setCurrentWidgetMode('half');
         
         // 设置Plugin模式标志
@@ -1398,7 +1399,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
       }
     } else if (!globalShowRightSidebar && currentWidgetMode) {
       // 当全局状态关闭右侧栏时，清理本地状态
-      console.log('🔄 CHAT_MODULE: Global sidebar closed - clearing local widget mode');
+      log.info('Global sidebar closed - clearing local widget mode');
       setCurrentWidgetMode(null);
     }
   }, [globalCurrentApp, globalShowRightSidebar, currentWidgetMode]);

--- a/src/modules/SessionModule.tsx
+++ b/src/modules/SessionModule.tsx
@@ -43,7 +43,8 @@ import {
   useKnowledgeActions 
 } from '../stores/useWidgetStores';
 import { useAuth } from '../hooks/useAuth';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+const log = createLogger('SessionModule');
 import { useSessionHandler } from '../components/core/SessionHandler';
 // 直接使用useSessionStore，不再依赖SessionProvider
 import { ChatSession } from '../hooks/useSession'; // 只导入类型
@@ -404,7 +405,7 @@ export const SessionModule: React.FC<SessionModuleProps> = (props) => {
   
   // 仅在组件挂载时初始化一次，移除可能导致循环的依赖
   useEffect(() => {
-    console.log('🗂️ SessionModule: Initializing sessions (mount only)');
+    log.info('Initializing sessions (mount only)');
     
     // 从localStorage加载会话（内部已包含去重逻辑）
     sessionStorageActions.loadFromStorage();
@@ -431,7 +432,7 @@ export const SessionModule: React.FC<SessionModuleProps> = (props) => {
   
   // 新增：当session加载完成后，自动加载当前session的消息到chat store
   useEffect(() => {
-    console.log('🔍 SessionModule: Auto-load effect triggered', {
+    log.debug('Auto-load effect triggered', {
       isLoading,
       sessionsLength: sessions.length,
       hasCurrentSession: !!currentSession,
@@ -440,7 +441,7 @@ export const SessionModule: React.FC<SessionModuleProps> = (props) => {
     
     // 当sessions加载完成且有当前session时，自动加载消息
     if (!isLoading && currentSession) {
-      console.log('📋 SessionModule: Auto-loading current session messages', {
+      log.debug('Auto-loading current session messages', {
         sessionId: currentSession.id,
         sessionMessageCount: currentSession.messages?.length || 0
       });
@@ -459,7 +460,7 @@ export const SessionModule: React.FC<SessionModuleProps> = (props) => {
   useEffect(() => {
     // 如果sessions已加载但没有currentSession，强制选择第一个
     if (!isLoading && sessions.length > 0 && !currentSession) {
-      console.log('⚠️ SessionModule: Sessions loaded but no current session, selecting first', {
+      log.warn('Sessions loaded but no current session, selecting first', {
         sessionsLength: sessions.length,
         firstSessionId: sessions[0]?.id
       });

--- a/src/modules/UserModule.tsx
+++ b/src/modules/UserModule.tsx
@@ -35,7 +35,8 @@ import React, { useEffect, useCallback, useMemo } from 'react';
 import { useAuthContext } from '../providers/AuthProvider';
 import { useUserStore } from '../stores/useUserStore';
 import { UserService } from '../api/userService';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+const log = createLogger('UserModule');
 import { PlanType, CreateExternalUserData, CreditConsumption } from '../types/userTypes';
 import { useUser } from '../hooks/useUser';
 import '../utils/creditMonitor'; // 🎯 初始化信用监控系统
@@ -202,7 +203,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
     };
 
     try {
-      console.log('👤 UserModule: 🚀 Initializing user', {
+      log.info('Initializing user', {
         auth0_id: auth0User.sub,
         email: auth0User.email,
         timestamp: new Date().toISOString()
@@ -211,7 +212,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
       logger.info(LogCategory.USER_AUTH, 'Starting user initialization', userData);
 
       // 🔄 Step 1: 确保外部用户存在
-      console.log('👤 UserModule: 📡 Calling userService.ensureUserExists...');
+      log.info('Calling userService.ensureUserExists...');
       const userResult = await userService.ensureUserExists(userData);
       
       // 📊 Step 2: 验证返回的用户数据
@@ -219,8 +220,8 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
         throw new Error('Invalid user data returned from service');
       }
 
-      console.log('👤 UserModule: ✅ User ensured successfully', { 
-        auth0_id: userResult.auth0_id, 
+      log.info('User ensured successfully', {
+        auth0_id: userResult.auth0_id,
         credits: userResult.credits,
         totalCredits: userResult.credits_total,
         plan: userResult.plan,
@@ -228,7 +229,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
       });
         
       // 💾 Step 3: 保存用户数据到store
-      console.log('👤 UserModule: 💾 Saving user data to store...');
+      log.info('Saving user data to store...');
       const userStore = useUserStore.getState();
       userStore.setExternalUser(userResult);
       
@@ -240,7 +241,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
         
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error('👤 UserModule: ❌ User initialization failed', {
+      log.error('User initialization failed', {
         error: errorMessage,
         auth0_id: auth0User.sub,
         executionTime: Date.now() - startTime + 'ms'
@@ -257,43 +258,42 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
 
   const refreshUser = useCallback(async () => {
     if (!isAuthenticated) {
-      console.log('👤 UserModule: Skipping user refresh - not authenticated');
+      log.info('Skipping user refresh - not authenticated');
       return;
     }
 
     try {
-      console.log('👤 UserModule: Starting user refresh process...');
-      console.log('👤 UserModule: Auth status:', { 
-        isAuthenticated, 
+      log.info('Starting user refresh process...');
+      log.debug('Auth status', {
+        isAuthenticated,
         hasAuth0User: !!auth0User,
-        auth0UserSub: auth0User?.sub 
+        auth0UserSub: auth0User?.sub
       });
       
       // Get access token with detailed logging
-      console.log('👤 UserModule: Getting access token...');
+      log.debug('Getting access token...');
       const token = await getAccessToken();
-      console.log('👤 UserModule: Token obtained:', {
+      log.debug('Token obtained', {
         hasToken: !!token,
-        tokenLength: token?.length,
-        tokenStart: token?.substring(0, 30) + '...'
+        tokenLength: token?.length
       });
       
       // Call fetchCurrentUser with token
-      console.log('👤 UserModule: Calling fetchCurrentUser...');
+      log.info('Calling fetchCurrentUser...');
       try {
         await userHook.fetchCurrentUser(token);
-        console.log('👤 UserModule: User data refreshed successfully');
+        log.info('User data refreshed successfully');
       } catch (error) {
         // If user doesn't exist (404), try to initialize user first
         if (error instanceof Error && error.message.includes('404')) {
-          console.log('👤 UserModule: User not found (404), attempting to initialize user...');
-          
+          log.info('User not found (404), attempting to initialize user...');
+
           if (auth0User?.sub && auth0User?.email && auth0User?.name) {
-            console.log('👤 UserModule: Initializing user via ensureUserExists...');
+            log.info('Initializing user via ensureUserExists...');
             await initializeUser();
-            console.log('👤 UserModule: User initialized, retrying fetchCurrentUser...');
+            log.info('User initialized, retrying fetchCurrentUser...');
             await userHook.fetchCurrentUser(token);
-            console.log('👤 UserModule: User data refreshed successfully after initialization');
+            log.info('User data refreshed successfully after initialization');
           } else {
             throw new Error('Cannot initialize user: missing auth user data');
           }
@@ -303,23 +303,22 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
       }
       
     } catch (error) {
-      console.error('👤 UserModule: Failed to refresh user', error);
-      
+      log.error('Failed to refresh user', error);
+
       // Enhanced error reporting
       if (error instanceof Error) {
-        console.error('👤 UserModule: Error details:', {
+        log.error('Error details', {
           message: error.message,
-          name: error.name,
-          stack: error.stack
+          name: error.name
         });
-        
+
         // Check for specific error types
         if (error.message.includes('404')) {
-          console.error('👤 UserModule: 404 Error - API endpoint not found or user not exists');
+          log.error('404 Error - API endpoint not found or user not exists');
         } else if (error.message.includes('401') || error.message.includes('403')) {
-          console.error('👤 UserModule: Auth Error - Token invalid or expired');
+          log.error('Auth Error - Token invalid or expired');
         } else if (error.message.includes('Network Error') || error.message.includes('fetch')) {
-          console.error('👤 UserModule: Network Error - Service might be down');
+          log.error('Network Error - Service might be down');
         }
       }
       
@@ -398,7 +397,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
     const currentUserId = auth0User?.sub;
     const hasRequiredData = auth0User?.sub && auth0User?.email && auth0User?.name;
     
-    console.log('👤 UserModule: Auth state changed', {
+    log.debug('Auth state changed', {
       auth0Loading,
       isAuthenticated,
       hasRequiredData,
@@ -409,13 +408,13 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
 
     // 🔄 情况1：正在加载 - 等待
     if (auth0Loading) {
-      console.log('👤 UserModule: Auth0 still loading, waiting...');
+      log.debug('Auth0 still loading, waiting...');
       return;
     }
 
     // 🚪 情况2：未认证 - 清理状态
     if (!isAuthenticated) {
-      console.log('👤 UserModule: User not authenticated, clearing state');
+      log.info('User not authenticated, clearing state');
       if (initializationStatus !== 'idle') {
         setInitializationStatus('idle');
         initializationRef.current = null;
@@ -426,7 +425,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
 
     // ✅ 情况3：已认证但缺少数据 - 等待完整数据
     if (!hasRequiredData) {
-      console.log('👤 UserModule: Authenticated but missing required user data, waiting...');
+      log.debug('Authenticated but missing required user data, waiting...');
       return;
     }
 
@@ -437,7 +436,7 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
     ) && initializationStatus !== 'initializing';
 
     if (shouldInitialize) {
-      console.log('👤 UserModule: Starting user initialization', {
+      log.info('Starting user initialization', {
         userId: currentUserId,
         previousStatus: initializationStatus
       });
@@ -447,11 +446,11 @@ export const UserModule: React.FC<{ children: React.ReactNode }> = ({ children }
       
       initializeUser()
         .then(() => {
-          console.log('👤 UserModule: User initialization completed successfully');
+          log.info('User initialization completed successfully');
           setInitializationStatus('initialized');
         })
         .catch((error) => {
-          console.error('👤 UserModule: User initialization failed', error);
+          log.error('User initialization failed', error);
           setInitializationStatus('error');
         });
     }

--- a/src/modules/widgets/BaseWidgetModule.tsx
+++ b/src/modules/widgets/BaseWidgetModule.tsx
@@ -18,7 +18,8 @@
  */
 import React, { useCallback, useEffect, useState, useRef, ReactNode } from 'react';
 import { useWidget, useWidgetActions } from '../../hooks/useWidget';
-import { logger, LogCategory } from '../../utils/logger';
+import { logger, LogCategory, createLogger } from '../../utils/logger';
+const log = createLogger('BaseWidget');
 import { WidgetType } from '../../types/widgetTypes';
 import { getChatServiceInstance } from '../../hooks/useChatService';
 import widgetHandler from '../../components/core/WidgetHandler';
@@ -132,14 +133,12 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
   useEffect(() => { isProcessingRef.current = isProcessing; }, [isProcessing]);
   useEffect(() => { currentOutputRef.current = currentOutput; }, [currentOutput]);
   
-  console.log(`🔧 ${config.type.toUpperCase()}_MODULE: Initializing with config:`, {
+  log.debug(`${config.type} initializing with config`, {
     type: config.type,
     title: config.title,
     maxHistory: config.maxHistoryItems,
     hasTriggeredInput: !!triggeredInput
   });
-  
-  console.log(`🚨DEBUG_WIDGET🚨 ${config.type.toUpperCase()}_MODULE: Mounted and running`);
   
   // Add item to output history
   const addToHistory = useCallback((item: Omit<OutputHistoryItem, 'id' | 'timestamp'>) => {
@@ -157,20 +156,19 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
     
     setCurrentOutput(historyItem);
     
-    console.log(`📋 ${config.type.toUpperCase()}_MODULE: Added to history:`, historyItem.title);
+    log.debug(`${config.type} added to history`, { title: historyItem.title });
     return historyItem;
   }, [config.type, config.maxHistoryItems]);
   
   // Update current output item
   const updateCurrentOutput = useCallback((updates: Partial<OutputHistoryItem>) => {
-    console.log(`🔍 ${config.type.toUpperCase()}_MODULE: updateCurrentOutput called:`, {
+    log.debug(`${config.type} updateCurrentOutput called`, {
       hasCurrentOutput: !!currentOutput,
-      currentOutput: currentOutput,
-      updates: updates
+      updates
     });
     
     if (!currentOutput) {
-      console.warn(`⚠️ ${config.type.toUpperCase()}_MODULE: No currentOutput to update, creating new one`);
+      log.warn(`${config.type} no currentOutput to update, creating new one`);
       // 创建新的output如果不存在
       const newOutput = {
         id: `output_${Date.now()}`,
@@ -181,14 +179,14 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         ...updates
       };
       setCurrentOutput(newOutput);
-      console.log(`📋 ${config.type.toUpperCase()}_MODULE: Created new currentOutput:`, newOutput);
+      log.debug(`${config.type} created new currentOutput`);
       return;
     }
     
     const updatedOutput = { ...currentOutput, ...updates };
     setCurrentOutput(updatedOutput);
     
-    console.log(`📋 ${config.type.toUpperCase()}_MODULE: Updated currentOutput:`, updatedOutput);
+    log.debug(`${config.type} updated currentOutput`);
     
     // Update in history as well
     setOutputHistory(prev =>
@@ -198,13 +196,13 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
   
   // Start processing with streaming support
   const startProcessing = useCallback(async (params: TParams): Promise<void> => {
-    console.log(`🚀 ${config.type.toUpperCase()}_MODULE: Starting processing with params:`, params);
+    log.info(`${config.type} starting processing`, { params });
     
     // 🆕 检查是否在Plugin模式中运行
     const isPluginMode = typeof window !== 'undefined' && (window as any).__CHAT_MODULE_PLUGIN_MODE__;
     
     if (isPluginMode) {
-      console.log(`🔌 ${config.type.toUpperCase()}_MODULE: Plugin mode detected - delegating to ChatModule via WidgetHandler event`);
+      log.info(`${config.type} plugin mode detected - delegating to ChatModule`);
       
       setIsProcessing(true);
       setIsStreaming(true);
@@ -224,7 +222,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
       
       // In Plugin mode, directly emit event to ChatModule - skip WidgetHandler to avoid double processing
       try {
-        console.log('🔌 BaseWidgetModule: Emitting widget:request directly to ChatModule');
+        log.info('Emitting widget:request directly to ChatModule');
         
         // Get ChatModule's event emitter
         const eventEmitter = (window as any).__CHAT_MODULE_EVENT_EMITTER__;
@@ -269,7 +267,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         
         // Wait for result
         const result = await resultPromise;
-        console.log('🔌 BaseWidgetModule: Received result from ChatModule:', result);
+        log.info('Received result from ChatModule');
         
         // Update UI state after receiving result
         setIsProcessing(false);
@@ -457,11 +455,11 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         // Call completion callback
         config.onProcessComplete?.(result);
         
-        console.log('🔌 BaseWidgetModule: Plugin mode processing completed, UI updated');
+        log.info('Plugin mode processing completed, UI updated');
         return;
         
       } catch (error) {
-        console.error('❌ BaseWidgetModule: Failed to communicate with ChatModule:', error);
+        log.error('Failed to communicate with ChatModule', error);
         setIsProcessing(false);
         setIsStreaming(false);
         throw error;
@@ -469,7 +467,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
     }
     
     // Independent mode - process directly  
-    console.log(`🔧 ${config.type.toUpperCase()}_MODULE: Independent mode - processing directly`);
+    log.info(`${config.type} independent mode - processing directly`);
     
     setIsProcessing(true);
     setIsStreaming(true);
@@ -489,10 +487,9 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
     
     try {
       // Use WidgetHandler to route request with streaming callbacks
-      console.log('🔥MODULE_DATA_FLOW🔥 BaseWidgetModule 转发数据到 WidgetHandler (Independent mode):', {
+      log.debug(`${config.type} forwarding data to WidgetHandler (Independent mode)`, {
         type: config.type,
-        params,
-        sessionId: `${config.sessionIdPrefix}_${Date.now()}`
+        params
       });
       logger.info(LogCategory.ARTIFACT_CREATION, `${config.type} module routing request via WidgetHandler (Independent mode)`, { params });
       
@@ -507,11 +504,11 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         userId: 'widget_user'
       });
       
-      console.log(`🔌 ${config.type.toUpperCase()}_MODULE: WidgetHandler returned:`, pluginResult);
+      log.debug(`${config.type} WidgetHandler returned`, { pluginResult });
       
       // 🆕 如果是Plugin模式，处理返回的结果
       if (pluginResult && pluginResult.content) {
-        console.log(`🔌 ${config.type.toUpperCase()}_MODULE: Received Plugin result:`, pluginResult);
+        log.debug(`${config.type} received Plugin result`);
         
         // 处理不同类型的Plugin返回格式
         let processedContent = pluginResult.content;
@@ -525,10 +522,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
             processedContent = results[0].content || results[0].description || JSON.stringify(results[0]);
             title = `Search Results (${results.length} found)`;
             
-            console.log(`🔍 ${config.type.toUpperCase()}_MODULE: Processed Hunt results:`, {
-              resultCount: results.length,
-              firstResultPreview: processedContent.substring(0, 100) + '...'
-            });
+            log.debug(`${config.type} processed Hunt results`, { resultCount: results.length });
           } else {
             processedContent = 'No search results found';
             title = 'Search completed - No results';
@@ -544,7 +538,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
           metadata: pluginResult.metadata
         };
         
-        console.log(`🔌 ${config.type.toUpperCase()}_MODULE: Updating currentOutput with:`, outputUpdate);
+        log.debug(`${config.type} updating currentOutput`, { title: outputUpdate.title });
         updateCurrentOutput(outputUpdate);
         
         // 🆕 清除所有loading状态
@@ -556,11 +550,11 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         config.onProcessComplete?.(pluginResult);
         
       } else {
-        console.log(`✅ ${config.type.toUpperCase()}_MODULE: Request successfully routed to store (Independent mode)`);
+        log.info(`${config.type} request successfully routed to store (Independent mode)`);
       }
       
     } catch (error) {
-      console.error(`❌ ${config.type.toUpperCase()}_MODULE: WidgetHandler request failed:`, error);
+      log.error(`${config.type} WidgetHandler request failed`, error);
       logger.error(LogCategory.ARTIFACT_CREATION, `${config.type} WidgetHandler request failed`, { error, params });
       
       // Update output with error
@@ -584,13 +578,13 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
   // Handle triggered input processing
   useEffect(() => {
     if (triggeredInput && !isProcessing && config.extractParamsFromInput) {
-      console.log(`🎯 ${config.type.toUpperCase()}_MODULE: Processing triggered input:`, triggeredInput);
+      log.info(`${config.type} processing triggered input`, { triggeredInput });
       
       const params = config.extractParamsFromInput(triggeredInput);
       if (params) {
         startProcessing(params);
       } else {
-        console.log(`⚠️ ${config.type.toUpperCase()}_MODULE: Could not extract params from input:`, triggeredInput);
+        log.warn(`${config.type} could not extract params from input`, { triggeredInput });
       }
     }
   }, [triggeredInput, isProcessing, config, startProcessing]);
@@ -634,9 +628,9 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
             finalResult = extractedResult.finalResult;
             outputContent = extractedResult.outputContent;
             outputTitle = extractedResult.title || outputTitle;
-            console.log(`✅ ${config.type.toUpperCase()}_MODULE: Extracted result using custom extractor:`, { 
+            log.debug(`${config.type} extracted result using custom extractor`, {
               hasResult: !!finalResult,
-              contentLength: outputContent?.length 
+              contentLength: outputContent?.length
             });
           }
         } else {
@@ -707,7 +701,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
   
   // Clear output history
   const handleClearHistory = useCallback(() => {
-    console.log(`🗑️ ${config.type.toUpperCase()}_MODULE: Clearing output history`);
+    log.info(`${config.type} clearing output history`);
     setOutputHistory([]);
     setCurrentOutput(null);
     setIsStreaming(false);
@@ -717,7 +711,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
   
   // Handle output selection
   const handleSelectOutput = useCallback((item: OutputHistoryItem) => {
-    console.log(`📋 ${config.type.toUpperCase()}_MODULE: Selected output:`, item.title);
+    log.debug(`${config.type} selected output`, { title: item.title });
     setCurrentOutput(item);
   }, [config.type]);
   
@@ -729,7 +723,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
       icon: '📋',
       onClick: (content) => {
         navigator.clipboard.writeText(typeof content === 'string' ? content : JSON.stringify(content));
-        console.log(`📋 ${config.type.toUpperCase()}_MODULE: Content copied to clipboard`);
+        log.info(`${config.type} content copied to clipboard`);
       }
     },
     {
@@ -745,7 +739,7 @@ export const BaseWidgetModule = <TParams extends BaseWidgetParams, TResult exten
         link.download = `${config.type}_output_${Date.now()}.txt`;
         link.click();
         URL.revokeObjectURL(url);
-        console.log(`💾 ${config.type.toUpperCase()}_MODULE: Content downloaded`);
+        log.info(`${config.type} content downloaded`);
       }
     }
   ];

--- a/src/modules/widgets/CustomAutomationWidgetModule.tsx
+++ b/src/modules/widgets/CustomAutomationWidgetModule.tsx
@@ -21,6 +21,8 @@ import React, { ReactNode } from 'react';
 import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { EditAction, ManagementAction, OutputHistoryItem } from '../../components/ui/widgets/BaseWidget';
 import { useCustomAutomationWidgetStore } from '../../stores/useWidgetStores';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('AutomationWidget');
 
 // Custom Automation specific types
 interface CustomAutomationWidgetParams {
@@ -112,11 +114,7 @@ const prepareAutomationTemplateParams = (params: CustomAutomationWidgetParams) =
     })
   };
   
-  console.log('🤖 AUTOMATION_MODULE: Prepared template params for', templateId, ':', {
-    template_id: mapping.template_id,
-    prompt_args,
-    inputCount: Object.keys(inputs).length
-  });
+  log.debug('Prepared template params', { templateId, template_id: mapping.template_id, prompt_args, inputCount: Object.keys(inputs).length });
   
   return {
     template_id: mapping.template_id,
@@ -216,15 +214,15 @@ export const customAutomationConfig = createWidgetConfig<CustomAutomationWidgetP
   
   // Callbacks
   onProcessStart: (params) => {
-    console.log('🤖 AUTOMATION_MODULE: Starting automation process:', params.templateId);
+    log.info('Starting automation process', { templateId: params.templateId });
   },
   
   onProcessComplete: (result) => {
-    console.log('🤖 AUTOMATION_MODULE: Automation completed:', result.status, 'Steps:', `${result.stepsCompleted}/${result.totalSteps}`);
+    log.info('Automation completed', { status: result.status, steps: `${result.stepsCompleted}/${result.totalSteps}` });
   },
   
   onProcessError: (error) => {
-    console.error('🤖 AUTOMATION_MODULE: Automation failed:', error.message);
+    log.error('Automation failed', error);
   },
   
   // Input processing
@@ -287,7 +285,7 @@ export const customAutomationConfig = createWidgetConfig<CustomAutomationWidgetP
       label: '刷新模板',
       icon: '🔄',
       onClick: () => {
-        console.log('🤖 AUTOMATION_MODULE: Refreshing automation templates...');
+        log.info('Refreshing automation templates...');
         // Logic to refresh available automation templates
       }
     },
@@ -304,7 +302,7 @@ export const customAutomationConfig = createWidgetConfig<CustomAutomationWidgetP
       label: '管理模板',
       icon: '⚙️',
       onClick: () => {
-        console.log('🤖 AUTOMATION_MODULE: Opening template management...');
+        log.info('Opening template management...');
         // Logic to open template management interface
       }
     },
@@ -313,7 +311,7 @@ export const customAutomationConfig = createWidgetConfig<CustomAutomationWidgetP
       label: '执行历史',
       icon: '📊',
       onClick: () => {
-        console.log('🤖 AUTOMATION_MODULE: Opening execution history...');
+        log.info('Opening execution history...');
         // Logic to view automation execution history
       }
     }

--- a/src/modules/widgets/DataScientistWidgetModule.tsx
+++ b/src/modules/widgets/DataScientistWidgetModule.tsx
@@ -21,6 +21,8 @@ import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { DataScientistWidgetParams, DataScientistWidgetResult } from '../../types/widgetTypes';
 import { EditAction, ManagementAction } from '../../components/ui/widgets/BaseWidget';
 import { useDataScientistState } from '../../stores/useWidgetStores';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('DataScientistWidget');
 
 interface DataScientistWidgetModuleProps {
   triggeredInput?: string;
@@ -75,10 +77,7 @@ const prepareDataScientistTemplateParams = (params: DataScientistWidgetParams) =
     depth: analysisType === 'prescriptive' || analysisType === 'predictive' ? 'deep' : 'shallow'
   };
   
-  console.log('📊 DATA_SCIENTIST_MODULE: Prepared template params for analysis type', analysisType, ':', {
-    template_id: mapping.template_id,
-    prompt_args
-  });
+  log.debug('Prepared template params', { analysisType, template_id: mapping.template_id, prompt_args });
   
   return {
     template_id: mapping.template_id,
@@ -150,7 +149,7 @@ const dataScientistWidgetConfig = createWidgetConfig({
       label: 'Export CSV',
       icon: '📋',
       onClick: (content) => {
-        console.log('📋 Exporting analysis as CSV:', content);
+        log.info('Exporting analysis as CSV');
       }
     },
     {
@@ -158,7 +157,7 @@ const dataScientistWidgetConfig = createWidgetConfig({
       label: 'Chart',
       icon: '📈',
       onClick: (content) => {
-        console.log('📈 Opening chart view:', content);
+        log.info('Opening chart view');
       }
     },
     {
@@ -166,7 +165,7 @@ const dataScientistWidgetConfig = createWidgetConfig({
       label: 'Report',
       icon: '📄', 
       onClick: (content) => {
-        console.log('📄 Downloading analysis report:', content);
+        log.info('Downloading analysis report');
       }
     }
   ],
@@ -175,7 +174,7 @@ const dataScientistWidgetConfig = createWidgetConfig({
       id: 'upload_csv',
       label: 'Upload CSV',
       icon: '📂',
-      onClick: () => console.log('📂 CSV upload dialog'),
+      onClick: () => log.info('CSV upload dialog'),
       variant: 'primary' as const,
       disabled: false
     },
@@ -183,21 +182,21 @@ const dataScientistWidgetConfig = createWidgetConfig({
       id: 'data_sources',
       label: 'Data Sources',
       icon: '🗄️',
-      onClick: () => console.log('🗄️ Data sources manager'),
+      onClick: () => log.info('Data sources manager'),
       disabled: false
     },
     {
       id: 'ml_models',
       label: 'ML Models', 
       icon: '🤖',
-      onClick: () => console.log('🤖 ML models - coming soon'),
+      onClick: () => log.info('ML models - coming soon'),
       disabled: true
     },
     {
       id: 'notebooks',
       label: 'Notebooks',
       icon: '📓',
-      onClick: () => console.log('📓 Jupyter notebooks - coming soon'),
+      onClick: () => log.info('Jupyter notebooks - coming soon'),
       disabled: true
     }
   ]
@@ -234,7 +233,7 @@ export const DataScientistWidgetModule: React.FC<DataScientistWidgetModuleProps>
     }];
   }, [analysisResult, lastParams]);
   
-  console.log('📊 DATA_SCIENTIST_MODULE: Converting analysis result to output history:', {
+  log.debug('Converting analysis result to output history', {
     hasResult: !!analysisResult,
     outputHistoryCount: outputHistory.length,
     latestResult: outputHistory[0]?.title
@@ -269,12 +268,12 @@ export const DataScientistWidgetModule: React.FC<DataScientistWidgetModuleProps>
                 templateParams // Add template configuration
               };
               
-              console.log('📊 DATA_SCIENTIST_MODULE: Sending enriched params to store:', enrichedParams);
+              log.debug('Sending enriched params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
             },
             // Add clear analysis function
             onClearAnalysis: () => {
-              console.log('📊 DATA_SCIENTIST_MODULE: Clearing analysis');
+              log.info('Clearing analysis');
               moduleProps.onClearHistory();
             },
             // BaseWidget state with converted data

--- a/src/modules/widgets/DreamWidgetModule.tsx
+++ b/src/modules/widgets/DreamWidgetModule.tsx
@@ -21,6 +21,8 @@ import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { DreamWidgetParams, DreamWidgetResult } from '../../types/widgetTypes';
 import { EditAction, ManagementAction } from '../../components/ui/widgets/BaseWidget';
 import { useDreamGeneratedImage, useDreamIsGenerating, useDreamLastParams } from '../../stores/useWidgetStores';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('DreamWidget');
 
 // Dream mode to MCP template mapping (based on the 9 MCP prompts)
 const DREAM_TEMPLATE_MAPPING = {
@@ -154,10 +156,7 @@ const prepareDreamTemplateParams = (params: DreamWidgetParams) => {
       };
   }
   
-  console.log('🎨 DREAM_MODULE: Prepared template params for mode', mode, ':', {
-    template_id: mapping.template_id,
-    prompt_args
-  });
+  log.debug('Prepared template params', { mode, template_id: mapping.template_id, prompt_args });
   
   return {
     template_id: mapping.template_id,
@@ -186,7 +185,7 @@ const dreamEditActions: EditAction[] = [
         link.target = '_blank';
         link.click();
       }
-      console.log('🎨 DREAM: Image download initiated');
+      log.info('Image download initiated');
     }
   },
   {
@@ -198,7 +197,7 @@ const dreamEditActions: EditAction[] = [
       const imageUrl = typeof content === 'string' ? content : content?.imageUrl;
       if (imageUrl) {
         window.open(imageUrl, '_blank');
-        console.log('🎨 DREAM: Image opened in new tab');
+        log.info('Image opened in new tab');
       }
     }
   },
@@ -211,7 +210,7 @@ const dreamEditActions: EditAction[] = [
       const imageUrl = typeof content === 'string' ? content : content?.imageUrl;
       if (imageUrl) {
         navigator.clipboard.writeText(imageUrl);
-        console.log('🎨 DREAM: Image URL copied to clipboard');
+        log.info('Image URL copied to clipboard');
       }
     }
   }
@@ -224,7 +223,7 @@ const dreamManagementActions: ManagementAction[] = [
     label: 'Create',
     icon: '🎨',
     onClick: () => {
-      console.log('🎨 DREAM: Creating new image variation');
+      log.info('Creating new image variation');
       // Could trigger a variation of the last generated image
     }
   },
@@ -233,7 +232,7 @@ const dreamManagementActions: ManagementAction[] = [
     label: 'Transform',
     icon: '✨',
     onClick: () => {
-      console.log('🎨 DREAM: Transforming image style');
+      log.info('Transforming image style');
       // Could apply style transformations
     }
   },
@@ -242,7 +241,7 @@ const dreamManagementActions: ManagementAction[] = [
     label: 'Enhance',
     icon: '⚡',
     onClick: () => {
-      console.log('🎨 DREAM: Enhancing image quality');
+      log.info('Enhancing image quality');
       // Could trigger image enhancement
     }
   }
@@ -289,18 +288,18 @@ const dreamConfig = createWidgetConfig<DreamWidgetParams, DreamWidgetResult>({
   
   // Lifecycle callbacks
   onProcessStart: (params: DreamWidgetParams) => {
-    console.log('🎨 DREAM_MODULE: Starting image generation:', params.prompt);
+    log.info('Starting image generation', { prompt: params.prompt });
   },
   
   onProcessComplete: (result: DreamWidgetResult) => {
-    console.log('🎨 DREAM_MODULE: Image generation completed:', {
+    log.info('Image generation completed', {
       hasImageUrl: !!result.data?.imageUrl,
       prompt: result.data?.prompt?.substring(0, 50)
     });
   },
   
   onProcessError: (error: Error) => {
-    console.error('🎨 DREAM_MODULE: Image generation failed:', error.message);
+    log.error('Image generation failed', error);
   },
   
   // Custom actions
@@ -344,10 +343,9 @@ export const DreamWidgetModule: React.FC<DreamWidgetModuleProps> = ({
   const generatedImage = useDreamGeneratedImage();
   const lastParams = useDreamLastParams();
   
-  console.log('🎨 DREAM_MODULE: Initializing with BaseWidgetModule architecture', {
+  log.debug('Initializing with BaseWidgetModule architecture', {
     hasTriggeredInput: !!triggeredInput,
-    hasGeneratedImage: !!generatedImage,
-    generatedImageUrl: generatedImage?.substring(0, 80)
+    hasGeneratedImage: !!generatedImage
   });
 
   // Convert generatedImage to outputHistory format for BaseWidget display (like HuntWidgetModule)
@@ -370,10 +368,9 @@ export const DreamWidgetModule: React.FC<DreamWidgetModuleProps> = ({
     }];
   }, [generatedImage, lastParams]);
   
-  console.log('🎨 DREAM_MODULE: Converting image to output history:', {
+  log.debug('Converting image to output history', {
     hasGeneratedImage: !!generatedImage,
-    outputHistoryCount: outputHistory.length,
-    generatedImageUrl: generatedImage?.substring(0, 80)
+    outputHistoryCount: outputHistory.length
   });
 
   return (
@@ -383,11 +380,11 @@ export const DreamWidgetModule: React.FC<DreamWidgetModuleProps> = ({
     >
       {(moduleProps) => {
         // Transform BaseWidgetModule props to match original DreamWidgetModule interface
-        console.log('🎨 DREAM_MODULE: Module props:', {
+        log.debug('Module props', {
           isProcessing: moduleProps.isProcessing,
-          currentOutput: moduleProps.currentOutput,
+          hasCurrentOutput: !!moduleProps.currentOutput,
           hasOutputContent: !!moduleProps.currentOutput?.content,
-          storeGeneratedImage: generatedImage?.substring(0, 80)
+          hasStoreGeneratedImage: !!generatedImage
         });
         
         const legacyProps = {
@@ -404,7 +401,7 @@ export const DreamWidgetModule: React.FC<DreamWidgetModuleProps> = ({
               templateParams // Add template configuration
             };
             
-            console.log('🔥MODULE_DATA_FLOW🔥 DreamWidgetModule 发送数据到 BaseWidgetModule:', enrichedParams);
+            log.debug('Sending data to BaseWidgetModule', enrichedParams);
             await moduleProps.startProcessing(enrichedParams);
           },
           onClearImage: () => {

--- a/src/modules/widgets/HuntWidgetModule.tsx
+++ b/src/modules/widgets/HuntWidgetModule.tsx
@@ -21,6 +21,8 @@ import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { HuntWidgetParams, HuntWidgetResult } from '../../types/widgetTypes';
 import { EditAction, ManagementAction } from '../../components/ui/widgets/BaseWidget';
 import { useHuntState } from '../../stores/useWidgetStores';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('HuntWidget');
 
 interface HuntWidgetModuleProps {
   triggeredInput?: string;
@@ -75,10 +77,7 @@ const prepareHuntTemplateParams = (params: HuntWidgetParams) => {
     })
   };
   
-  console.log('🔍 HUNT_MODULE: Prepared template params for mode', category, ':', {
-    template_id: mapping.template_id,
-    prompt_args
-  });
+  log.debug('Prepared template params', { category, template_id: mapping.template_id, prompt_args });
   
   return {
     template_id: mapping.template_id,
@@ -144,7 +143,7 @@ const huntWidgetConfig = createWidgetConfig({
       label: 'Save',
       icon: '🔖', 
       onClick: (content) => {
-        console.log('🔖 Bookmarking search result:', content);
+        log.info('Bookmarking search result');
       }
     }
   ],
@@ -153,7 +152,7 @@ const huntWidgetConfig = createWidgetConfig({
       id: 'search',
       label: 'Search',
       icon: '🔍',
-      onClick: () => console.log('🔍 Search mode active'),
+      onClick: () => log.info('Search mode active'),
       variant: 'primary' as const,
       disabled: false
     },
@@ -161,21 +160,21 @@ const huntWidgetConfig = createWidgetConfig({
       id: 'crawler',
       label: 'Crawler',
       icon: '🕷️',
-      onClick: () => console.log('🕷️ Crawler mode - coming soon'),
+      onClick: () => log.info('Crawler mode - coming soon'),
       disabled: true
     },
     {
       id: 'automation',
       label: 'Automation', 
       icon: '🤖',
-      onClick: () => console.log('🤖 Automation mode - coming soon'),
+      onClick: () => log.info('Automation mode - coming soon'),
       disabled: true
     },
     {
       id: 'other',
       label: 'Other',
       icon: '⚙️',
-      onClick: () => console.log('⚙️ Other tools - coming soon'),
+      onClick: () => log.info('Other tools - coming soon'),
       disabled: true
     }
   ]
@@ -213,9 +212,7 @@ export const HuntWidgetModule: React.FC<HuntWidgetModuleProps> = ({
     }));
   }, [searchResults, lastQuery]);
   
-  console.log('🔍 HUNT_MODULE: Converting search results to output history:', {
-    searchResultsType: typeof searchResults,
-    searchResultsIsArray: Array.isArray(searchResults),
+  log.debug('Converting search results to output history', {
     searchResultsCount: Array.isArray(searchResults) ? searchResults.length : 0,
     outputHistoryCount: outputHistory.length,
     latestResult: outputHistory[0]?.title
@@ -251,7 +248,7 @@ export const HuntWidgetModule: React.FC<HuntWidgetModuleProps> = ({
                 templateParams // Add template configuration
               };
               
-              console.log('🔍 HUNT_MODULE: Sending enriched params to store:', enrichedParams);
+              log.debug('Sending enriched params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
             },
             // BaseWidget state with converted data

--- a/src/modules/widgets/KnowledgeWidgetModule.tsx
+++ b/src/modules/widgets/KnowledgeWidgetModule.tsx
@@ -20,6 +20,8 @@ import React, { ReactNode } from 'react';
 import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { EditAction, ManagementAction } from '../../components/ui/widgets/BaseWidget';
 import { useAppStore } from '../../stores/useAppStore';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('KnowledgeWidget');
 
 interface KnowledgeDocument {
   id: string;
@@ -138,7 +140,8 @@ const prepareKnowledgeTemplateParams = (params: KnowledgeWidgetParams) => {
       };
   }
   
-  console.log('🧠 KNOWLEDGE_MODULE: Prepared template params for search type', searchType, ':', {
+  log.debug('Prepared template params for search type', {
+    searchType,
     template_id: mapping.template_id,
     prompt_args
   });
@@ -209,7 +212,7 @@ const knowledgeWidgetConfig = createWidgetConfig({
       label: 'Cite',
       icon: '📚',
       onClick: (content) => {
-        console.log('📚 Generating citations for:', content);
+        log.info('Generating citations for content');
       }
     },
     {
@@ -217,7 +220,7 @@ const knowledgeWidgetConfig = createWidgetConfig({
       label: 'Export',
       icon: '📤',
       onClick: (content) => {
-        console.log('📤 Exporting knowledge:', content);
+        log.info('Exporting knowledge');
       }
     },
     {
@@ -225,7 +228,7 @@ const knowledgeWidgetConfig = createWidgetConfig({
       label: 'Related',
       icon: '🔗', 
       onClick: (content) => {
-        console.log('🔗 Finding related topics for:', content);
+        log.info('Finding related topics');
       }
     }
   ],
@@ -234,7 +237,7 @@ const knowledgeWidgetConfig = createWidgetConfig({
       id: 'upload_docs',
       label: 'Upload Docs',
       icon: '📁',
-      onClick: () => console.log('📁 Document upload dialog'),
+      onClick: () => log.info('Document upload dialog'),
       variant: 'primary' as const,
       disabled: false
     },
@@ -242,21 +245,21 @@ const knowledgeWidgetConfig = createWidgetConfig({
       id: 'knowledge_base',
       label: 'Knowledge Base',
       icon: '🗂️',
-      onClick: () => console.log('🗂️ Knowledge base manager'),
+      onClick: () => log.info('Knowledge base manager'),
       disabled: false
     },
     {
       id: 'embeddings',
       label: 'Embeddings', 
       icon: '🔍',
-      onClick: () => console.log('🔍 Embedding management - coming soon'),
+      onClick: () => log.info('Embedding management - coming soon'),
       disabled: true
     },
     {
       id: 'graph_view',
       label: 'Graph View',
       icon: '🕸️',
-      onClick: () => console.log('🕸️ Knowledge graph view - coming soon'),
+      onClick: () => log.info('Knowledge graph view - coming soon'),
       disabled: true
     }
   ]
@@ -295,7 +298,7 @@ export const KnowledgeWidgetModule: React.FC<KnowledgeWidgetModuleProps> = ({
     }];
   }, [searchResult]);
   
-  console.log('🧠 KNOWLEDGE_MODULE: Converting search result to output history:', {
+  log.debug('Converting search result to output history', {
     hasResult: !!searchResult,
     outputHistoryCount: outputHistory.length,
     latestResult: outputHistory[0]?.title
@@ -318,7 +321,7 @@ export const KnowledgeWidgetModule: React.FC<KnowledgeWidgetModuleProps> = ({
             knowledgeBase,
             // Add knowledge actions with template parameter preparation
             onUploadDocuments: async (files: File[]) => {
-              console.log('🧠 KNOWLEDGE_MODULE: Uploading documents:', files.length);
+              log.info('Uploading documents', { count: files.length });
               
               // Prepare template parameters for document upload
               const templateParams = prepareKnowledgeTemplateParams({
@@ -336,7 +339,7 @@ export const KnowledgeWidgetModule: React.FC<KnowledgeWidgetModuleProps> = ({
                 templateParams
               };
               
-              console.log('🧠 KNOWLEDGE_MODULE: Sending enriched upload params to store:', enrichedParams);
+              log.debug('Sending enriched upload params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
             },
             onProcess: async (params: KnowledgeWidgetParams) => {
@@ -356,7 +359,7 @@ export const KnowledgeWidgetModule: React.FC<KnowledgeWidgetModuleProps> = ({
                 templateParams // Add template configuration
               };
               
-              console.log('🧠 KNOWLEDGE_MODULE: Sending enriched search params to store:', enrichedParams);
+              log.debug('Sending enriched search params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
               
               // 模拟成功生成的结果（在真实应用中，这应该在API回调中处理）
@@ -383,15 +386,15 @@ export const KnowledgeWidgetModule: React.FC<KnowledgeWidgetModuleProps> = ({
                 templateParams // Add template configuration
               };
               
-              console.log('🧠 KNOWLEDGE_MODULE: Sending enriched search params to store:', enrichedParams);
+              log.debug('Sending enriched search params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
             },
             onRemoveDocument: (docId: string) => {
-              console.log('🧠 KNOWLEDGE_MODULE: Removing document:', docId);
+              log.info('Removing document', { docId });
               setKnowledgeBase(prev => prev.filter(doc => doc.id !== docId));
             },
             onClearResults: () => {
-              console.log('🧠 KNOWLEDGE_MODULE: Clearing results');
+              log.info('Clearing results');
               setSearchResult(null);
               moduleProps.onClearHistory();
             },

--- a/src/modules/widgets/OmniWidgetModule.tsx
+++ b/src/modules/widgets/OmniWidgetModule.tsx
@@ -21,6 +21,8 @@ import { BaseWidgetModule, createWidgetConfig } from './BaseWidgetModule';
 import { OmniWidgetParams, OmniWidgetResult } from '../../types/widgetTypes';
 import { EditAction, ManagementAction } from '../../components/ui/widgets/BaseWidget';
 import { useOmniState } from '../../stores/useWidgetStores';
+import { createLogger } from '../../utils/logger';
+const log = createLogger('OmniWidget');
 
 interface OmniWidgetModuleProps {
   triggeredInput?: string;
@@ -141,11 +143,7 @@ const prepareOmniTemplateParams = (params: OmniWidgetParams & {
     reference_text: referenceText || `Create ${contentType} content with ${tone} tone. Focus on ${topicForMapping} domain expertise.`
   };
   
-  console.log('⚡ OMNI_MODULE: Prepared template params for topic', topicForMapping, ':', {
-    template_id: final_template_id,
-    prompt_args,
-    originalContentType: contentType
-  });
+  log.debug('Prepared template params', { topic: topicForMapping, template_id: final_template_id, prompt_args, originalContentType: contentType });
   
   return {
     template_id: final_template_id,
@@ -240,7 +238,7 @@ const omniWidgetConfig = createWidgetConfig({
       icon: '📋',
       onClick: (content) => {
         navigator.clipboard.writeText(content);
-        console.log('📋 Content copied to clipboard');
+        log.info('Content copied to clipboard');
       }
     },
     {
@@ -248,7 +246,7 @@ const omniWidgetConfig = createWidgetConfig({
       label: 'Export MD',
       icon: '📝',
       onClick: (content) => {
-        console.log('📝 Exporting as Markdown:', content);
+        log.info('Exporting as Markdown');
       }
     },
     {
@@ -256,7 +254,7 @@ const omniWidgetConfig = createWidgetConfig({
       label: 'Refine',
       icon: '✨', 
       onClick: (content) => {
-        console.log('✨ Refining content:', content);
+        log.info('Refining content');
       }
     }
   ],
@@ -265,7 +263,7 @@ const omniWidgetConfig = createWidgetConfig({
       id: 'content_types',
       label: 'Content Types',
       icon: '📑',
-      onClick: () => console.log('📑 Content type selector'),
+      onClick: () => log.info('Content type selector'),
       variant: 'primary' as const,
       disabled: false
     },
@@ -273,21 +271,21 @@ const omniWidgetConfig = createWidgetConfig({
       id: 'templates',
       label: 'Templates',
       icon: '📋',
-      onClick: () => console.log('📋 Content templates library'),
+      onClick: () => log.info('Content templates library'),
       disabled: false
     },
     {
       id: 'tone_style',
       label: 'Tone & Style', 
       icon: '🎨',
-      onClick: () => console.log('🎨 Tone and style settings'),
+      onClick: () => log.info('Tone and style settings'),
       disabled: false
     },
     {
       id: 'ai_models',
       label: 'AI Models',
       icon: '🧠',
-      onClick: () => console.log('🧠 AI model selection - coming soon'),
+      onClick: () => log.info('AI model selection - coming soon'),
       disabled: true
     }
   ]
@@ -325,7 +323,7 @@ export const OmniWidgetModule: React.FC<OmniWidgetModuleProps> = ({
     }];
   }, [generatedContent, lastParams]);
   
-  console.log('⚡ OMNI_MODULE: Converting generated content to output history:', {
+  log.debug('Converting generated content to output history', {
     hasContent: !!generatedContent,
     outputHistoryCount: outputHistory.length,
     latestResult: outputHistory[0]?.title
@@ -361,12 +359,12 @@ export const OmniWidgetModule: React.FC<OmniWidgetModuleProps> = ({
                 templateParams // Add template configuration
               };
               
-              console.log('⚡ OMNI_MODULE: Sending enriched params to store:', enrichedParams);
+              log.debug('Sending enriched params to store', enrichedParams);
               await moduleProps.startProcessing(enrichedParams);
             },
             // Add clear content function
             onClearContent: () => {
-              console.log('⚡ OMNI_MODULE: Clearing content');
+              log.info('Clearing content');
               moduleProps.onClearHistory();
             },
             // BaseWidget state with converted data  

--- a/src/plugins/DataScientistWidgetPlugin.ts
+++ b/src/plugins/DataScientistWidgetPlugin.ts
@@ -16,7 +16,9 @@
 
 import { WidgetPlugin, PluginInput, PluginOutput } from '../types/pluginTypes';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('DataScientistWidgetPlugin', LogCategory.ARTIFACT_CREATION);
 
 /**
  * DataScientist Widget 插件实现
@@ -180,13 +182,13 @@ export class DataScientistWidgetPlugin implements WidgetPlugin {
 
         const callbacks = {
           onStreamContent: (contentChunk: string) => {
-            console.log(`📊 DATASCIENTIST_PLUGIN: onStreamContent chunk:`, contentChunk?.substring(0, 50) + '...');
+            log.debug('onStreamContent chunk', { preview: contentChunk?.substring(0, 50) });
             accumulatedContent += contentChunk;
           },
           
           onStreamComplete: (finalContent?: string) => {
             messageCount++;
-            console.log(`📊 DATASCIENTIST_PLUGIN: onStreamComplete - Final message (${messageCount} total):`, finalContent?.substring(0, 100) + '...');
+            log.debug(`onStreamComplete - Final message (${messageCount} total)`, { preview: finalContent?.substring(0, 100) });
             
             // Only process on [DONE] or when we have substantial accumulated content
             if (finalContent === '[DONE]' || accumulatedContent.length > 100) {
@@ -194,7 +196,7 @@ export class DataScientistWidgetPlugin implements WidgetPlugin {
               
               // Use accumulated streaming content as the real result
               const completeMessage = accumulatedContent.trim();
-              console.log(`📊 DATASCIENTIST_PLUGIN: Processing final result with accumulated content (${completeMessage.length} chars):`, completeMessage.substring(0, 100) + '...');
+              log.debug(`Processing final result with accumulated content (${completeMessage.length} chars)`, { preview: completeMessage.substring(0, 100) });
             
               if (completeMessage) {
                 try {
@@ -224,16 +226,16 @@ export class DataScientistWidgetPlugin implements WidgetPlugin {
               }
             } else {
               // Skip this onStreamComplete call - waiting for the final one
-              console.log(`📊 DATASCIENTIST_PLUGIN: Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content...`);
+              log.debug(`Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content`);
             }
           },
           
           onStreamStart: (messageId: string, status?: string) => {
-            console.log(`📊 DATASCIENTIST_PLUGIN: onStreamStart:`, { messageId, status });
+            log.debug('onStreamStart', { messageId, status });
           },
           
           onStreamStatus: (status: string) => {
-            console.log(`📊 DATASCIENTIST_PLUGIN: onStreamStatus:`, status);
+            log.debug('onStreamStatus', { status });
           },
           
           onArtifactCreated: (artifact: any) => {

--- a/src/plugins/DreamWidgetPlugin.ts
+++ b/src/plugins/DreamWidgetPlugin.ts
@@ -16,7 +16,9 @@
 
 import { WidgetPlugin, PluginInput, PluginOutput } from '../types/pluginTypes';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('DreamWidgetPlugin', LogCategory.ARTIFACT_CREATION);
 
 /**
  * Dream Widget 插件实现
@@ -201,13 +203,13 @@ export class DreamWidgetPlugin implements WidgetPlugin {
 
         const callbacks = {
           onStreamContent: (contentChunk: string) => {
-            console.log(`🎨 DREAM_PLUGIN: onStreamContent chunk:`, contentChunk?.substring(0, 50) + '...');
+            log.debug('onStreamContent chunk', { preview: contentChunk?.substring(0, 50) });
             accumulatedContent += contentChunk;
           },
           
           onStreamComplete: (finalContent?: string) => {
             messageCount++;
-            console.log(`🎨 DREAM_PLUGIN: onStreamComplete - Final message (${messageCount} total):`, finalContent?.substring(0, 100) + '...');
+            log.debug(`onStreamComplete - Final message (${messageCount} total)`, { preview: finalContent?.substring(0, 100) });
             
             // Only process on [DONE] or when we have substantial accumulated content
             if (finalContent === '[DONE]' || accumulatedContent.length > 50) {
@@ -215,7 +217,7 @@ export class DreamWidgetPlugin implements WidgetPlugin {
               
               // Use accumulated streaming content as the real result
               const completeMessage = accumulatedContent.trim();
-              console.log(`🎨 DREAM_PLUGIN: Processing final result with accumulated content (${completeMessage.length} chars):`, completeMessage.substring(0, 100) + '...');
+              log.debug(`Processing final result with accumulated content (${completeMessage.length} chars)`, { preview: completeMessage.substring(0, 100) });
             
               if (completeMessage) {
                 // Extract image URL from the message
@@ -237,16 +239,16 @@ export class DreamWidgetPlugin implements WidgetPlugin {
               }
             } else {
               // Skip this onStreamComplete call - waiting for the final one
-              console.log(`🎨 DREAM_PLUGIN: Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content...`);
+              log.debug(`Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content`);
             }
           },
           
           onStreamStart: (messageId: string, status?: string) => {
-            console.log(`🎨 DREAM_PLUGIN: onStreamStart:`, { messageId, status });
+            log.debug('onStreamStart', { messageId, status });
           },
           
           onStreamStatus: (status: string) => {
-            console.log(`🎨 DREAM_PLUGIN: onStreamStatus:`, status);
+            log.debug('onStreamStatus', { status });
           },
           
           onArtifactCreated: (artifact: any) => {

--- a/src/plugins/HuntWidgetPlugin.ts
+++ b/src/plugins/HuntWidgetPlugin.ts
@@ -16,7 +16,9 @@
 
 import { WidgetPlugin, PluginInput, PluginOutput } from '../types/pluginTypes';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('HuntWidgetPlugin', LogCategory.ARTIFACT_CREATION);
 
 /**
  * Hunt Widget 插件实现
@@ -194,13 +196,13 @@ export class HuntWidgetPlugin implements WidgetPlugin {
         
         const callbacks = {
           onStreamContent: (contentChunk: string) => {
-            console.log(`🔍 HUNT_PLUGIN: onStreamContent chunk:`, contentChunk?.substring(0, 50) + '...');
+            log.debug('onStreamContent chunk', { preview: contentChunk?.substring(0, 50) });
             accumulatedContent += contentChunk;
           },
           
           onStreamComplete: (finalContent?: string) => {
             messageCount++;
-            console.log(`🔍 HUNT_PLUGIN: onStreamComplete - Final message (${messageCount} total):`, finalContent?.substring(0, 100) + '...');
+            log.debug(`onStreamComplete - Final message (${messageCount} total)`, { preview: finalContent?.substring(0, 100) });
             
             // Only process on [DONE] or when we have substantial accumulated content
             // Skip system messages like "Chat processing completed"
@@ -209,7 +211,7 @@ export class HuntWidgetPlugin implements WidgetPlugin {
               
               // Use accumulated streaming content as the real search result
               const completeMessage = accumulatedContent.trim();
-              console.log(`🔍 HUNT_PLUGIN: Processing final result with accumulated content (${completeMessage.length} chars):`, completeMessage.substring(0, 100) + '...');
+              log.debug(`Processing final result with accumulated content (${completeMessage.length} chars)`, { preview: completeMessage.substring(0, 100) });
             
               if (completeMessage) {
               try {
@@ -256,16 +258,16 @@ export class HuntWidgetPlugin implements WidgetPlugin {
               }
             } else {
               // Skip this onStreamComplete call - waiting for the final one
-              console.log(`🔍 HUNT_PLUGIN: Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content...`);
+              log.debug(`Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content`);
             }
           },
           
           onStreamStart: (messageId: string, status?: string) => {
-            console.log(`🔍 HUNT_PLUGIN: onStreamStart:`, { messageId, status });
+            log.debug('onStreamStart', { messageId, status });
           },
           
           onStreamStatus: (status: string) => {
-            console.log(`🔍 HUNT_PLUGIN: onStreamStatus:`, status);
+            log.debug('onStreamStatus', { status });
           },
           
           onArtifactCreated: (artifact: any) => {

--- a/src/plugins/KnowledgeWidgetPlugin.ts
+++ b/src/plugins/KnowledgeWidgetPlugin.ts
@@ -16,7 +16,9 @@
 
 import { WidgetPlugin, PluginInput, PluginOutput } from '../types/pluginTypes';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('KnowledgeWidgetPlugin', LogCategory.ARTIFACT_CREATION);
 
 /**
  * Knowledge Widget 插件实现
@@ -180,13 +182,13 @@ export class KnowledgeWidgetPlugin implements WidgetPlugin {
 
         const callbacks = {
           onStreamContent: (contentChunk: string) => {
-            console.log(`🧠 KNOWLEDGE_PLUGIN: onStreamContent chunk:`, contentChunk?.substring(0, 50) + '...');
+            log.debug('onStreamContent chunk', { preview: contentChunk?.substring(0, 50) });
             accumulatedContent += contentChunk;
           },
           
           onStreamComplete: (finalContent?: string) => {
             messageCount++;
-            console.log(`🧠 KNOWLEDGE_PLUGIN: onStreamComplete - Final message (${messageCount} total):`, finalContent?.substring(0, 100) + '...');
+            log.debug(`onStreamComplete - Final message (${messageCount} total)`, { preview: finalContent?.substring(0, 100) });
             
             // Only process on [DONE] or when we have substantial accumulated content
             if (finalContent === '[DONE]' || accumulatedContent.length > 100) {
@@ -194,7 +196,7 @@ export class KnowledgeWidgetPlugin implements WidgetPlugin {
               
               // Use accumulated streaming content as the real result
               const completeMessage = accumulatedContent.trim();
-              console.log(`🧠 KNOWLEDGE_PLUGIN: Processing final result with accumulated content (${completeMessage.length} chars):`, completeMessage.substring(0, 100) + '...');
+              log.debug(`Processing final result with accumulated content (${completeMessage.length} chars)`, { preview: completeMessage.substring(0, 100) });
             
               if (completeMessage) {
                 knowledgeResult = completeMessage;
@@ -205,16 +207,16 @@ export class KnowledgeWidgetPlugin implements WidgetPlugin {
               }
             } else {
               // Skip this onStreamComplete call - waiting for the final one
-              console.log(`🧠 KNOWLEDGE_PLUGIN: Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content...`);
+              log.debug(`Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content`);
             }
           },
           
           onStreamStart: (messageId: string, status?: string) => {
-            console.log(`🧠 KNOWLEDGE_PLUGIN: onStreamStart:`, { messageId, status });
+            log.debug('onStreamStart', { messageId, status });
           },
           
           onStreamStatus: (status: string) => {
-            console.log(`🧠 KNOWLEDGE_PLUGIN: onStreamStatus:`, status);
+            log.debug('onStreamStatus', { status });
           },
           
           onArtifactCreated: (artifact: any) => {

--- a/src/plugins/OmniWidgetPlugin.ts
+++ b/src/plugins/OmniWidgetPlugin.ts
@@ -16,7 +16,9 @@
 
 import { WidgetPlugin, PluginInput, PluginOutput } from '../types/pluginTypes';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('OmniWidgetPlugin', LogCategory.ARTIFACT_CREATION);
 
 /**
  * Omni Widget 插件实现
@@ -183,13 +185,13 @@ export class OmniWidgetPlugin implements WidgetPlugin {
 
         const callbacks = {
           onStreamContent: (contentChunk: string) => {
-            console.log(`⚡ OMNI_PLUGIN: onStreamContent chunk:`, contentChunk?.substring(0, 50) + '...');
+            log.debug('onStreamContent chunk', { preview: contentChunk?.substring(0, 50) });
             accumulatedContent += contentChunk;
           },
           
           onStreamComplete: (finalContent?: string) => {
             messageCount++;
-            console.log(`⚡ OMNI_PLUGIN: onStreamComplete - Final message (${messageCount} total):`, finalContent?.substring(0, 100) + '...');
+            log.debug(`onStreamComplete - Final message (${messageCount} total)`, { preview: finalContent?.substring(0, 100) });
             
             // Only process on [DONE] or when we have substantial accumulated content
             if (finalContent === '[DONE]' || accumulatedContent.length > 100) {
@@ -197,7 +199,7 @@ export class OmniWidgetPlugin implements WidgetPlugin {
               
               // Use accumulated streaming content as the real result
               const completeMessage = accumulatedContent.trim();
-              console.log(`⚡ OMNI_PLUGIN: Processing final result with accumulated content (${completeMessage.length} chars):`, completeMessage.substring(0, 100) + '...');
+              log.debug(`Processing final result with accumulated content (${completeMessage.length} chars)`, { preview: completeMessage.substring(0, 100) });
             
               if (completeMessage) {
                 resolve(completeMessage);
@@ -207,16 +209,16 @@ export class OmniWidgetPlugin implements WidgetPlugin {
               }
             } else {
               // Skip this onStreamComplete call - waiting for the final one
-              console.log(`⚡ OMNI_PLUGIN: Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content...`);
+              log.debug(`Skipping intermediate completion (${finalContent}), waiting for [DONE] or substantial content`);
             }
           },
           
           onStreamStart: (messageId: string, status?: string) => {
-            console.log(`⚡ OMNI_PLUGIN: onStreamStart:`, { messageId, status });
+            log.debug('onStreamStart', { messageId, status });
           },
           
           onStreamStatus: (status: string) => {
-            console.log(`⚡ OMNI_PLUGIN: onStreamStatus:`, status);
+            log.debug('onStreamStatus', { status });
           },
           
           onArtifactCreated: (artifact: any) => {

--- a/src/providers/AIProvider.tsx
+++ b/src/providers/AIProvider.tsx
@@ -28,7 +28,10 @@
  * - Use useConnectionStatus() to get connection state
  */
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createLogger } from '../utils/logger';
 import { ChatService } from '../api/chatService';
+
+const log = createLogger('AIProvider');
 import { setChatServiceInstance } from '../hooks/useChatService';
 
 interface AIContextType {
@@ -75,7 +78,7 @@ export const useAIError = () => {
 
 // Keep backward compatibility for existing code
 export const useAI = () => {
-  console.warn('useAI is deprecated, use useChatService instead');
+  log.warn('useAI is deprecated, use useChatService instead');
   return useChatService();
 };
 
@@ -98,7 +101,7 @@ export const AIProvider: React.FC<AIProviderProps> = ({ children }) => {
       setError(null);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown initialization error';
-      console.error('AIProvider: ChatService initialization failed', { error: errorMessage });
+      log.error('ChatService initialization failed', { error: errorMessage });
       setError(errorMessage);
       setIsConnected(false);
       setChatServiceInstance(null);

--- a/src/providers/AnalyticsProvider.tsx
+++ b/src/providers/AnalyticsProvider.tsx
@@ -1,5 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createLogger } from '@/utils/logger';
 import analytics, { AnalyticsService } from '@/services/analytics';
+
+const log = createLogger('AnalyticsProvider');
 
 interface AnalyticsContextType {
   analytics: AnalyticsService;
@@ -26,7 +29,7 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
       const isAnalyticsEnabled = process.env.REACT_APP_ENABLE_ANALYTICS !== 'false';
       
       if (!isAnalyticsEnabled) {
-        console.log('Analytics disabled by feature flag');
+        log.info('Analytics disabled by feature flag');
         return;
       }
 
@@ -34,7 +37,7 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
         await analytics.initialize();
         setIsReady(true);
       } catch (error) {
-        console.error('Failed to initialize analytics:', error);
+        log.error('Failed to initialize analytics:', error);
       }
     };
 

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,5 +1,7 @@
 
 import { RudderAnalytics } from '@rudderstack/analytics-js';
+import { createLogger } from '../utils/logger';
+const log = createLogger('Analytics');
 
 interface AnalyticsConfig {
   writeKey: string;
@@ -27,7 +29,7 @@ class AnalyticsService {
 
     try {
       if (!this.config.writeKey || !this.config.dataPlaneUrl) {
-        console.warn('RudderStack not configured: missing write key or data plane URL');
+        log.warn('RudderStack not configured: missing write key or data plane URL');
         return;
       }
 
@@ -49,7 +51,7 @@ class AnalyticsService {
       });
 
       this.isInitialized = true;
-      console.log('RudderStack Analytics initialized successfully');
+      log.info('RudderStack Analytics initialized successfully');
       
       // 如果是营销页面，初始化营销会话追踪
       if (this.isMarketingPage()) {
@@ -60,14 +62,14 @@ class AnalyticsService {
       }
       
     } catch (error) {
-      console.error('Failed to initialize RudderStack:', error);
+      log.error('Failed to initialize RudderStack', error);
     }
   }
 
   // 页面浏览事件
   page(name?: string, properties?: Record<string, any>): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -93,7 +95,7 @@ class AnalyticsService {
   // 事件追踪
   track(event: string, properties?: Record<string, any>): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -106,7 +108,7 @@ class AnalyticsService {
   // 用户识别
   identify(userId: string, traits?: Record<string, any>): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -119,7 +121,7 @@ class AnalyticsService {
   // 用户组
   group(groupId: string, traits?: Record<string, any>): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -129,7 +131,7 @@ class AnalyticsService {
   // 别名
   alias(newId: string, previousId?: string): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -139,7 +141,7 @@ class AnalyticsService {
   // 重置用户
   reset(): void {
     if (!this.isInitialized || !this.analytics) {
-      console.warn('Analytics not initialized');
+      log.warn('Analytics not initialized');
       return;
     }
 
@@ -359,7 +361,7 @@ class AnalyticsService {
       // 追踪落地页访问
       this.trackLandingPageEntry();
     } catch (error) {
-      console.warn('Failed to initialize marketing session:', error);
+      log.warn('Failed to initialize marketing session', error);
     }
   }
 

--- a/src/stores/BaseWidgetStore.ts
+++ b/src/stores/BaseWidgetStore.ts
@@ -18,7 +18,9 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('BaseWidgetStore', LogCategory.ARTIFACT_CREATION);
 import { chatService } from '../api/chatService';
 import { useAppStore } from './useAppStore';
 import { useSessionStore } from './useSessionStore';
@@ -84,7 +86,7 @@ function createChatServiceCallbacks(
           contentPreview: completeMessage.substring(0, 100) + '...'
         });
       } else {
-        console.log(`${config.logEmoji} ${config.widgetType.toUpperCase()}_STORE: No complete message content provided`);
+        log.debug(`${config.widgetType} message completed with no content`);
       }
     },
 
@@ -114,7 +116,7 @@ function createChatServiceCallbacks(
           (currentState as any)._lastProcessedArtifact = artifactKey;
         }
       } catch (error) {
-        console.warn('Failed to update _lastProcessedArtifact:', error);
+        log.warn('Failed to update _lastProcessedArtifact', error);
       }
 
       if (customHandlers.onArtifactCreated) {
@@ -303,10 +305,10 @@ export function createBaseWidgetStore<TSpecificState, TSpecificActions>(
           set((state) => {
             // 浅比较，如果内容相同就不更新，避免不必要的引用变化
             if (JSON.stringify(state.lastParams) === JSON.stringify(params)) {
-              console.log('🚨DEBUG_DUPLICATE🚨 setParams 跳过更新，内容相同');
+              log.debug('setParams skipped, content identical');
               return state; // 不更新，保持引用不变
             }
-            console.log('🚨DEBUG_DUPLICATE🚨 setParams 更新参数:', params);
+            log.debug('setParams updating', params);
             return { ...state, lastParams: params };
           });
           logger.debug(LogCategory.ARTIFACT_CREATION, `${config.logEmoji} ${config.widgetType} params updated`, { 
@@ -369,13 +371,12 @@ export function createBaseWidgetStore<TSpecificState, TSpecificActions>(
             const callbacks = createChatServiceCallbacks(config, params, helpers, customHandlers, get);
             
             // 调用chatService
-            console.log('🔥MODULE_DATA_FLOW🔥 BaseWidgetStore 发送到 chatService:', {
+            log.debug('Sending to chatService', {
               prompt,
               widgetType: config.widgetType,
-              'chatOptions.prompt_name': chatOptions.prompt_name,
-              'chatOptions.prompt_args': chatOptions.prompt_args,
-              'chatOptions.template_parameters': chatOptions.template_parameters,
-              'chatOptions完整': chatOptions
+              promptName: chatOptions.prompt_name,
+              promptArgs: chatOptions.prompt_args,
+              templateParameters: chatOptions.template_parameters
             });
             // chatService.sendMessage expects: (message, sessionId, callbacks, userId)
             // Extract sessionId and userId from chatOptions

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -35,7 +35,9 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { AppId } from '../types/appTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('AppStore', LogCategory.STATE_CHANGE);
 
 // Widget使用状态跟踪
 export interface WidgetUsageState {
@@ -199,7 +201,7 @@ export const useAppStore = create<AppStore>()(
           resetTaskHistory();
         });
       } catch (error) {
-        console.warn('Failed to reset task history:', error);
+        log.warn('Failed to reset task history', error);
       }
     },
     

--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -44,7 +44,9 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('ChatStore', LogCategory.CHAT_FLOW);
 // 使用全局实例获取函数而不是直接导入
 import { getChatServiceInstance } from '../hooks/useChatService';
 import { ChatMetadata, ChatMessage, StreamingStatus } from '../types/chatTypes';
@@ -511,7 +513,7 @@ export const useChatStore = create<ChatStore>()(
             parsedContent = contentParser.parse(finalizedMessage.content) || undefined;
             // Content parsed successfully
           } catch (error) {
-            console.warn('🔍 CONTENT_PARSER: Failed to parse content:', error);
+            log.warn('Failed to parse content', error);
           }
         }
         

--- a/src/stores/useLanguageStore.ts
+++ b/src/stores/useLanguageStore.ts
@@ -16,6 +16,9 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { createLogger, LogCategory } from '../utils/logger';
+
+const log = createLogger('LanguageStore', LogCategory.SYSTEM);
 
 // ================================================================================
 // Types
@@ -79,7 +82,7 @@ export const useLanguageStore = create<LanguageState>()(
       
       // Actions
       setLanguage: (language: SupportedLanguage) => {
-        console.log('🌐 Language changed:', language);
+        log.info('Language changed', { language });
         
         set({ currentLanguage: language });
         

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -39,7 +39,9 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('SessionStore', LogCategory.CHAT_FLOW);
 import { createAuthenticatedSessionService } from '../api/sessionService';
 
 const STORAGE_SAVE_DEBOUNCE_MS = 500;
@@ -198,7 +200,7 @@ export const useSessionStore = create<SessionStore>()(
       
       // 防止重复设置相同的sessionId，避免无限循环
       if (currentState.currentSessionId === sessionId) {
-        console.log('🚫 SESSION_STORE: Session already selected, skipping', { sessionId });
+        log.debug('Session already selected, skipping', { sessionId });
         return;
       }
       
@@ -206,9 +208,9 @@ export const useSessionStore = create<SessionStore>()(
       localStorage.setItem('currentSessionId', sessionId);
       
       logger.debug(LogCategory.CHAT_FLOW, 'Session selected', { sessionId });
-      console.log('✅ SESSION_STORE: Session selected', { 
-        sessionId, 
-        previousSessionId: currentState.currentSessionId 
+      log.info('Session selected', {
+        sessionId,
+        previousSessionId: currentState.currentSessionId
       });
     },
     
@@ -436,7 +438,7 @@ export const useSessionStore = create<SessionStore>()(
             const firstSessionId = parsedSessions.length > 0 ? parsedSessions[0].id : 'default';
             set({ currentSessionId: firstSessionId });
             localStorage.setItem('currentSessionId', firstSessionId);
-            console.log('⚠️ SESSION_STORE: Saved session not found, using first session', {
+            log.warn('Saved session not found, using first session', {
               savedSessionId: savedCurrentSessionId,
               newSessionId: firstSessionId
             });
@@ -450,12 +452,12 @@ export const useSessionStore = create<SessionStore>()(
           const firstSessionId = parsedSessions[0].id;
           set({ currentSessionId: firstSessionId });
           localStorage.setItem('currentSessionId', firstSessionId);
-          console.log('🆕 SESSION_STORE: No saved session ID, using first session', {
+          log.info('No saved session ID, using first session', {
             firstSessionId,
             totalSessions: parsedSessions.length
           });
         } else {
-          console.log('❌ SESSION_STORE: No sessions available, cannot set current session');
+          log.warn('No sessions available, cannot set current session');
         }
         
         const finalCurrentSessionId = get().currentSessionId;

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -38,7 +38,9 @@ import {
   ExternalSubscription,
   CreditConsumption 
 } from '../types/userTypes';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('UserStore', LogCategory.USER_AUTH);
 
 // ================================================================================
 // Store State Interface
@@ -188,7 +190,7 @@ export const useUserStore = create<UserStore>()(
     updateCredits: (newCredits: number, source?: 'api' | 'billing' | 'manual') => {
       const currentUser = get().externalUser;
       if (!currentUser) {
-        console.warn('💳 USER_STORE: Cannot update credits - no current user');
+        log.warn('Cannot update credits - no current user');
         return;
       }
       
@@ -198,14 +200,13 @@ export const useUserStore = create<UserStore>()(
       
       // 🔍 数据验证
       if (newCredits < 0) {
-        console.warn('💳 USER_STORE: Invalid credits value - cannot be negative', { newCredits });
+        log.warn('Invalid credits value - cannot be negative', { newCredits });
         return;
       }
       
       // 🛡️ 防御性检查：确保用户数据完整
       if (!currentUser.auth0_id) {
-        console.error('💳 USER_STORE: Critical error - currentUser missing auth0_id', {
-          currentUser,
+        log.error('Critical error - currentUser missing auth0_id', {
           hasAuth0Id: !!currentUser.auth0_id,
           userKeys: Object.keys(currentUser),
           newCredits,
@@ -214,13 +215,13 @@ export const useUserStore = create<UserStore>()(
         return; // 阻止继续执行，避免错误传播
       }
       
-      console.log('💳 USER_STORE: 🚀 Updating user credits', { 
+      log.info('Updating user credits', {
         auth0_id: currentUser.auth0_id,
         transition: `${oldCredits} → ${newCredits}`,
         difference: difference > 0 ? `+${difference}` : `${difference}`,
         source: source || 'unknown',
         timestamp,
-        totalCredits: currentUser.credits_total // 保持总积分不变
+        totalCredits: currentUser.credits_total
       });
         
       logger.info(LogCategory.USER_AUTH, 'Smart credit update', { 

--- a/src/stores/useWidgetStores.ts
+++ b/src/stores/useWidgetStores.ts
@@ -43,7 +43,9 @@ import {
 } from './widgetStoreUtils';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { logger, LogCategory } from '../utils/logger';
+import { logger, LogCategory, createLogger } from '../utils/logger';
+
+const log = createLogger('WidgetStores', LogCategory.ARTIFACT_CREATION);
 import { useAppStore } from './useAppStore';
 
 // Dream Widget State (simplified with BaseWidgetStore)
@@ -92,7 +94,7 @@ export const useDreamWidgetStore = createBaseWidgetStore(
     onArtifactCreated: (artifact: any, params: any, helpers: any, get: any) => {
       const store = get();
       const setDreamGeneratedImage = store.setDreamGeneratedImage;
-      console.log('🚨DEBUG_DREAM🚨 onArtifactCreated called:', {
+      log.debug('Dream onArtifactCreated called', {
         artifactType: artifact.type,
         hasContent: !!artifact.content,
         contentPreview: artifact.content?.substring(0, 80),
@@ -104,37 +106,37 @@ export const useDreamWidgetStore = createBaseWidgetStore(
       // Handle direct image URL (type: 'image')
       if (artifact.type === 'image' && artifact.content) {
         imageUrl = artifact.content;
-        console.log('🚨DEBUG_DREAM🚨 Direct image URL:', imageUrl);
+        log.debug('Dream direct image URL', { imageUrl });
       }
       // Handle JSON data with image URLs (type: 'data')
       else if (artifact.type === 'data' && artifact.content) {
         try {
           const data = JSON.parse(artifact.content);
-          console.log('🚨DEBUG_DREAM🚨 Parsed data artifact:', data);
-          
+          log.debug('Dream parsed data artifact', data);
+
           // Extract image URL from different possible structures
           if (data.data?.image_urls && Array.isArray(data.data.image_urls) && data.data.image_urls.length > 0) {
             imageUrl = data.data.image_urls[0];
-            console.log('🚨DEBUG_DREAM🚨 Extracted from image_urls array:', imageUrl);
+            log.debug('Dream extracted from image_urls array', { imageUrl });
           } else if (data.image_urls && Array.isArray(data.image_urls) && data.image_urls.length > 0) {
             imageUrl = data.image_urls[0];
-            console.log('🚨DEBUG_DREAM🚨 Extracted from top-level image_urls:', imageUrl);
+            log.debug('Dream extracted from top-level image_urls', { imageUrl });
           } else if (data.url) {
             imageUrl = data.url;
-            console.log('🚨DEBUG_DREAM🚨 Extracted from url field:', imageUrl);
+            log.debug('Dream extracted from url field', { imageUrl });
           }
         } catch (parseError) {
-          console.error('🚨DEBUG_DREAM🚨 Failed to parse data artifact:', parseError);
+          log.error('Dream failed to parse data artifact', parseError);
         }
       }
       
       // Set the image if we found a valid URL and don't already have an image
       if (imageUrl && !store.generatedImage) {
-        console.log('🚨DEBUG_DREAM🚨 Setting dream generated image:', imageUrl);
+        log.debug('Setting dream generated image', { imageUrl });
         setDreamGeneratedImage(imageUrl);
         helpers.markWithArtifacts();
       } else {
-        console.log('🚨DEBUG_DREAM🚨 NOT setting dream image - conditions not met:', {
+        log.debug('Dream image not set - conditions not met', {
           hasImageUrl: !!imageUrl,
           hasExistingImage: !!store.generatedImage,
           imageUrl: imageUrl?.substring(0, 50)

--- a/src/stores/widgetStoreUtils.ts
+++ b/src/stores/widgetStoreUtils.ts
@@ -10,6 +10,9 @@
  */
 
 import { WidgetHelpers, CustomResultHandlers } from '../types/widgetTypes';
+import { createLogger, LogCategory } from '../utils/logger';
+
+const log = createLogger('WidgetStoreUtils', LogCategory.ARTIFACT_CREATION);
 
 /**
  * 通用图片URL提取函数 (用于Dream等图片生成Widget)
@@ -34,10 +37,10 @@ export function extractImageFromMessage(
         messageLength: completeMessage.length
       });
     } else {
-      console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: No valid image URL found in complete message`);
+      log.debug(`${helpers.config.widgetType} no valid image URL found in complete message`);
     }
   } else {
-    console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: No image markdown found in complete message`);
+    log.debug(`${helpers.config.widgetType} no image markdown found in complete message`);
   }
 }
 
@@ -58,7 +61,7 @@ export function extractTextFromMessage(
       contentPreview: completeMessage.substring(0, 100) + '...'
     });
   } else {
-    console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: No complete message content provided`);
+    log.debug(`${helpers.config.widgetType} no complete message content provided`);
   }
 }
 
@@ -72,7 +75,7 @@ export function extractSearchResultFromMessage(
   helpers: WidgetHelpers
 ): void {
   if (completeMessage && completeMessage.trim()) {
-    console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: Processing complete search response from chatService:`, completeMessage.substring(0, 200) + '...');
+    log.debug(`${helpers.config.widgetType} processing complete search response`, { preview: completeMessage.substring(0, 200) });
     
     // 创建搜索结果
     const searchResult = {
@@ -91,7 +94,7 @@ export function extractSearchResultFromMessage(
     });
   } else {
     // Fallback if no complete message was provided
-    console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: No complete message provided, creating placeholder result`);
+    log.debug(`${helpers.config.widgetType} no complete message provided, creating placeholder result`);
     const placeholderResult = {
       title: `Search Results for: ${params.query}`,
       description: 'Search completed but no content was returned.',
@@ -144,7 +147,7 @@ export function extractAnalysisFromMessage(
       });
     }
   } else {
-    console.log(`${helpers.config.logEmoji} ${helpers.config.widgetType.toUpperCase()}_STORE: No complete message content provided`);
+    log.debug(`${helpers.config.widgetType} no complete message content provided`);
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -335,3 +335,35 @@ export const logger = new MainAppLogger();
 if (typeof window !== 'undefined') {
   (window as any).mainAppLogger = logger;
 }
+
+/**
+ * Module-scoped logger created via createLogger('ModuleName').
+ * Provides a simpler API without requiring LogCategory on every call.
+ */
+export interface ScopedLogger {
+  debug(message: string, data?: any): void;
+  info(message: string, data?: any): void;
+  warn(message: string, data?: any): void;
+  error(message: string, data?: any): void;
+}
+
+/**
+ * Create a module-scoped logger with a simpler API.
+ *
+ * @example
+ * const log = createLogger('ChatModule');
+ * log.info('Message sent', { id });
+ * log.error('Send failed', err);
+ */
+export function createLogger(module: string, category: LogCategory = LogCategory.SYSTEM): ScopedLogger {
+  return {
+    debug: (message: string, data?: any) =>
+      logger.debug(category, `[${module}] ${message}`, data),
+    info: (message: string, data?: any) =>
+      logger.info(category, `[${module}] ${message}`, data),
+    warn: (message: string, data?: any) =>
+      logger.warn(category, `[${module}] ${message}`, data),
+    error: (message: string, data?: any) =>
+      logger.error(category, `[${module}] ${message}`, data),
+  };
+}


### PR DESCRIPTION
## Summary

- **Added `createLogger()` factory** to `src/utils/logger.ts` — provides module-scoped loggers with a simpler API (`log.info/warn/error/debug`) that don't require `LogCategory` on every call
- **Replaced 893 `console.*` calls** across 97 source files with structured `createLogger` calls
- **Added ESLint `no-console` rule** to `.eslintrc.json` to prevent regression (with overrides for `logger.ts` and test files)
- Production builds continue to suppress debug-level output via existing logger configuration

Fixes #27
**Parent Epic**: #24

## Changes by area

| Area | Files | Description |
|------|-------|-------------|
| Logger | `src/utils/logger.ts` | Added `createLogger(name, category?)` factory + `ScopedLogger` interface |
| ESLint | `.eslintrc.json` | Added `no-console: error` with overrides for logger + tests |
| Modules | 11 files | `ChatModule`, `UserModule`, `SessionModule`, widget modules |
| Components | 40 files | Core, UI, shared, mobile, widget components |
| API/Transport | 7 files | `chatService`, `storageService`, `SSETransport`, parsers |
| Stores | 8 files | All Zustand stores |
| Hooks | 6 files | `useAuth`, `useUser`, `useTheme`, `useTranslation`, etc. |
| Plugins | 5 files | All widget plugins |
| Config/Services | 6 files | `analytics`, `config/index`, `runtimeEnv`, etc. |
| Pages | 5 files | `_app`, `index`, `pricing`, API routes |
| Providers | 2 files | `AIProvider`, `AnalyticsProvider` |

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 0 | N/A (refactor — no logic changes) |
| L2 Component | 0 | N/A |
| L3 Integration | 0 | N/A |
| L4 API | 0 | N/A |
| L5 Smoke | 1 | Pass (ESLint `no-console` rule: 0 errors) |

## Verification

- **ESLint**: 0 `no-console` errors (zero runtime `console.*` calls in src/ and pages/)
- **TypeScript**: 27 errors before → 27 errors after (zero regressions introduced)
- **Remaining `console.*` in comments/JSDoc**: 43 occurrences in commented-out code and `@example` blocks — not runtime code

## Test plan

- [ ] Verify `npx next lint` passes with no `no-console` errors
- [ ] Verify `npx tsc --noEmit` error count unchanged (27 pre-existing)
- [ ] Verify dev server starts and logging appears with `[ModuleName]` prefixes
- [ ] Verify production build suppresses debug-level logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)