### PR TITLE
feat(api): wire Mate backend into ChatModule with feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ NEXT_PUBLIC_CONSOLE_URL=http://localhost:4200/console
 NEXT_PUBLIC_DOCS_URL=http://localhost:4300/docs
 
 # ----------------------------------------------------------------------------
+# Chat Backend (Mate integration)
+# ----------------------------------------------------------------------------
+# Set to 'mate' to use isA_Mate as chat backend (default: 'agent')
+# NEXT_PUBLIC_CHAT_BACKEND=mate
+# Direct Mate URL for local dev without gateway routing
+# NEXT_PUBLIC_MATE_URL=http://localhost:18789
+
+# ----------------------------------------------------------------------------
 # Analytics (optional)
 # ----------------------------------------------------------------------------
 NEXT_PUBLIC_RUDDERSTACK_WRITE_KEY=your-rudderstack-write-key

--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -167,17 +167,34 @@ export function adaptMateEvent(
       break;
     }
 
-    default: {
-      // Pass through unknown events as custom metadata
-      if (event.type) {
+    // Informational events from Mate — map to AGUI status or silently consume
+    case 'session_start': {
+      // Session started — update context with the session_id from Mate
+      break;
+    }
+
+    case 'system': {
+      // System status (e.g., "Context ready: 47 tools, 38 prompts")
+      // Map to stream status notification
+      if (event.content) {
         results.push({
-          type: 'run_started' as AGUIEventType, // fallback type
+          type: 'run_started' as AGUIEventType,
           thread_id: threadId,
           timestamp: now,
           run_id: context.runId,
-          metadata: { custom_type: event.type, custom_data: event },
+          metadata: { mate_status: event.content, ...event.metadata },
         });
       }
+      break;
+    }
+
+    case 'node_exit': {
+      // LangGraph node transition — no UI action needed
+      break;
+    }
+
+    default: {
+      // Unknown events — silently ignore (no spurious AGUI events)
       break;
     }
   }

--- a/src/api/adapters/__tests__/MateEventAdapter.test.ts
+++ b/src/api/adapters/__tests__/MateEventAdapter.test.ts
@@ -167,6 +167,39 @@ describe('adaptMateEvent — lifecycle events', () => {
   });
 });
 
+describe('adaptMateEvent — informational events', () => {
+  const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+
+  test('session_start emits no events', () => {
+    const event: MateSSEEvent = { type: 'session_start', content: 'Session started', session_id: 'mate_abc' };
+    const { events } = adaptMateEvent(event, ctx);
+    expect(events).toHaveLength(0);
+  });
+
+  test('system event emits status metadata', () => {
+    const event: MateSSEEvent = {
+      type: 'system',
+      content: 'Context ready: 47 tools',
+      metadata: { tools_count: 47 },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata?.mate_status).toBe('Context ready: 47 tools');
+  });
+
+  test('node_exit emits no events', () => {
+    const event: MateSSEEvent = { type: 'node_exit', content: 'Exiting sense', metadata: { node: 'sense' } };
+    const { events } = adaptMateEvent(event, ctx);
+    expect(events).toHaveLength(0);
+  });
+
+  test('unknown event type emits no events', () => {
+    const event: MateSSEEvent = { type: 'some_future_event', content: 'data' };
+    const { events } = adaptMateEvent(event, ctx);
+    expect(events).toHaveLength(0);
+  });
+});
+
 describe('adaptMateEvent — context propagation', () => {
   test('session_id from event overrides context', () => {
     const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -118,19 +118,25 @@ export const GATEWAY_ENDPOINTS = {
   },
   
   // ==== Mate服务端点 (isA Mate agentic chat) ====
-  MATE: {
-    BASE: buildEndpoint(GATEWAY_SERVICES.MATE),
-    CHAT: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/chat'),
-    QUERY: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/query'),
-    TOOLS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/tools'),
-    SKILLS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/skills'),
-    TEAMS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/teams'),
-    MEMORY: {
-      SESSIONS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/memory/sessions'),
-      TURNS: buildEndpoint(GATEWAY_SERVICES.MATE, '/v1/memory/turns'),
-    },
-    HEALTH: buildEndpoint(GATEWAY_SERVICES.MATE, '/health'),
-  },
+  // Supports direct URL via NEXT_PUBLIC_MATE_URL env var for local dev
+  // without gateway routing. Falls back to gateway path.
+  MATE: (() => {
+    const mateBase = process.env.NEXT_PUBLIC_MATE_URL || buildEndpoint(GATEWAY_SERVICES.MATE);
+    const buildMateEndpoint = (path: string) => `${mateBase}${path}`;
+    return {
+      BASE: mateBase,
+      CHAT: buildMateEndpoint('/v1/chat'),
+      QUERY: buildMateEndpoint('/v1/query'),
+      TOOLS: buildMateEndpoint('/v1/tools'),
+      SKILLS: buildMateEndpoint('/v1/skills'),
+      TEAMS: buildMateEndpoint('/v1/teams'),
+      MEMORY: {
+        SESSIONS: buildMateEndpoint('/v1/memory/sessions'),
+        TURNS: buildMateEndpoint('/v1/memory/turns'),
+      },
+      HEALTH: buildMateEndpoint('/health'),
+    };
+  })(),
 
   // ==== MCP服务端点 (工具调用) ====
   MCP: {

--- a/src/config/runtimeEnv.ts
+++ b/src/config/runtimeEnv.ts
@@ -33,3 +33,12 @@ export const getGatewayUrl = (): string => {
 
   throw new Error('Missing required environment variable: NEXT_PUBLIC_GATEWAY_URL');
 };
+
+/**
+ * Chat backend selector: 'mate' uses isA_Mate, 'agent' uses isA_Agent (default).
+ * Set NEXT_PUBLIC_CHAT_BACKEND=mate to enable Mate integration.
+ */
+export const getChatBackend = (): 'mate' | 'agent' => {
+  const value = process.env.NEXT_PUBLIC_CHAT_BACKEND;
+  return value === 'mate' ? 'mate' : 'agent';
+};

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -1135,8 +1135,14 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         const token = await userModule.getAccessToken();
         const chatService = await getChatService();
         
-        // 直接调用 ChatService 并处理回调
-        await chatService.sendMessage(content, enrichedMetadata, token, {
+        // Select backend: Mate or Agent based on feature flag
+        const { getChatBackend } = await import('../config/runtimeEnv');
+        const useMate = getChatBackend() === 'mate';
+        const sendFn = useMate
+          ? chatService.sendMessageViaMate.bind(chatService, content, { session_id: enrichedMetadata.session_id }, token)
+          : chatService.sendMessage.bind(chatService, content, enrichedMetadata, token);
+
+        await sendFn({
           onStreamStart: (messageId: string, status?: string) => {
             useChatStore.getState().startStreamingMessage(messageId, status);
             useChatStore.getState().setExecutingPlan(true);


### PR DESCRIPTION
Completes Mate integration (#33). Adds NEXT_PUBLIC_CHAT_BACKEND=mate flag, direct MATE URL support, and real event handling. 173 tests pass (22 adapter). Related to #33, #9.