### PR TITLE
test(e2e): add Playwright L5 smoke tests for Multi-Zone platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@isa/core": "file:../isA_App_SDK/packages/core",
         "@isa/transport": "file:../isA_App_SDK/packages/transport",
+        "@isa/ui-web": "file:../isA_App_SDK/packages/ui-web",
         "@rudderstack/analytics-js": "^3.23.2",
         "@supabase/supabase-js": "^2.57.2",
         "@types/node": "^20.0.0",
@@ -31,6 +32,7 @@
         "zustand": "^4.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@vitest/coverage-v8": "^4.0.18",
         "vitest": "^2.1.9"
       }
@@ -58,6 +60,65 @@
         "@types/paho-mqtt": "^1.0.10",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
+      }
+    },
+    "../isA_App_SDK/packages/ui-web": {
+      "name": "@isa/ui-web",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.13",
+        "@codesandbox/nodebox": "^0.1.9",
+        "@codesandbox/sandpack-client": "^2.19.8",
+        "@codesandbox/sandpack-react": "^2.13.5",
+        "@isa/core": "workspace:*",
+        "@isa/theme": "workspace:*",
+        "@lezer/common": "^1.5.1",
+        "@lezer/css": "^1.3.0",
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/html": "^1.3.13",
+        "@lezer/javascript": "^1.5.4",
+        "@lezer/lr": "^1.4.8",
+        "@react-hook/intersection-observer": "^3.1.2",
+        "@stitches/core": "^1.2.8",
+        "anser": "^2.3.5",
+        "buffer": "^6.0.3",
+        "class-variance-authority": "^0.7.0",
+        "clean-set": "^1.1.2",
+        "clsx": "^2.1.0",
+        "dequal": "^2.0.3",
+        "escape-carriage": "^1.3.1",
+        "highlight.js": "^11.9.0",
+        "lucide-react": "^0.554.0",
+        "lz-string": "^1.5.0",
+        "mime-db": "^1.54.0",
+        "outvariant": "^1.4.3",
+        "react-devtools-inline": "^7.0.1",
+        "react-is": "^19.2.4",
+        "react-markdown": "^9.0.1",
+        "rehype-highlight": "^7.0.0",
+        "remark-gfm": "^4.0.0",
+        "static-browser-server": "^1.1.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "tailwindcss": "^3.4.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -645,6 +706,10 @@
       "resolved": "../isA_App_SDK/packages/transport",
       "link": true
     },
+    "node_modules/@isa/ui-web": {
+      "resolved": "../isA_App_SDK/packages/ui-web",
+      "link": true
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -924,6 +989,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1450,7 +1531,6 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1517,7 +1597,6 @@
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
       "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.1",
         "@typescript-eslint/types": "8.39.1",
@@ -2203,7 +2282,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2621,7 +2699,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -3386,7 +3463,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3542,7 +3618,6 @@
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6480,6 +6555,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6506,7 +6628,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6654,7 +6775,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6666,7 +6786,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7685,7 +7804,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7885,7 +8003,6 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "export": "next export",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@isa/core": "file:../isA_App_SDK/packages/core",
@@ -37,6 +39,7 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@vitest/coverage-v8": "^4.0.18",
     "vitest": "^2.1.9"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:4100',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    port: 4100,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/tests/e2e/mate-chat.spec.ts
+++ b/tests/e2e/mate-chat.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * L5 Smoke Tests — isA_Mate chat integration.
+ *
+ * Tests the Mate SSE endpoint directly to verify the backend is
+ * reachable and returns valid events.
+ *
+ * These tests SKIP automatically when Mate is not running.
+ *
+ * Prerequisites: isA_Mate running on localhost:18789
+ *   Start with: cd isA_Mate && bash deployment/local-dev.sh
+ */
+
+// Use 127.0.0.1 explicitly — Mate binds to IPv4
+const MATE_URL = process.env.NEXT_PUBLIC_MATE_URL || 'http://127.0.0.1:18789';
+
+// Check if Mate is available before running tests
+let mateAvailable = false;
+
+test.beforeAll(async ({ request }) => {
+  try {
+    const response = await request.get(`${MATE_URL}/health`, { timeout: 3000 });
+    mateAvailable = response.ok();
+  } catch {
+    mateAvailable = false;
+  }
+});
+
+test.describe('Mate backend health', () => {
+  test('Mate service is reachable', async ({ request }) => {
+    test.skip(!mateAvailable, 'isA_Mate not running — start with: cd isA_Mate && bash deployment/local-dev.sh');
+
+    const response = await request.get(`${MATE_URL}/health`);
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.json();
+    expect(body.status).toBe('ok');
+    expect(body.service).toBe('isa-mate');
+    expect(body.initialized).toBe(true);
+  });
+
+  test('Mate lists available tools', async ({ request }) => {
+    test.skip(!mateAvailable, 'isA_Mate not running');
+
+    const response = await request.get(`${MATE_URL}/v1/tools`);
+    expect(response.ok()).toBeTruthy();
+
+    const tools = await response.json();
+    expect(Array.isArray(tools)).toBe(true);
+    expect(tools.length).toBeGreaterThan(0);
+  });
+});
+
+test.describe('Mate chat endpoint', () => {
+  test('POST /v1/query returns text response', async ({ request }) => {
+    test.skip(!mateAvailable, 'isA_Mate not running');
+
+    const response = await request.post(`${MATE_URL}/v1/query`, {
+      data: { prompt: 'Say exactly: test-ok' },
+      timeout: 60_000,
+    });
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.json();
+    expect(body.text).toBeTruthy();
+    expect(body.session_id).toBeTruthy();
+  });
+
+  test('POST /v1/chat returns SSE stream', async ({ request }) => {
+    test.skip(!mateAvailable, 'isA_Mate not running');
+
+    const response = await request.post(`${MATE_URL}/v1/chat`, {
+      data: { prompt: 'Say exactly: stream-ok' },
+      headers: { Accept: 'text/event-stream' },
+      timeout: 60_000,
+    });
+    expect(response.ok()).toBeTruthy();
+
+    const text = await response.text();
+    // Verify SSE format — should contain event types
+    expect(text).toContain('event:');
+    expect(text).toContain('data:');
+    // Should have session_start event
+    expect(text).toContain('session_start');
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * L5 Smoke Tests — Critical user paths for isA_ platform.
+ *
+ * These verify that the app loads, marketing pages render,
+ * navigation works, and key UI elements are present.
+ *
+ * Prerequisites: `npm run dev` on port 4100 (auto-started by playwright.config.ts)
+ */
+
+test.describe('Marketing pages', () => {
+  test('homepage loads with hero section', async ({ page }) => {
+    await page.goto('/home');
+    // Marketing home should render
+    await expect(page.locator('.marketing-home')).toBeVisible({ timeout: 10_000 });
+    // Hero section with headline (split across two h1 elements)
+    await expect(page.locator('.marketing-hero h1').nth(1)).toContainText(/AI Assistant/i);
+  });
+
+  test('homepage has customer and developer CTAs', async ({ page }) => {
+    await page.goto('/home');
+    await expect(page.locator('.marketing-home')).toBeVisible({ timeout: 10_000 });
+
+    // Customer CTA
+    const tryCta = page.locator('a', { hasText: /Start Free Trial/i }).first();
+    await expect(tryCta).toBeVisible();
+
+    // Developer CTA
+    const devCta = page.locator('a', { hasText: /Developer Docs/i }).first();
+    await expect(devCta).toBeVisible();
+  });
+
+  test('pricing page loads', async ({ page }) => {
+    await page.goto('/pricing');
+    await expect(page.locator('.pricing-page')).toBeVisible({ timeout: 10_000 });
+    // Should have pricing plan headings
+    await expect(page.getByRole('heading', { name: /Free/i }).first()).toBeVisible();
+  });
+
+  test('enterprise page loads', async ({ page }) => {
+    await page.goto('/enterprise');
+    // Should have enterprise heading
+    await expect(page.getByRole('heading', { name: /Enterprise/i }).first()).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe('App page', () => {
+  test('/app route loads without crash', async ({ page }) => {
+    await page.goto('/app');
+    // The app page should load (may show auth wall or chat UI)
+    // Just verify no error page / blank screen
+    await page.waitForLoadState('networkidle');
+    const body = page.locator('body');
+    await expect(body).not.toBeEmpty();
+  });
+});
+
+test.describe('Navigation links', () => {
+  test('CTA section has "Build with isA" link to console', async ({ page }) => {
+    await page.goto('/home');
+    await expect(page.locator('.marketing-home')).toBeVisible({ timeout: 10_000 });
+
+    const buildCta = page.locator('a', { hasText: /Build with isA/i });
+    if (await buildCta.isVisible()) {
+      const href = await buildCta.getAttribute('href');
+      expect(href).toContain('/console');
+    }
+  });
+
+  test('pricing page has developer docs link', async ({ page }) => {
+    await page.goto('/pricing');
+    await expect(page.locator('.pricing-page')).toBeVisible({ timeout: 10_000 });
+
+    const docsLink = page.locator('a', { hasText: /Developer Docs/i });
+    if (await docsLink.isVisible()) {
+      const href = await docsLink.getAttribute('href');
+      expect(href).toContain('/docs');
+    }
+  });
+});


### PR DESCRIPTION
Add Playwright E2E smoke tests. 7 smoke tests (marketing pages, CTAs, nav links) + 4 Mate integration tests (auto-skip when Mate not running). 173 unit tests + 7 E2E pass. Fixes #62. Related to #9.