### PR TITLE
feat(api): add isA Mate backend integration with event adapter (#33)

### DIFF
--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -1,0 +1,225 @@
+/**
+ * MateEventAdapter — Maps isA_Mate SSE events to AGUI protocol events.
+ *
+ * isA_Mate streams events with this format:
+ *   { type: "text", content: "...", session_id: "...", metadata: {...} }
+ *
+ * The AGUI pipeline expects:
+ *   { type: "text_message_content", delta: "...", thread_id: "...", timestamp: "..." }
+ *
+ * This adapter translates Mate events so the downstream AGUIEventParser,
+ * callbacks, stores, and UI components remain unchanged.
+ */
+
+import type { AGUIEventType } from '../../types/aguiTypes';
+
+export interface MateSSEEvent {
+  type: string;
+  content?: string;
+  session_id?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: string;
+  tool_name?: string;
+  tool_call_id?: string;
+  parameters?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+}
+
+export interface AGUICompatEvent {
+  type: AGUIEventType;
+  thread_id: string;
+  timestamp: string;
+  run_id?: string;
+  message_id?: string;
+  delta?: string;
+  final_content?: string;
+  role?: string;
+  tool_name?: string;
+  tool_call_id?: string;
+  parameters?: Record<string, unknown>;
+  result?: unknown;
+  error?: { code: string; message: string };
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+let messageCounter = 0;
+
+function generateId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${++messageCounter}`;
+}
+
+/**
+ * Convert a single Mate SSE event to one or more AGUI-compatible events.
+ * Some Mate events (like "text") map 1:1. Others (like the first "text")
+ * also emit a preceding "text_message_start" event.
+ */
+export function adaptMateEvent(
+  event: MateSSEEvent,
+  context: { runId: string; sessionId: string; currentMessageId: string | null }
+): { events: AGUICompatEvent[]; updatedContext: typeof context } {
+  const now = event.timestamp || new Date().toISOString();
+  const threadId = event.session_id || context.sessionId;
+  const results: AGUICompatEvent[] = [];
+  let { currentMessageId } = context;
+
+  switch (event.type) {
+    case 'text': {
+      // If no message started yet, emit text_message_start first
+      if (!currentMessageId) {
+        currentMessageId = generateId('msg');
+        results.push({
+          type: 'text_message_start',
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          message_id: currentMessageId,
+          role: 'assistant',
+        });
+      }
+      results.push({
+        type: 'text_message_content',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        message_id: currentMessageId,
+        delta: event.content || '',
+      });
+      break;
+    }
+
+    case 'tool_use': {
+      results.push({
+        type: 'tool_call_start',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        tool_name: event.tool_name || 'unknown',
+        tool_call_id: event.tool_call_id || generateId('tool'),
+        parameters: event.parameters,
+      });
+      break;
+    }
+
+    case 'tool_result': {
+      results.push({
+        type: 'tool_call_end',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        tool_name: event.tool_name || 'unknown',
+        tool_call_id: event.tool_call_id || '',
+        result: event.result,
+        error: event.error ? { code: 'TOOL_ERROR', message: event.error } : undefined,
+      });
+      break;
+    }
+
+    case 'result': {
+      // Final result — close the text message and finish the run
+      if (currentMessageId) {
+        results.push({
+          type: 'text_message_end',
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          message_id: currentMessageId,
+          final_content: event.content,
+        });
+        currentMessageId = null;
+      }
+      results.push({
+        type: 'run_finished',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        result: { status: 'success', output: event.content },
+      });
+      break;
+    }
+
+    case 'session_end': {
+      if (currentMessageId) {
+        results.push({
+          type: 'text_message_end',
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          message_id: currentMessageId,
+        });
+        currentMessageId = null;
+      }
+      break;
+    }
+
+    case 'error': {
+      results.push({
+        type: 'run_error',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        error: {
+          code: 'MATE_ERROR',
+          message: event.content || event.error || 'Unknown error',
+        },
+      });
+      break;
+    }
+
+    default: {
+      // Pass through unknown events as custom metadata
+      if (event.type) {
+        results.push({
+          type: 'run_started' as AGUIEventType, // fallback type
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          metadata: { custom_type: event.type, custom_data: event },
+        });
+      }
+      break;
+    }
+  }
+
+  return {
+    events: results,
+    updatedContext: { ...context, currentMessageId },
+  };
+}
+
+/**
+ * Create the initial run_started event and context for a Mate streaming session.
+ */
+export function createMateStreamContext(sessionId: string): {
+  startEvent: AGUICompatEvent;
+  context: { runId: string; sessionId: string; currentMessageId: string | null };
+} {
+  const runId = generateId('run');
+  const now = new Date().toISOString();
+
+  return {
+    startEvent: {
+      type: 'run_started',
+      thread_id: sessionId,
+      timestamp: now,
+      run_id: runId,
+      agent_info: { name: 'isA Mate', version: '0.2.0', capabilities: ['chat', 'tools', 'delegation'] },
+      session_info: { user_id: '', session_id: sessionId },
+    },
+    context: { runId, sessionId, currentMessageId: null },
+  };
+}
+
+/**
+ * Build the request payload for Mate's /v1/chat endpoint.
+ */
+export function buildMateRequest(message: string, sessionId?: string): {
+  prompt: string;
+  session_id?: string;
+} {
+  return {
+    prompt: message,
+    ...(sessionId && { session_id: sessionId }),
+  };
+}

--- a/src/api/adapters/__tests__/MateEventAdapter.test.ts
+++ b/src/api/adapters/__tests__/MateEventAdapter.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect } from 'vitest';
+import {
+  adaptMateEvent,
+  createMateStreamContext,
+  buildMateRequest,
+  type MateSSEEvent,
+} from '../MateEventAdapter';
+
+describe('buildMateRequest', () => {
+  test('builds request with prompt only', () => {
+    const req = buildMateRequest('hello');
+    expect(req).toEqual({ prompt: 'hello' });
+  });
+
+  test('builds request with prompt and session_id', () => {
+    const req = buildMateRequest('hello', 'sess_123');
+    expect(req).toEqual({ prompt: 'hello', session_id: 'sess_123' });
+  });
+
+  test('omits session_id when undefined', () => {
+    const req = buildMateRequest('hello', undefined);
+    expect(req).toEqual({ prompt: 'hello' });
+    expect('session_id' in req).toBe(false);
+  });
+});
+
+describe('createMateStreamContext', () => {
+  test('creates run_started event and context', () => {
+    const { startEvent, context } = createMateStreamContext('sess_abc');
+
+    expect(startEvent.type).toBe('run_started');
+    expect(startEvent.thread_id).toBe('sess_abc');
+    expect(startEvent.run_id).toBeTruthy();
+    expect(context.sessionId).toBe('sess_abc');
+    expect(context.runId).toBeTruthy();
+    expect(context.currentMessageId).toBeNull();
+  });
+
+  test('generates unique run IDs', () => {
+    const a = createMateStreamContext('s1');
+    const b = createMateStreamContext('s2');
+    expect(a.context.runId).not.toBe(b.context.runId);
+  });
+});
+
+describe('adaptMateEvent — text events', () => {
+  const baseCtx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+
+  test('first text event emits text_message_start + text_message_content', () => {
+    const event: MateSSEEvent = { type: 'text', content: 'Hello' };
+    const { events, updatedContext } = adaptMateEvent(event, baseCtx);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('text_message_start');
+    expect(events[0].role).toBe('assistant');
+    expect(events[1].type).toBe('text_message_content');
+    expect(events[1].delta).toBe('Hello');
+    expect(updatedContext.currentMessageId).toBeTruthy();
+  });
+
+  test('subsequent text events emit only text_message_content', () => {
+    const ctx = { ...baseCtx, currentMessageId: 'msg_existing' };
+    const event: MateSSEEvent = { type: 'text', content: ' world' };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_message_content');
+    expect(events[0].delta).toBe(' world');
+    expect(events[0].message_id).toBe('msg_existing');
+  });
+
+  test('empty content is preserved', () => {
+    const event: MateSSEEvent = { type: 'text', content: '' };
+    const { events } = adaptMateEvent(event, baseCtx);
+
+    const contentEvent = events.find((e) => e.type === 'text_message_content');
+    expect(contentEvent?.delta).toBe('');
+  });
+});
+
+describe('adaptMateEvent — tool events', () => {
+  const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+
+  test('tool_use maps to tool_call_start', () => {
+    const event: MateSSEEvent = {
+      type: 'tool_use',
+      tool_name: 'web_search',
+      tool_call_id: 'tc_1',
+      parameters: { query: 'isA platform' },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool_call_start');
+    expect(events[0].tool_name).toBe('web_search');
+    expect(events[0].tool_call_id).toBe('tc_1');
+    expect(events[0].parameters).toEqual({ query: 'isA platform' });
+  });
+
+  test('tool_result maps to tool_call_end', () => {
+    const event: MateSSEEvent = {
+      type: 'tool_result',
+      tool_name: 'web_search',
+      tool_call_id: 'tc_1',
+      result: { url: 'https://example.com' },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool_call_end');
+    expect(events[0].result).toEqual({ url: 'https://example.com' });
+  });
+
+  test('tool_result with error maps to tool_call_end with error', () => {
+    const event: MateSSEEvent = {
+      type: 'tool_result',
+      tool_name: 'web_search',
+      error: 'Timeout after 10s',
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events[0].type).toBe('tool_call_end');
+    expect(events[0].error).toEqual({ code: 'TOOL_ERROR', message: 'Timeout after 10s' });
+  });
+});
+
+describe('adaptMateEvent — lifecycle events', () => {
+  test('result event closes message and finishes run', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: 'msg_1' };
+    const event: MateSSEEvent = { type: 'result', content: 'Final answer' };
+    const { events, updatedContext } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('text_message_end');
+    expect(events[0].final_content).toBe('Final answer');
+    expect(events[1].type).toBe('run_finished');
+    expect(updatedContext.currentMessageId).toBeNull();
+  });
+
+  test('result without active message only emits run_finished', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+    const event: MateSSEEvent = { type: 'result', content: 'Done' };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('run_finished');
+  });
+
+  test('session_end closes active message', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: 'msg_1' };
+    const event: MateSSEEvent = { type: 'session_end' };
+    const { events, updatedContext } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text_message_end');
+    expect(updatedContext.currentMessageId).toBeNull();
+  });
+
+  test('error maps to run_error', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+    const event: MateSSEEvent = { type: 'error', content: 'Rate limited' };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('run_error');
+    expect(events[0].error?.message).toBe('Rate limited');
+  });
+});
+
+describe('adaptMateEvent — context propagation', () => {
+  test('session_id from event overrides context', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+    const event: MateSSEEvent = { type: 'text', content: 'hi', session_id: 'sess_override' };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events[0].thread_id).toBe('sess_override');
+  });
+
+  test('uses context sessionId when event has no session_id', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+    const event: MateSSEEvent = { type: 'text', content: 'hi' };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events[0].thread_id).toBe('sess_1');
+  });
+
+  test('preserves timestamp from event', () => {
+    const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+    const ts = '2026-03-18T12:00:00Z';
+    const event: MateSSEEvent = { type: 'text', content: 'hi', timestamp: ts };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events[0].timestamp).toBe(ts);
+  });
+});

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -19,6 +19,8 @@ import { createSSETransport } from './transport/SSETransport';
 import { createAGUIEventParser } from './parsing/AGUIEventParser';
 import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { createLogger, LogCategory } from '../utils/logger';
+import { adaptMateEvent, createMateStreamContext, buildMateRequest } from './adapters/MateEventAdapter';
+import type { MateSSEEvent } from './adapters/MateEventAdapter';
 
 const log = createLogger('ChatService', LogCategory.CHAT_FLOW);
 
@@ -439,6 +441,121 @@ export class ChatService {
     }
   }
   
+  /**
+   * Send message via isA_Mate backend (streaming SSE).
+   * Uses MateEventAdapter to convert Mate events to AGUI format,
+   * so all downstream callbacks, stores, and UI remain unchanged.
+   */
+  async sendMessageViaMate(
+    message: string,
+    metadata: { session_id: string },
+    token: string,
+    callbacks: ChatServiceCallbacks
+  ): Promise<void> {
+    log.info('Sending message via Mate backend');
+
+    try {
+      const payload = buildMateRequest(message, metadata.session_id);
+      const endpoint = GATEWAY_ENDPOINTS.MATE.CHAT;
+
+      const transport = createSSETransport({
+        url: endpoint,
+        timeout: 300000,
+        retryConfig: { maxRetries: 3, retryDelay: 1000 },
+      });
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const connection = await transport.connect(endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      });
+
+      return new Promise<void>((resolve, reject) => {
+        let streamEnded = false;
+        const { startEvent, context } = createMateStreamContext(metadata.session_id);
+        let adaptCtx = context;
+
+        // Emit synthetic run_started
+        this.handleAGUIEvent(startEvent, callbacks);
+
+        const handleComplete = async (finalContent?: string) => {
+          if (!streamEnded) {
+            streamEnded = true;
+            await connection.close();
+            callbacks.onStreamComplete?.(finalContent);
+            resolve();
+          }
+        };
+
+        const handleError = async (error: Error) => {
+          if (!streamEnded) {
+            streamEnded = true;
+            await connection.close();
+            callbacks.onError?.(error);
+            reject(error);
+          }
+        };
+
+        const processData = async () => {
+          try {
+            for await (const rawData of connection.stream()) {
+              const lines = rawData.split('\n');
+              for (const line of lines) {
+                // Handle SSE "event: done" format
+                if (line.trim() === 'event: done' || line.trim() === 'data: [DONE]') {
+                  await handleComplete();
+                  return;
+                }
+
+                if (line.startsWith('data: ')) {
+                  const dataContent = line.slice(6).trim();
+                  if (dataContent === '[DONE]') {
+                    await handleComplete();
+                    return;
+                  }
+
+                  try {
+                    const mateEvent: MateSSEEvent = JSON.parse(dataContent);
+                    const { events, updatedContext } = adaptMateEvent(mateEvent, adaptCtx);
+                    adaptCtx = updatedContext;
+
+                    for (const aguiEvent of events) {
+                      this.handleAGUIEvent(aguiEvent, callbacks);
+                    }
+                  } catch (parseError) {
+                    log.warn('Failed to parse Mate event', parseError);
+                  }
+                }
+              }
+            }
+          } catch (error) {
+            if (error instanceof Error && error.name === 'AbortError') {
+              log.debug('Mate stream aborted normally');
+            } else {
+              log.error('Mate stream error', error);
+              await handleError(error instanceof Error ? error : new Error(String(error)));
+            }
+          }
+        };
+
+        processData();
+      });
+    } catch (error) {
+      log.error('Failed to connect to Mate', error);
+      callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  }
+
   /**
    * 发送多模态消息
    */

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -55,6 +55,7 @@ export const GATEWAY_CONFIG = {
 export const GATEWAY_SERVICES = {
   // 核心AI服务
   AGENTS: 'agents',           // Agent聊天服务 (8080)
+  MATE: 'mate',               // isA Mate聊天服务 (18789)
   MCP: 'mcp',                 // MCP工具服务 (8081)
   
   // 用户相关服务  
@@ -116,6 +117,21 @@ export const GATEWAY_ENDPOINTS = {
     }
   },
   
+  // ==== Mate服务端点 (isA Mate agentic chat) ====
+  MATE: {
+    BASE: buildEndpoint(GATEWAY_SERVICES.MATE),
+    CHAT: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/chat'),
+    QUERY: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/query'),
+    TOOLS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/tools'),
+    SKILLS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/skills'),
+    TEAMS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/teams'),
+    MEMORY: {
+      SESSIONS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/memory/sessions'),
+      TURNS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/memory/turns'),
+    },
+    HEALTH: buildEndpoint(GATEWAY_SERVICES.MATE, '/health'),
+  },
+
   // ==== MCP服务端点 (工具调用) ====
   MCP: {
     BASE: buildEndpoint(GATEWAY_SERVICES.MCP),
@@ -330,19 +346,21 @@ export const requiresAuth = (url: string): boolean => {
 
 export const SSE_CONFIG = {
   // SSE支持的服务
-  SSE_SERVICES: ['agents', 'mcp'],
-  
+  SSE_SERVICES: ['agents', 'mate', 'mcp'],
+
   // SSE端点
   SSE_ENDPOINTS: {
     CHAT: GATEWAY_ENDPOINTS.AGENTS.CHAT,
+    MATE_CHAT: GATEWAY_ENDPOINTS.MATE.CHAT,
     EXECUTION_RESUME: GATEWAY_ENDPOINTS.AGENTS.EXECUTION.RESUME_STREAM,
     MCP_TOOLS: GATEWAY_ENDPOINTS.MCP.TOOLS_CALL,
   },
-  
+
   // 检查是否为SSE端点 (reference GATEWAY_ENDPOINTS directly to avoid self-reference)
   isSSEEndpoint: (url: string): boolean => {
     return [
       GATEWAY_ENDPOINTS.AGENTS.CHAT,
+      GATEWAY_ENDPOINTS.MATE.CHAT,
       GATEWAY_ENDPOINTS.AGENTS.EXECUTION.RESUME_STREAM,
       GATEWAY_ENDPOINTS.MCP.TOOLS_CALL,
     ].some(endpoint => url.startsWith(endpoint));


### PR DESCRIPTION
## Summary

Integrate isA_Mate as the chat backend for isA_. Uses an adapter pattern to map Mate's SSE events to AGUI protocol, keeping all downstream code unchanged.

### Architecture

```
User → ChatService.sendMessageViaMate()
  → MateEventAdapter.buildMateRequest()
  → SSETransport → Mate (:18789/v1/chat)
  → MateEventAdapter.adaptMateEvent() → AGUI events
  → handleAGUIEvent() → callbacks → stores → UI (unchanged)
```

### Changes

- **gatewayConfig.ts**: Add MATE service + 8 endpoints (chat, query, tools, skills, teams, memory, health)
- **MateEventAdapter.ts**: Maps Mate events (text, tool_use, tool_result, result, error) to AGUI events
- **chatService.ts**: Add `sendMessageViaMate()` method using adapter
- **18 new unit tests** for MateEventAdapter

### Event Mapping

| Mate Event | AGUI Event |
|-----------|------------|
| `text` (first) | `text_message_start` + `text_message_content` |
| `text` (subsequent) | `text_message_content` |
| `tool_use` | `tool_call_start` |
| `tool_result` | `tool_call_end` |
| `result` | `text_message_end` + `run_finished` |
| `error` | `run_error` |

### Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 169 (18 new) | Pass |

Fixes #33
Related to #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)