### PR TITLE
test(api): add L2 component tests for all 6 API services (#55-60)

### DIFF
--- a/src/api/__tests__/BaseApiService.test.ts
+++ b/src/api/__tests__/BaseApiService.test.ts
@@ -1,0 +1,483 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { BaseApiService } from '../BaseApiService';
+import type { ApiResponse } from '../BaseApiService';
+
+// Hoisted mock references — vi.hoisted runs before vi.mock hoisting
+const {
+  mockRequest,
+  mockPost,
+  mockInterceptors,
+  mockDefaults,
+  mockCreate,
+  mockIsAxiosError,
+} = vi.hoisted(() => {
+  const mockRequest = vi.fn();
+  const mockPost = vi.fn();
+  const mockInterceptors = {
+    request: { use: vi.fn() },
+    response: { use: vi.fn() },
+  };
+  const mockDefaults = { headers: { common: {} as Record<string, string> } };
+  const mockCreate = vi.fn().mockReturnValue({
+    request: mockRequest,
+    post: mockPost,
+    interceptors: mockInterceptors,
+    defaults: mockDefaults,
+  });
+  const mockIsAxiosError = vi.fn();
+  return { mockRequest, mockPost, mockInterceptors, mockDefaults, mockCreate, mockIsAxiosError };
+});
+
+// Mock axios
+vi.mock('axios', () => ({
+  default: {
+    create: mockCreate,
+    isAxiosError: mockIsAxiosError,
+  },
+}));
+
+// Mock config
+vi.mock('../../config', () => ({
+  config: {
+    api: {
+      baseUrl: 'http://localhost:3000',
+      timeout: 30000,
+    },
+    externalApis: {
+      userServiceUrl: 'http://localhost:3001',
+      aiServiceUrl: 'http://localhost:3002',
+      imageServiceUrl: 'http://localhost:3003',
+      contentServiceUrl: 'http://localhost:3004',
+    },
+  },
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  LogCategory: {
+    API_REQUEST: 'api_request',
+  },
+}));
+
+describe('BaseApiService', () => {
+  let service: BaseApiService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset common headers between tests
+    mockDefaults.headers.common = {};
+    // Restore mockCreate to return a fresh-looking instance with shared refs
+    mockCreate.mockReturnValue({
+      request: mockRequest,
+      post: mockPost,
+      interceptors: mockInterceptors,
+      defaults: mockDefaults,
+    });
+    service = new BaseApiService();
+  });
+
+  // ============================================================================
+  // Constructor
+  // ============================================================================
+
+  describe('constructor', () => {
+    test('uses config defaults when no arguments provided', () => {
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'http://localhost:3000',
+          timeout: 30000,
+        })
+      );
+    });
+
+    test('uses custom baseUrl and timeout when provided', () => {
+      new BaseApiService('http://custom:5000', 5000);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'http://custom:5000',
+          timeout: 5000,
+        })
+      );
+    });
+
+    test('sets default Content-Type and Accept headers', () => {
+      const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0];
+
+      expect(lastCall.headers).toEqual(
+        expect.objectContaining({
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        })
+      );
+    });
+
+    test('sets up axios interceptors', () => {
+      expect(mockInterceptors.request.use).toHaveBeenCalled();
+      expect(mockInterceptors.response.use).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // HTTP convenience methods
+  // ============================================================================
+
+  describe('get', () => {
+    test('sends a GET request to the endpoint', async () => {
+      mockRequest.mockResolvedValue({
+        data: { id: 1 },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await service.get('/users/1');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ id: 1 });
+      expect(result.statusCode).toBe(200);
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/users/1',
+          method: 'get',
+        })
+      );
+    });
+  });
+
+  describe('post', () => {
+    test('sends a POST request with body', async () => {
+      mockRequest.mockResolvedValue({
+        data: { id: 2, name: 'Alice' },
+        status: 201,
+        headers: {},
+      });
+
+      const result = await service.post('/users', { name: 'Alice' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ id: 2, name: 'Alice' });
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/users',
+          method: 'post',
+          data: { name: 'Alice' },
+        })
+      );
+    });
+  });
+
+  describe('put', () => {
+    test('sends a PUT request with body', async () => {
+      mockRequest.mockResolvedValue({
+        data: { id: 1, name: 'Bob' },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await service.put('/users/1', { name: 'Bob' });
+
+      expect(result.success).toBe(true);
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/users/1',
+          method: 'put',
+          data: { name: 'Bob' },
+        })
+      );
+    });
+  });
+
+  describe('delete', () => {
+    test('sends a DELETE request', async () => {
+      mockRequest.mockResolvedValue({
+        data: null,
+        status: 204,
+        headers: {},
+      });
+
+      const result = await service.delete('/users/1');
+
+      expect(result.success).toBe(true);
+      expect(result.statusCode).toBe(204);
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/users/1',
+          method: 'delete',
+        })
+      );
+    });
+  });
+
+  describe('patch', () => {
+    test('sends a PATCH request with body', async () => {
+      mockRequest.mockResolvedValue({
+        data: { id: 1, active: false },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await service.patch('/users/1', { active: false });
+
+      expect(result.success).toBe(true);
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/users/1',
+          method: 'patch',
+          data: { active: false },
+        })
+      );
+    });
+  });
+
+  // ============================================================================
+  // Auth header injection
+  // ============================================================================
+
+  describe('setAuthToken', () => {
+    test('sets Bearer authorization header by default', () => {
+      service.setAuthToken('my-token');
+
+      expect(mockDefaults.headers.common['Authorization']).toBe('Bearer my-token');
+    });
+
+    test('supports API-Key auth type', () => {
+      service.setAuthToken('key-123', 'API-Key');
+
+      expect(mockDefaults.headers.common['Authorization']).toBe('API-Key key-123');
+    });
+
+    test('supports Basic auth type', () => {
+      service.setAuthToken('base64creds', 'Basic');
+
+      expect(mockDefaults.headers.common['Authorization']).toBe('Basic base64creds');
+    });
+
+    test('auth token is included in subsequent requests', async () => {
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      service.setAuthToken('req-token');
+      await service.get('/protected');
+
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers).toEqual(
+        expect.objectContaining({
+          Authorization: 'Bearer req-token',
+        })
+      );
+    });
+  });
+
+  describe('clearAuth', () => {
+    test('removes authorization header', () => {
+      service.setAuthToken('temp-token');
+      service.clearAuth();
+
+      expect(mockDefaults.headers.common['Authorization']).toBeUndefined();
+    });
+
+    test('auth header is absent after clearing', async () => {
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      service.setAuthToken('temp-token');
+      service.clearAuth();
+      await service.get('/public');
+
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers['Authorization']).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // Custom header management
+  // ============================================================================
+
+  describe('setHeader', () => {
+    test('adds a custom header', () => {
+      service.setHeader('X-Custom', 'value-1');
+
+      expect(mockDefaults.headers.common['X-Custom']).toBe('value-1');
+    });
+
+    test('custom header is included in subsequent requests', async () => {
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      service.setHeader('X-Request-Id', 'abc-123');
+      await service.get('/resource');
+
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers['X-Request-Id']).toBe('abc-123');
+    });
+  });
+
+  describe('removeHeader', () => {
+    test('removes a previously set custom header', () => {
+      service.setHeader('X-Temp', 'remove-me');
+      service.removeHeader('X-Temp');
+
+      expect(mockDefaults.headers.common['X-Temp']).toBeUndefined();
+    });
+
+    test('header is absent from requests after removal', async () => {
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      service.setHeader('X-Temp', 'remove-me');
+      service.removeHeader('X-Temp');
+      await service.get('/resource');
+
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers['X-Temp']).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // Error handling
+  // ============================================================================
+
+  describe('error handling', () => {
+    test('handles network errors gracefully', async () => {
+      const networkError = new Error('Network Error');
+      mockRequest.mockRejectedValue(networkError);
+      mockIsAxiosError.mockReturnValue(false);
+
+      const result = await service.get('/unreachable', { retries: 0 });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network Error');
+    });
+
+    test('handles timeout errors', async () => {
+      const timeoutError = new Error('timeout of 30000ms exceeded');
+      (timeoutError as any).code = 'ECONNABORTED';
+      mockRequest.mockRejectedValue(timeoutError);
+      mockIsAxiosError.mockReturnValue(false);
+
+      const result = await service.get('/slow-endpoint', { retries: 0 });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('timeout');
+    });
+
+    test('handles 4xx client errors via axios error', async () => {
+      const axiosError = new Error('Request failed with status code 404');
+      (axiosError as any).response = { status: 404, data: 'Not Found' };
+      mockRequest.mockRejectedValue(axiosError);
+      mockIsAxiosError.mockReturnValue(true);
+
+      const result = await service.get('/missing', { retries: 0 });
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(404);
+      expect(result.error).toContain('404');
+    });
+
+    test('handles 5xx server errors via axios error', async () => {
+      const axiosError = new Error('Request failed with status code 500');
+      (axiosError as any).response = { status: 500, data: 'Internal Server Error' };
+      mockRequest.mockRejectedValue(axiosError);
+      mockIsAxiosError.mockReturnValue(true);
+
+      const result = await service.get('/broken', { retries: 0 });
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(500);
+    });
+
+    test('returns timestamp on error responses', async () => {
+      mockRequest.mockRejectedValue(new Error('fail'));
+      mockIsAxiosError.mockReturnValue(false);
+
+      const result = await service.get('/fail', { retries: 0 });
+
+      expect(result.timestamp).toBeDefined();
+      expect(typeof result.timestamp).toBe('string');
+    });
+  });
+
+  // ============================================================================
+  // Request cancellation
+  // ============================================================================
+
+  describe('cancelRequest', () => {
+    test('cancels all requests when no requestId is provided', () => {
+      expect(() => service.cancelRequest()).not.toThrow();
+    });
+
+    test('cancels a specific request by id when provided', () => {
+      expect(() => service.cancelRequest('non-existent-id')).not.toThrow();
+    });
+  });
+
+  // ============================================================================
+  // Response format
+  // ============================================================================
+
+  describe('response format', () => {
+    test('successful response includes all expected fields', async () => {
+      mockRequest.mockResolvedValue({
+        data: { items: [] },
+        status: 200,
+        headers: { 'x-request-id': 'abc' },
+      });
+
+      const result = await service.get('/items');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          data: { items: [] },
+          statusCode: 200,
+          timestamp: expect.any(String),
+        })
+      );
+      expect(result.headers).toBeDefined();
+    });
+  });
+
+  // ============================================================================
+  // getAuthHeaders callback
+  // ============================================================================
+
+  describe('getAuthHeaders callback', () => {
+    test('injects auth headers from callback into requests', async () => {
+      const authFn = vi.fn().mockResolvedValue({ Authorization: 'Bearer dynamic-token' });
+      const authedService = new BaseApiService(undefined, undefined, authFn);
+
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      await authedService.get('/secure');
+
+      expect(authFn).toHaveBeenCalled();
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers).toEqual(
+        expect.objectContaining({
+          Authorization: 'Bearer dynamic-token',
+        })
+      );
+    });
+
+    test('proceeds without auth headers when callback throws', async () => {
+      const authFn = vi.fn().mockRejectedValue(new Error('Auth failed'));
+      const authedService = new BaseApiService(undefined, undefined, authFn);
+
+      mockRequest.mockResolvedValue({ data: {}, status: 200, headers: {} });
+
+      const result = await authedService.get('/fallback');
+
+      expect(result.success).toBe(true);
+      const callConfig = mockRequest.mock.calls[0][0];
+      expect(callConfig.headers['Authorization']).toBeUndefined();
+    });
+  });
+});

--- a/src/api/__tests__/ExecutionControlService.test.ts
+++ b/src/api/__tests__/ExecutionControlService.test.ts
@@ -1,0 +1,410 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExecutionControlService } from '../ExecutionControlService';
+
+// Mock BaseApiService
+vi.mock('../BaseApiService', () => ({
+  BaseApiService: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock gatewayConfig
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://localhost:9080',
+  },
+  GATEWAY_ENDPOINTS: {
+    AGENTS: {
+      EXECUTION: {
+        HEALTH: 'http://localhost:9080/agents/api/execution/health',
+        STATUS: 'http://localhost:9080/agents/api/execution/status',
+        HISTORY: 'http://localhost:9080/agents/api/execution/history',
+        ROLLBACK: 'http://localhost:9080/agents/api/execution/rollback',
+        RESUME: 'http://localhost:9080/agents/api/execution/resume',
+        RESUME_STREAM: 'http://localhost:9080/agents/api/execution/resume-stream',
+      },
+    },
+  },
+}));
+
+// Mock authTokenStore
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: {
+    getToken: vi.fn().mockReturnValue('mock-token'),
+  },
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  LogCategory: {
+    CHAT_FLOW: 'chat_flow',
+  },
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ExecutionControlService', () => {
+  let service: ExecutionControlService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    service = new ExecutionControlService();
+  });
+
+  afterEach(() => {
+    service.dispose();
+    vi.useRealTimers();
+  });
+
+  // ============================================================================
+  // getHealth
+  // ============================================================================
+
+  describe('getHealth', () => {
+    test('returns health data on success', async () => {
+      const healthData = {
+        status: 'healthy',
+        service: 'execution-control',
+        features: {
+          human_in_loop: true,
+          approval_workflow: true,
+          tool_authorization: true,
+          total_interrupts: 5,
+        },
+        graph_info: {
+          nodes: 10,
+          durable: true,
+          checkpoints: true,
+          environment: 'development',
+        },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(healthData),
+      });
+
+      const result = await service.getHealth();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/api/execution/health',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result.status).toBe('healthy');
+      expect(result.features.human_in_loop).toBe(true);
+    });
+
+    test('throws on non-ok response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+
+      await expect(service.getHealth()).rejects.toThrow(
+        'Health check failed: 503 Service Unavailable'
+      );
+    });
+
+    test('throws on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Connection refused'));
+
+      await expect(service.getHealth()).rejects.toThrow('Connection refused');
+    });
+  });
+
+  // ============================================================================
+  // getExecutionStatus
+  // ============================================================================
+
+  describe('getExecutionStatus', () => {
+    test('fetches execution status for a thread', async () => {
+      const statusData = {
+        thread_id: 'thread-1',
+        status: 'running',
+        current_node: 'tool_node',
+        interrupts: [],
+        checkpoints: 3,
+        durable: true,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(statusData),
+      });
+
+      const result = await service.getExecutionStatus('thread-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/api/execution/status/thread-1',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result.thread_id).toBe('thread-1');
+      expect(result.status).toBe('running');
+    });
+
+    test('returns cached status within cache duration', async () => {
+      const statusData = {
+        thread_id: 'thread-1',
+        status: 'running',
+        current_node: 'tool_node',
+        interrupts: [],
+        checkpoints: 3,
+        durable: true,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(statusData),
+      });
+
+      // First call — fetches from network
+      await service.getExecutionStatus('thread-1');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Second call within cache window — should use cache
+      const result = await service.getExecutionStatus('thread-1');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe('running');
+    });
+
+    test('throws on non-ok response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(service.getExecutionStatus('bad-thread')).rejects.toThrow(
+        'Status check failed: 404 Not Found'
+      );
+    });
+  });
+
+  // ============================================================================
+  // getExecutionHistory
+  // ============================================================================
+
+  describe('getExecutionHistory', () => {
+    test('fetches execution history with default limit', async () => {
+      const historyData = {
+        thread_id: 'thread-1',
+        history: [
+          { checkpoint: 'cp-1', node: 'start', timestamp: '2026-01-01T00:00:00Z', state_summary: 'Initial' },
+        ],
+        total: 1,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(historyData),
+      });
+
+      const result = await service.getExecutionHistory('thread-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/api/execution/history/thread-1?limit=50',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result.history).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    test('passes custom limit', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ thread_id: 'thread-1', history: [], total: 0 }),
+      });
+
+      await service.getExecutionHistory('thread-1', 10);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('limit=10'),
+        expect.anything()
+      );
+    });
+
+    test('throws on failure', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      await expect(service.getExecutionHistory('thread-1')).rejects.toThrow(
+        'History retrieval failed: 500 Internal Server Error'
+      );
+    });
+  });
+
+  // ============================================================================
+  // rollbackToCheckpoint
+  // ============================================================================
+
+  describe('rollbackToCheckpoint', () => {
+    test('rolls back to a specific checkpoint', async () => {
+      const rollbackResult = {
+        thread_id: 'thread-1',
+        success: true,
+        checkpoint_id: 'cp-1',
+        message: 'Rollback successful',
+        restored_state: { node: 'start', timestamp: '2026-01-01T00:00:00Z' },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(rollbackResult),
+      });
+
+      const result = await service.rollbackToCheckpoint('thread-1', 'cp-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/api/execution/rollback/thread-1?checkpoint_id=cp-1',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(result.success).toBe(true);
+      expect(result.checkpoint_id).toBe('cp-1');
+    });
+
+    test('throws on rollback failure', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+      await expect(
+        service.rollbackToCheckpoint('thread-1', 'bad-cp')
+      ).rejects.toThrow('Rollback failed: 400 Bad Request');
+    });
+  });
+
+  // ============================================================================
+  // resumeExecution
+  // ============================================================================
+
+  describe('resumeExecution', () => {
+    test('resumes execution with action and resume data', async () => {
+      const resumeResult = {
+        success: true,
+        thread_id: 'thread-1',
+        message: 'Execution resumed',
+        next_step: 'tool_node',
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(resumeResult),
+      });
+
+      const request = {
+        thread_id: 'thread-1',
+        action: 'continue' as const,
+        resume_data: { approved: true },
+      };
+      const result = await service.resumeExecution(request);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/api/execution/resume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(request),
+        })
+      );
+      expect(result.success).toBe(true);
+      expect(result.next_step).toBe('tool_node');
+    });
+
+    test('throws on resume failure', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+      });
+
+      await expect(
+        service.resumeExecution({ thread_id: 'thread-1', action: 'continue' })
+      ).rejects.toThrow('Resume execution failed: 409 Conflict');
+    });
+  });
+
+  // ============================================================================
+  // isServiceAvailable
+  // ============================================================================
+
+  describe('isServiceAvailable', () => {
+    test('returns true when health check succeeds', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ status: 'healthy' }),
+      });
+
+      const result = await service.isServiceAvailable();
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false when health check fails', async () => {
+      mockFetch.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await service.isServiceAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // getActiveMonitoringStats
+  // ============================================================================
+
+  describe('getActiveMonitoringStats', () => {
+    test('returns zero counts when no monitoring is active', () => {
+      const stats = service.getActiveMonitoringStats();
+
+      expect(stats.activePollers).toBe(0);
+      expect(stats.cachedStatuses).toBe(0);
+    });
+
+    test('reflects cached statuses after a status fetch', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          thread_id: 'thread-1',
+          status: 'running',
+          current_node: 'node',
+          interrupts: [],
+          checkpoints: 0,
+          durable: false,
+        }),
+      });
+
+      await service.getExecutionStatus('thread-1');
+      const stats = service.getActiveMonitoringStats();
+
+      expect(stats.cachedStatuses).toBe(1);
+    });
+  });
+
+  // ============================================================================
+  // dispose
+  // ============================================================================
+
+  describe('dispose', () => {
+    test('clears all timers and stops monitoring', () => {
+      // Call dispose — should not throw
+      service.dispose();
+
+      const stats = service.getActiveMonitoringStats();
+      expect(stats.activePollers).toBe(0);
+      expect(stats.cachedStatuses).toBe(0);
+    });
+
+    test('is safe to call multiple times', () => {
+      service.dispose();
+      service.dispose();
+
+      expect(service.getActiveMonitoringStats().activePollers).toBe(0);
+    });
+  });
+});

--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -1,0 +1,688 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ChatService } from '../chatService';
+import type { ChatServiceCallbacks } from '../chatService';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockConnection = {
+  stream: vi.fn(),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockTransport = {
+  connect: vi.fn().mockResolvedValue(mockConnection),
+};
+
+vi.mock('../transport/SSETransport', () => ({
+  createSSETransport: vi.fn(() => mockTransport),
+}));
+
+const mockParser = {
+  parse: vi.fn(),
+};
+
+vi.mock('../parsing/AGUIEventParser', () => ({
+  createAGUIEventParser: vi.fn(() => mockParser),
+}));
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    AGENTS: {
+      CHAT: 'http://localhost:9080/agents/chat',
+    },
+    MATE: {
+      CHAT: 'http://localhost:9080/mate/v1/chat',
+    },
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  LogCategory: {
+    CHAT_FLOW: 'chat_flow',
+  },
+}));
+
+const mockBuildMateRequest = vi.fn();
+const mockCreateMateStreamContext = vi.fn();
+const mockAdaptMateEvent = vi.fn();
+
+vi.mock('../adapters/MateEventAdapter', () => ({
+  buildMateRequest: (...args: any[]) => mockBuildMateRequest(...args),
+  createMateStreamContext: (...args: any[]) => mockCreateMateStreamContext(...args),
+  adaptMateEvent: (...args: any[]) => mockAdaptMateEvent(...args),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Create an async iterable that yields the given chunks then returns. */
+function createAsyncIterable(chunks: string[]): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        async next() {
+          if (i < chunks.length) {
+            return { value: chunks[i++], done: false };
+          }
+          return { value: undefined as any, done: true };
+        },
+      };
+    },
+  };
+}
+
+const defaultMetadata = {
+  user_id: 'user-1',
+  session_id: 'session-1',
+  prompt_name: null,
+  prompt_args: {},
+  proactive_enabled: false,
+  collaborative_enabled: false,
+  confidence_threshold: 0.7,
+  proactive_predictions: null,
+};
+
+const defaultToken = 'test-token';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ChatService', () => {
+  let service: ChatService;
+  let callbacks: ChatServiceCallbacks;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ChatService();
+    callbacks = {
+      onStreamStart: vi.fn(),
+      onStreamContent: vi.fn(),
+      onStreamStatus: vi.fn(),
+      onStreamComplete: vi.fn(),
+      onError: vi.fn(),
+      onToolStart: vi.fn(),
+      onToolExecuting: vi.fn(),
+      onToolCompleted: vi.fn(),
+      onLLMCompleted: vi.fn(),
+      onNodeUpdate: vi.fn(),
+      onStateUpdate: vi.fn(),
+      onPaused: vi.fn(),
+      onMemoryUpdate: vi.fn(),
+      onBillingUpdate: vi.fn(),
+      onResumeStart: vi.fn(),
+      onResumeEnd: vi.fn(),
+      onTaskProgress: vi.fn(),
+      onHILInterruptDetected: vi.fn(),
+      onHILCheckpointCreated: vi.fn(),
+      onArtifactCreated: vi.fn(),
+      onArtifactUpdated: vi.fn(),
+    };
+  });
+
+  // ==========================================================================
+  // Constructor
+  // ==========================================================================
+
+  describe('constructor', () => {
+    test('creates a ChatService instance', () => {
+      expect(service).toBeInstanceOf(ChatService);
+    });
+  });
+
+  // ==========================================================================
+  // sendMessage — payload & transport
+  // ==========================================================================
+
+  describe('sendMessage', () => {
+    test('builds correct payload from message and metadata', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessage('Hello', defaultMetadata, defaultToken, callbacks);
+
+      expect(mockTransport.connect).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/chat',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            message: 'Hello',
+            user_id: 'user-1',
+            session_id: 'session-1',
+            prompt_name: null,
+            prompt_args: {},
+            proactive_enabled: false,
+            collaborative_enabled: false,
+            confidence_threshold: 0.7,
+            proactive_predictions: null,
+          }),
+        })
+      );
+    });
+
+    test('sets Authorization header from token', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessage('Hi', defaultMetadata, 'my-jwt', callbacks);
+
+      const connectCall = mockTransport.connect.mock.calls[0];
+      const options = connectCall[1];
+      expect(options.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Authorization': 'Bearer my-jwt',
+      });
+    });
+
+    test('omits Authorization header when token is empty', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessage('Hi', defaultMetadata, '', callbacks);
+
+      const connectCall = mockTransport.connect.mock.calls[0];
+      const options = connectCall[1];
+      expect(options.headers).not.toHaveProperty('Authorization');
+    });
+
+    test('uses AGENTS.CHAT gateway endpoint', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks);
+
+      const { createSSETransport } = await import('../transport/SSETransport');
+      expect(createSSETransport).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'http://localhost:9080/agents/chat' })
+      );
+    });
+
+    test('calls onStreamComplete when [DONE] is received', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks);
+
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+
+    test('applies defaults for optional metadata fields', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      const sparseMetadata = { user_id: 'u1', session_id: 's1' };
+      await service.sendMessage('Hi', sparseMetadata, defaultToken, callbacks);
+
+      const body = JSON.parse(mockTransport.connect.mock.calls[0][1].body);
+      expect(body.prompt_name).toBeNull();
+      expect(body.prompt_args).toEqual({});
+      expect(body.proactive_enabled).toBe(false);
+      expect(body.collaborative_enabled).toBe(false);
+      expect(body.confidence_threshold).toBe(0.7);
+      expect(body.proactive_predictions).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // handleAGUIEvent (via sendMessage stream)
+  // ==========================================================================
+
+  describe('handleAGUIEvent routing', () => {
+    /**
+     * Helper: stream a single JSON event through the service.
+     * The parser mock returns the given aguiEvent so handleAGUIEvent runs.
+     */
+    async function streamEvent(aguiEvent: any): Promise<void> {
+      const rawPayload = JSON.stringify({ type: aguiEvent.type });
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable([
+          `data: ${rawPayload}`,
+          'data: [DONE]',
+        ])
+      );
+      mockParser.parse.mockReturnValueOnce(aguiEvent);
+      await service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks);
+    }
+
+    test('run_started → onStreamStart', async () => {
+      await streamEvent({ type: 'run_started', message_id: 'msg-1' });
+      expect(callbacks.onStreamStart).toHaveBeenCalledWith('msg-1', 'Starting...');
+    });
+
+    test('text_message_content → onStreamContent', async () => {
+      await streamEvent({ type: 'text_message_content', delta: 'chunk' });
+      expect(callbacks.onStreamContent).toHaveBeenCalledWith('chunk');
+    });
+
+    test('text_delta → onStreamContent', async () => {
+      await streamEvent({ type: 'text_delta', delta: 'piece' });
+      expect(callbacks.onStreamContent).toHaveBeenCalledWith('piece');
+    });
+
+    test('tool_call_start → onToolStart', async () => {
+      await streamEvent({
+        type: 'tool_call_start',
+        tool_name: 'search',
+        tool_call_id: 'tc-1',
+        parameters: { q: 'test' },
+      });
+      expect(callbacks.onToolStart).toHaveBeenCalledWith('search', 'tc-1', { q: 'test' });
+    });
+
+    test('tool_executing → onToolExecuting', async () => {
+      await streamEvent({
+        type: 'tool_executing',
+        tool_name: 'search',
+        status: 'running',
+        progress: 50,
+      });
+      expect(callbacks.onToolExecuting).toHaveBeenCalledWith('search', 'running', 50);
+    });
+
+    test('tool_call_end → onToolCompleted', async () => {
+      await streamEvent({
+        type: 'tool_call_end',
+        tool_name: 'search',
+        result: { data: [] },
+        error: undefined,
+        duration_ms: 120,
+      });
+      expect(callbacks.onToolCompleted).toHaveBeenCalledWith('search', { data: [] }, undefined, 120);
+    });
+
+    test('run_finished → onStreamComplete', async () => {
+      await streamEvent({ type: 'run_finished', content: 'final' });
+      expect(callbacks.onStreamComplete).toHaveBeenCalledWith('final');
+    });
+
+    test('run_error → onError', async () => {
+      await streamEvent({ type: 'run_error', error: { message: 'boom' } });
+      expect(callbacks.onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
+    });
+
+    test('error → onError', async () => {
+      await streamEvent({ type: 'error', message: 'bad request' });
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'bad request' })
+      );
+    });
+
+    test('llm_completed → onLLMCompleted', async () => {
+      await streamEvent({
+        type: 'llm_completed',
+        model: 'gpt-4',
+        token_count: 100,
+        finish_reason: 'stop',
+      });
+      expect(callbacks.onLLMCompleted).toHaveBeenCalledWith('gpt-4', 100, 'stop');
+    });
+
+    test('node_update → onNodeUpdate', async () => {
+      await streamEvent({
+        type: 'node_update',
+        node_name: 'router',
+        status: 'completed',
+        credits: 5,
+        messages_count: 2,
+        data: null,
+      });
+      expect(callbacks.onNodeUpdate).toHaveBeenCalledWith('router', 'completed', {
+        credits: 5,
+        messages_count: 2,
+        data: null,
+      });
+    });
+
+    test('state_update → onStateUpdate', async () => {
+      await streamEvent({ type: 'state_update', state_data: { key: 1 }, node: 'n1' });
+      expect(callbacks.onStateUpdate).toHaveBeenCalledWith({ key: 1 }, 'n1');
+    });
+
+    test('paused → onPaused', async () => {
+      await streamEvent({ type: 'paused', reason: 'approval', checkpoint_id: 'cp-1' });
+      expect(callbacks.onPaused).toHaveBeenCalledWith('approval', 'cp-1');
+    });
+
+    test('memory_update → onMemoryUpdate', async () => {
+      await streamEvent({ type: 'memory_update', memory_data: { facts: [] }, operation: 'add' });
+      expect(callbacks.onMemoryUpdate).toHaveBeenCalledWith({ facts: [] }, 'add');
+    });
+
+    test('billing → onBillingUpdate', async () => {
+      await streamEvent({
+        type: 'billing',
+        credits_remaining: 90,
+        total_credits: 100,
+        model_calls: 5,
+        tool_calls: 3,
+        cost: 0.12,
+      });
+      expect(callbacks.onBillingUpdate).toHaveBeenCalledWith({
+        creditsRemaining: 90,
+        totalCredits: 100,
+        modelCalls: 5,
+        toolCalls: 3,
+        cost: 0.12,
+      });
+    });
+
+    test('resume_start → onResumeStart', async () => {
+      await streamEvent({ type: 'resume_start', resumed_from: 'step-2', checkpoint_id: 'cp-2' });
+      expect(callbacks.onResumeStart).toHaveBeenCalledWith('step-2', 'cp-2');
+    });
+
+    test('resume_end → onResumeEnd', async () => {
+      await streamEvent({ type: 'resume_end', success: true, result: 'ok' });
+      expect(callbacks.onResumeEnd).toHaveBeenCalledWith(true, 'ok');
+    });
+
+    test('task_progress_update → onTaskProgress', async () => {
+      const task = { id: 't1', progress: 80 };
+      await streamEvent({ type: 'task_progress_update', task });
+      expect(callbacks.onTaskProgress).toHaveBeenCalledWith(task);
+    });
+
+    test('hil_interrupt_detected → onHILInterruptDetected', async () => {
+      const event = { type: 'hil_interrupt_detected', tool: 'bash' };
+      await streamEvent(event);
+      expect(callbacks.onHILInterruptDetected).toHaveBeenCalledWith(event);
+    });
+
+    test('hil_checkpoint_created → onHILCheckpointCreated', async () => {
+      const event = { type: 'hil_checkpoint_created', checkpoint_id: 'cp-3' };
+      await streamEvent(event);
+      expect(callbacks.onHILCheckpointCreated).toHaveBeenCalledWith(event);
+    });
+
+    test('hil_approval_required → onHILInterruptDetected', async () => {
+      const event = { type: 'hil_approval_required', action: 'file_write' };
+      await streamEvent(event);
+      expect(callbacks.onHILInterruptDetected).toHaveBeenCalledWith(event);
+    });
+
+    test('artifact_created → onArtifactCreated', async () => {
+      const artifact = { id: 'a1', name: 'code.py' };
+      await streamEvent({ type: 'artifact_created', artifact });
+      expect(callbacks.onArtifactCreated).toHaveBeenCalledWith(artifact);
+    });
+
+    test('artifact_updated → onArtifactUpdated', async () => {
+      const artifact = { id: 'a1', name: 'code.py', version: 2 };
+      await streamEvent({ type: 'artifact_updated', artifact });
+      expect(callbacks.onArtifactUpdated).toHaveBeenCalledWith(artifact);
+    });
+
+    test('status_update → onStreamStatus', async () => {
+      await streamEvent({ type: 'status_update', status: 'Thinking...' });
+      expect(callbacks.onStreamStatus).toHaveBeenCalledWith('Thinking...');
+    });
+
+    test('text_message_end → onStreamComplete', async () => {
+      await streamEvent({ type: 'text_message_end', content: 'done' });
+      expect(callbacks.onStreamComplete).toHaveBeenCalledWith('done');
+    });
+
+    test('stream_done → onStreamComplete', async () => {
+      await streamEvent({ type: 'stream_done' });
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // sendMessageViaMate
+  // ==========================================================================
+
+  describe('sendMessageViaMate', () => {
+    const mateMetadata = { session_id: 'mate-session-1' };
+
+    beforeEach(() => {
+      mockBuildMateRequest.mockReturnValue({
+        prompt: 'Hello mate',
+        session_id: 'mate-session-1',
+      });
+      mockCreateMateStreamContext.mockReturnValue({
+        startEvent: { type: 'run_started', message_id: 'mate-run-1' },
+        context: { runId: 'mate-run-1', sessionId: 'mate-session-1', currentMessageId: null },
+      });
+    });
+
+    test('calls buildMateRequest with message and session_id', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessageViaMate('Hello mate', mateMetadata, defaultToken, callbacks);
+
+      expect(mockBuildMateRequest).toHaveBeenCalledWith('Hello mate', 'mate-session-1');
+    });
+
+    test('builds Mate request format with prompt and session_id', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessageViaMate('Hello mate', mateMetadata, defaultToken, callbacks);
+
+      const body = JSON.parse(mockTransport.connect.mock.calls[0][1].body);
+      expect(body).toEqual({ prompt: 'Hello mate', session_id: 'mate-session-1' });
+    });
+
+    test('uses MATE.CHAT gateway endpoint', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
+
+      expect(mockTransport.connect).toHaveBeenCalledWith(
+        'http://localhost:9080/mate/v1/chat',
+        expect.anything()
+      );
+    });
+
+    test('emits synthetic run_started event via createMateStreamContext', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
+
+      expect(mockCreateMateStreamContext).toHaveBeenCalledWith('mate-session-1');
+      expect(callbacks.onStreamStart).toHaveBeenCalledWith('mate-run-1', 'Starting...');
+    });
+
+    test('adapts Mate events via adaptMateEvent', async () => {
+      const mateRaw = { type: 'text', content: 'world' };
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable([
+          `data: ${JSON.stringify(mateRaw)}`,
+          'data: [DONE]',
+        ])
+      );
+      mockAdaptMateEvent.mockReturnValue({
+        events: [{ type: 'text_message_content', delta: 'world' }],
+        updatedContext: { runId: 'mate-run-1', sessionId: 'mate-session-1', currentMessageId: 'mid-1' },
+      });
+
+      await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
+
+      expect(mockAdaptMateEvent).toHaveBeenCalledWith(
+        mateRaw,
+        { runId: 'mate-run-1', sessionId: 'mate-session-1', currentMessageId: null }
+      );
+    });
+
+    test('handles "event: done" SSE format', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['event: done'])
+      );
+
+      await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
+
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // sendMultimodalMessage
+  // ==========================================================================
+
+  describe('sendMultimodalMessage', () => {
+    test('falls back to sendMessage', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.sendMultimodalMessage(
+        'Look at this',
+        defaultMetadata,
+        defaultToken,
+        callbacks,
+        [new File(['content'], 'test.png', { type: 'image/png' })]
+      );
+
+      // Should use AGENTS.CHAT, same as sendMessage
+      expect(mockTransport.connect).toHaveBeenCalledWith(
+        'http://localhost:9080/agents/chat',
+        expect.objectContaining({
+          body: expect.stringContaining('"message":"Look at this"'),
+        })
+      );
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // resumeHIL
+  // ==========================================================================
+
+  describe('resumeHIL', () => {
+    test('delegates to sendMessage', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable(['data: [DONE]'])
+      );
+
+      await service.resumeHIL('approve', defaultMetadata, defaultToken, callbacks);
+
+      const body = JSON.parse(mockTransport.connect.mock.calls[0][1].body);
+      expect(body.message).toBe('approve');
+      expect(body.user_id).toBe('user-1');
+      expect(body.session_id).toBe('session-1');
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Error handling
+  // ==========================================================================
+
+  describe('error handling', () => {
+    test('calls onError when transport.connect throws', async () => {
+      mockTransport.connect.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(
+        service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks)
+      ).rejects.toThrow('Connection refused');
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Connection refused' })
+      );
+    });
+
+    test('calls onError when stream throws a non-abort error', async () => {
+      const streamError = new Error('Network failure');
+      mockConnection.stream.mockReturnValue({
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              throw streamError;
+            },
+          };
+        },
+      });
+
+      await expect(
+        service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks)
+      ).rejects.toThrow('Network failure');
+
+      expect(callbacks.onError).toHaveBeenCalledWith(streamError);
+      expect(mockConnection.close).toHaveBeenCalled();
+    });
+
+    test('does not call onError on AbortError', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockConnection.stream.mockReturnValue({
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              throw abortError;
+            },
+          };
+        },
+      });
+
+      // AbortError is silently handled — the promise never resolves or rejects
+      // via handleError, so we race with a timeout
+      const result = await Promise.race([
+        service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks).catch(() => 'rejected'),
+        new Promise((r) => setTimeout(() => r('timeout'), 100)),
+      ]);
+
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    test('calls onError callback for Mate connection failure', async () => {
+      mockBuildMateRequest.mockReturnValue({ prompt: 'Hi', session_id: 's1' });
+      mockCreateMateStreamContext.mockReturnValue({
+        startEvent: { type: 'run_started', message_id: 'r1' },
+        context: { runId: 'r1', sessionId: 's1', currentMessageId: null },
+      });
+      mockTransport.connect.mockRejectedValueOnce(new Error('Mate down'));
+
+      await expect(
+        service.sendMessageViaMate('Hi', { session_id: 's1' }, defaultToken, callbacks)
+      ).rejects.toThrow('Mate down');
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Mate down' })
+      );
+    });
+
+    test('skips unparseable SSE data lines gracefully', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable([
+          'data: not-valid-json',
+          'data: [DONE]',
+        ])
+      );
+      mockParser.parse.mockImplementation(() => {
+        throw new Error('parse error');
+      });
+
+      await service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks);
+
+      // Should complete without throwing; onError should NOT be called for parse errors
+      expect(callbacks.onStreamComplete).toHaveBeenCalled();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/__tests__/sessionService.test.ts
+++ b/src/api/__tests__/sessionService.test.ts
@@ -1,0 +1,401 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { SessionService } from '../sessionService';
+
+// Mock @isa/core
+const mockCreateSession = vi.fn();
+const mockGetSession = vi.fn();
+const mockGetUserSessions = vi.fn();
+const mockUpdateSession = vi.fn();
+const mockEndSession = vi.fn();
+const mockGetSessionMessages = vi.fn();
+const mockAddMessage = vi.fn();
+const mockSetAuthToken = vi.fn();
+const mockClearAuth = vi.fn();
+
+vi.mock('@isa/core', () => ({
+  SessionService: vi.fn().mockImplementation(() => ({
+    createSession: mockCreateSession,
+    getSession: mockGetSession,
+    getUserSessions: mockGetUserSessions,
+    updateSession: mockUpdateSession,
+    endSession: mockEndSession,
+    getSessionMessages: mockGetSessionMessages,
+    addMessage: mockAddMessage,
+    setAuthToken: mockSetAuthToken,
+    clearAuth: mockClearAuth,
+  })),
+  BaseApiService: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock gatewayConfig
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://localhost:9080',
+  },
+  GATEWAY_ENDPOINTS: {
+    SESSIONS: {
+      BASE: 'http://localhost:9080/sessions',
+      HEALTH: 'http://localhost:9080/sessions/health',
+    },
+  },
+  getAuthHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-token' }),
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  LogCategory: {
+    API_REQUEST: 'api_request',
+  },
+}));
+
+// Mock global fetch for healthCheck
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('SessionService', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+  });
+
+  // ============================================================================
+  // createSession
+  // ============================================================================
+
+  describe('createSession', () => {
+    test('creates a session with required user_id', async () => {
+      const mockSession = {
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+      };
+      mockCreateSession.mockResolvedValue(mockSession);
+
+      const result = await service.createSession({ user_id: 'user-1' });
+
+      expect(mockCreateSession).toHaveBeenCalledWith({
+        user_id: 'user-1',
+        title: expect.stringContaining('Session'),
+        conversation_data: {},
+        metadata: {},
+      });
+      expect(result.session_id).toBe('sess-1');
+      expect(result.user_id).toBe('user-1');
+    });
+
+    test('passes name as title and context as conversation_data', async () => {
+      mockCreateSession.mockResolvedValue({
+        session_id: 'sess-2',
+        user_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+      });
+
+      await service.createSession({
+        user_id: 'user-1',
+        name: 'My Session',
+        context: { topic: 'test' },
+      });
+
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'My Session',
+          conversation_data: { topic: 'test' },
+        })
+      );
+    });
+
+    test('throws when user_id is missing', async () => {
+      await expect(
+        service.createSession({ user_id: '' })
+      ).rejects.toThrow('user_id is required to create a session');
+    });
+
+    test('throws when core SDK rejects', async () => {
+      mockCreateSession.mockRejectedValue(new Error('SDK error'));
+
+      await expect(
+        service.createSession({ user_id: 'user-1' })
+      ).rejects.toThrow('SDK error');
+    });
+  });
+
+  // ============================================================================
+  // getSession
+  // ============================================================================
+
+  describe('getSession', () => {
+    test('retrieves a session by ID', async () => {
+      const mockSession = {
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        status: 'active',
+        metadata: { topic: 'chat' },
+      };
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const result = await service.getSession('sess-1');
+
+      expect(mockGetSession).toHaveBeenCalledWith('sess-1');
+      expect(result.session_id).toBe('sess-1');
+      expect(result.status).toBe('active');
+    });
+
+    test('throws when session not found', async () => {
+      mockGetSession.mockRejectedValue(new Error('Not found'));
+
+      await expect(service.getSession('bad-id')).rejects.toThrow('Not found');
+    });
+  });
+
+  // ============================================================================
+  // getUserSessions
+  // ============================================================================
+
+  describe('getUserSessions', () => {
+    test('retrieves sessions for a user with default pagination', async () => {
+      const mockResponse = {
+        sessions: [{ session_id: 'sess-1' }],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      };
+      mockGetUserSessions.mockResolvedValue(mockResponse);
+
+      const result = await service.getUserSessions('user-1');
+
+      expect(mockGetUserSessions).toHaveBeenCalledWith('user-1', {
+        page: 1,
+        pageSize: 20,
+      });
+      expect(result.sessions).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    test('calculates page from offset and limit', async () => {
+      mockGetUserSessions.mockResolvedValue({
+        sessions: [],
+        total: 50,
+        page: 3,
+        page_size: 10,
+      });
+
+      await service.getUserSessions('user-1', { limit: 10, offset: 20 });
+
+      expect(mockGetUserSessions).toHaveBeenCalledWith('user-1', {
+        page: 3,
+        pageSize: 10,
+      });
+    });
+
+    test('computes has_more correctly', async () => {
+      mockGetUserSessions.mockResolvedValue({
+        sessions: [{ session_id: 'sess-1' }],
+        total: 50,
+        page: 1,
+        page_size: 10,
+      });
+
+      const result = await service.getUserSessions('user-1', { limit: 10 });
+
+      expect(result.has_more).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // updateSession
+  // ============================================================================
+
+  describe('updateSession', () => {
+    test('updates session with metadata, title, and tags', async () => {
+      const mockSession = {
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        updated_at: '2026-01-02T00:00:00Z',
+        metadata: { title: 'New Title', tags: ['tag1'] },
+      };
+      mockUpdateSession.mockResolvedValue(mockSession);
+
+      const result = await service.updateSession('sess-1', {
+        title: 'New Title',
+        tags: ['tag1'],
+        context: { key: 'value' },
+      });
+
+      expect(mockUpdateSession).toHaveBeenCalledWith('sess-1', {
+        metadata: { title: 'New Title', tags: ['tag1'] },
+        conversation_data: { key: 'value' },
+      });
+      expect(result.session_id).toBe('sess-1');
+    });
+
+    test('throws when update fails', async () => {
+      mockUpdateSession.mockRejectedValue(new Error('Update failed'));
+
+      await expect(
+        service.updateSession('sess-1', {})
+      ).rejects.toThrow('Update failed');
+    });
+  });
+
+  // ============================================================================
+  // deleteSession
+  // ============================================================================
+
+  describe('deleteSession', () => {
+    test('ends the session and returns success', async () => {
+      mockEndSession.mockResolvedValue(undefined);
+
+      const result = await service.deleteSession('sess-1');
+
+      expect(mockEndSession).toHaveBeenCalledWith('sess-1');
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Session ended successfully');
+    });
+
+    test('throws when delete fails', async () => {
+      mockEndSession.mockRejectedValue(new Error('Delete error'));
+
+      await expect(service.deleteSession('sess-1')).rejects.toThrow('Delete error');
+    });
+  });
+
+  // ============================================================================
+  // searchSessions
+  // ============================================================================
+
+  describe('searchSessions', () => {
+    test('returns empty when no user_id provided', async () => {
+      const result = await service.searchSessions({});
+
+      expect(result.sessions).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    test('fetches user sessions and filters by query', async () => {
+      mockGetUserSessions.mockResolvedValue({
+        sessions: [
+          { session_id: 's1', title: 'AI Chat', metadata: {} },
+          { session_id: 's2', title: 'Bug Report', metadata: {} },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 50,
+      });
+
+      const result = await service.searchSessions({
+        user_id: 'user-1',
+        query: 'ai',
+      });
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    test('returns all sessions when no query filter', async () => {
+      mockGetUserSessions.mockResolvedValue({
+        sessions: [{ session_id: 's1', title: 'Chat' }],
+        total: 1,
+        page: 1,
+        page_size: 50,
+      });
+
+      const result = await service.searchSessions({ user_id: 'user-1' });
+
+      expect(result.sessions).toHaveLength(1);
+    });
+  });
+
+  // ============================================================================
+  // exportSession
+  // ============================================================================
+
+  describe('exportSession', () => {
+    test('exports session in JSON format', async () => {
+      mockGetSession.mockResolvedValue({
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+      });
+      mockGetSessionMessages.mockResolvedValue({
+        messages: [{ content: 'Hello' }],
+      });
+
+      const result = await service.exportSession('sess-1', 'json');
+
+      expect(result.format).toBe('json');
+      expect(typeof result.data).toBe('string');
+      expect(result.filename).toContain('session_sess-1_');
+      expect(result.filename).toMatch(/\.json$/);
+    });
+
+    test('exports session in non-JSON format as object', async () => {
+      mockGetSession.mockResolvedValue({
+        session_id: 'sess-1',
+        user_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+      });
+      mockGetSessionMessages.mockResolvedValue({ messages: [] });
+
+      const result = await service.exportSession('sess-1', 'csv');
+
+      expect(result.format).toBe('csv');
+      expect(typeof result.data).toBe('object');
+    });
+
+    test('throws when session retrieval fails', async () => {
+      mockGetSession.mockRejectedValue(new Error('Not found'));
+
+      await expect(service.exportSession('bad-id')).rejects.toThrow('Not found');
+    });
+  });
+
+  // ============================================================================
+  // healthCheck
+  // ============================================================================
+
+  describe('healthCheck', () => {
+    test('returns healthy status on success', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      const result = await service.healthCheck();
+
+      expect(result.status).toBe('healthy');
+      expect(result.service).toBe('SessionService');
+      expect(result.timestamp).toBeDefined();
+    });
+
+    test('returns unhealthy status on fetch failure', async () => {
+      mockFetch.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await service.healthCheck();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.service).toBe('SessionService');
+    });
+
+    test('returns unhealthy status on non-ok response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 503 });
+
+      const result = await service.healthCheck();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.service).toBe('SessionService');
+    });
+  });
+});

--- a/src/api/__tests__/storageService.test.ts
+++ b/src/api/__tests__/storageService.test.ts
@@ -1,0 +1,287 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { StorageService } from '../storageService';
+
+// Mock @isa/core
+const mockUploadFile = vi.fn();
+const mockListFiles = vi.fn();
+const mockGetFileInfo = vi.fn();
+const mockDeleteFile = vi.fn();
+const mockGetQuota = vi.fn();
+const mockHealthCheck = vi.fn();
+const mockSetAuthToken = vi.fn();
+const mockShareFile = vi.fn();
+const mockGetDownloadUrl = vi.fn();
+const mockSemanticSearch = vi.fn();
+const mockRagQuery = vi.fn();
+const mockGetStats = vi.fn();
+
+vi.mock('@isa/core', () => ({
+  StorageService: vi.fn().mockImplementation(() => ({
+    uploadFile: mockUploadFile,
+    listFiles: mockListFiles,
+    getFileInfo: mockGetFileInfo,
+    deleteFile: mockDeleteFile,
+    getQuota: mockGetQuota,
+    healthCheck: mockHealthCheck,
+    setAuthToken: mockSetAuthToken,
+    shareFile: mockShareFile,
+    getDownloadUrl: mockGetDownloadUrl,
+    semanticSearch: mockSemanticSearch,
+    ragQuery: mockRagQuery,
+    getStats: mockGetStats,
+  })),
+  StorageTypes: {},
+}));
+
+// Mock @isa/transport
+vi.mock('@isa/transport', () => ({
+  HttpClient: vi.fn(),
+}));
+
+// Mock gatewayConfig
+vi.mock('../../config/gatewayConfig', () => ({
+  getAuthHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-token' }),
+}));
+
+// Mock runtimeEnv
+vi.mock('../../config/runtimeEnv', () => ({
+  getGatewayUrl: vi.fn().mockReturnValue('http://localhost:9080'),
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  LogCategory: {
+    API_REQUEST: 'api_request',
+  },
+}));
+
+describe('StorageService', () => {
+  let service: StorageService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new StorageService();
+  });
+
+  // ============================================================================
+  // uploadFile
+  // ============================================================================
+
+  describe('uploadFile', () => {
+    test('uploads a File object successfully', async () => {
+      const uploadResponse = {
+        file_id: 'file-1',
+        file_name: 'doc.pdf',
+        file_size: 1024,
+        download_url: 'http://example.com/doc.pdf',
+      };
+      mockUploadFile.mockResolvedValue(uploadResponse);
+
+      const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+      const request = { user_id: 'user-1', access_level: 'private' as const };
+
+      const result = await service.uploadFile(file, request);
+
+      expect(mockUploadFile).toHaveBeenCalledWith(file, 'doc.pdf', request);
+      expect(result.file_id).toBe('file-1');
+    });
+
+    test('uploads a Blob with fallback filename', async () => {
+      mockUploadFile.mockResolvedValue({ file_id: 'file-2', file_size: 512 });
+
+      const blob = new Blob(['data'], { type: 'text/plain' });
+      const request = { user_id: 'user-1' };
+
+      await service.uploadFile(blob, request as any);
+
+      expect(mockUploadFile).toHaveBeenCalledWith(blob, 'upload.bin', request);
+    });
+
+    test('throws when upload fails', async () => {
+      mockUploadFile.mockRejectedValue(new Error('Upload failed'));
+
+      const file = new File(['x'], 'test.txt');
+      await expect(
+        service.uploadFile(file, { user_id: 'user-1' } as any)
+      ).rejects.toThrow('Upload failed');
+    });
+  });
+
+  // ============================================================================
+  // listFiles
+  // ============================================================================
+
+  describe('listFiles', () => {
+    test('lists files for a user', async () => {
+      const files = [
+        { file_id: 'f1', file_name: 'doc.pdf', file_size: 1024 },
+        { file_id: 'f2', file_name: 'img.png', file_size: 2048 },
+      ];
+      mockListFiles.mockResolvedValue(files);
+
+      const result = await service.listFiles({ user_id: 'user-1', limit: 20 } as any);
+
+      expect(mockListFiles).toHaveBeenCalledWith({ user_id: 'user-1', limit: 20 });
+      expect(result).toHaveLength(2);
+      expect(result[0].file_name).toBe('doc.pdf');
+    });
+
+    test('returns empty array when no files exist', async () => {
+      mockListFiles.mockResolvedValue([]);
+
+      const result = await service.listFiles({ user_id: 'user-1' } as any);
+
+      expect(result).toEqual([]);
+    });
+
+    test('throws when listing fails', async () => {
+      mockListFiles.mockRejectedValue(new Error('Unauthorized'));
+
+      await expect(
+        service.listFiles({ user_id: 'user-1' } as any)
+      ).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  // ============================================================================
+  // getFileInfo
+  // ============================================================================
+
+  describe('getFileInfo', () => {
+    test('retrieves file information', async () => {
+      const fileInfo = {
+        file_id: 'file-1',
+        file_name: 'doc.pdf',
+        file_size: 1024,
+        status: 'available',
+      };
+      mockGetFileInfo.mockResolvedValue(fileInfo);
+
+      const result = await service.getFileInfo('file-1', 'user-1');
+
+      expect(mockGetFileInfo).toHaveBeenCalledWith('file-1', 'user-1');
+      expect(result.file_name).toBe('doc.pdf');
+    });
+
+    test('throws when file not found', async () => {
+      mockGetFileInfo.mockRejectedValue(new Error('File not found'));
+
+      await expect(
+        service.getFileInfo('bad-id', 'user-1')
+      ).rejects.toThrow('File not found');
+    });
+  });
+
+  // ============================================================================
+  // deleteFile
+  // ============================================================================
+
+  describe('deleteFile', () => {
+    test('deletes a file successfully', async () => {
+      const deleteResult = { success: true, message: 'File deleted successfully' };
+      mockDeleteFile.mockResolvedValue(deleteResult);
+
+      const result = await service.deleteFile('file-1', 'user-1');
+
+      expect(mockDeleteFile).toHaveBeenCalledWith('file-1', 'user-1');
+      expect(result.success).toBe(true);
+    });
+
+    test('throws when deletion fails', async () => {
+      mockDeleteFile.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(
+        service.deleteFile('file-1', 'user-1')
+      ).rejects.toThrow('Permission denied');
+    });
+  });
+
+  // ============================================================================
+  // getQuota
+  // ============================================================================
+
+  describe('getQuota', () => {
+    test('retrieves storage quota for a user', async () => {
+      const quotaData = {
+        total_quota_bytes: 10737418240,
+        used_bytes: 1073741824,
+        available_bytes: 9663676416,
+        usage_percentage: 10,
+      };
+      mockGetQuota.mockResolvedValue(quotaData);
+
+      const result = await service.getQuota('user-1');
+
+      expect(mockGetQuota).toHaveBeenCalledWith('user-1', undefined);
+      expect(result.usage_percentage).toBe(10);
+    });
+
+    test('passes organizationId when provided', async () => {
+      mockGetQuota.mockResolvedValue({ usage_percentage: 50 });
+
+      await service.getQuota('user-1', 'org-1');
+
+      expect(mockGetQuota).toHaveBeenCalledWith('user-1', 'org-1');
+    });
+
+    test('throws when quota retrieval fails', async () => {
+      mockGetQuota.mockRejectedValue(new Error('Quota error'));
+
+      await expect(service.getQuota('user-1')).rejects.toThrow('Quota error');
+    });
+  });
+
+  // ============================================================================
+  // healthCheck
+  // ============================================================================
+
+  describe('healthCheck', () => {
+    test('returns health status on success', async () => {
+      const healthData = { status: 'healthy', timestamp: '2026-01-01T00:00:00Z' };
+      mockHealthCheck.mockResolvedValue(healthData);
+
+      const result = await service.healthCheck();
+
+      expect(mockHealthCheck).toHaveBeenCalled();
+      expect(result.status).toBe('healthy');
+    });
+
+    test('throws when health check fails', async () => {
+      mockHealthCheck.mockRejectedValue(new Error('Service down'));
+
+      await expect(service.healthCheck()).rejects.toThrow('Service down');
+    });
+  });
+
+  // ============================================================================
+  // Constructor auth
+  // ============================================================================
+
+  describe('constructor', () => {
+    test('uses custom baseUrl when provided', () => {
+      const customService = new StorageService('http://custom:8080');
+      // Verifies no error — the service initializes with custom URL
+      expect(customService).toBeDefined();
+    });
+
+    test('uses custom auth headers function when provided', () => {
+      const customAuth = () => ({ Authorization: 'Bearer custom-token' });
+      const customService = new StorageService(undefined, customAuth);
+      expect(customService).toBeDefined();
+      expect(mockSetAuthToken).toHaveBeenCalledWith('custom-token');
+    });
+
+    test('falls back to default auth headers', () => {
+      // Default constructor uses getAuthHeaders()
+      const svc = new StorageService();
+      expect(svc).toBeDefined();
+      expect(mockSetAuthToken).toHaveBeenCalledWith('test-token');
+    });
+  });
+});

--- a/src/api/__tests__/userService.test.ts
+++ b/src/api/__tests__/userService.test.ts
@@ -1,0 +1,353 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { UserService } from '../userService';
+import { BaseApiService } from '../BaseApiService';
+
+// Mock BaseApiService
+vi.mock('../BaseApiService', () => {
+  const mockGet = vi.fn();
+  const mockPost = vi.fn();
+  const mockCancelRequest = vi.fn();
+
+  return {
+    BaseApiService: vi.fn().mockImplementation(() => ({
+      get: mockGet,
+      post: mockPost,
+      cancelRequest: mockCancelRequest,
+    })),
+    __mockGet: mockGet,
+    __mockPost: mockPost,
+    __mockCancelRequest: mockCancelRequest,
+  };
+});
+
+// Mock config
+vi.mock('../../config', () => ({
+  config: {
+    externalApis: {
+      userServiceUrl: 'http://localhost:9080/users',
+    },
+  },
+}));
+
+// Mock gatewayConfig
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://localhost:9080',
+    API_VERSION: 'v1',
+    AUTH: {
+      TOKEN_KEY: 'isa_auth_token',
+      API_KEY: 'isa_api_key',
+      AUTH_HEADER: 'Authorization',
+      API_KEY_HEADER: 'X-API-Key',
+    },
+    TIMEOUT: { DEFAULT: 30000, CHAT_SSE: 300000, UPLOAD: 120000 },
+  },
+  GATEWAY_SERVICES: { USER: 'users' },
+  GATEWAY_ENDPOINTS: {},
+  getAuthHeaders: vi.fn().mockReturnValue({ Authorization: 'Bearer test-token' }),
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  LogCategory: {
+    API_REQUEST: 'api_request',
+  },
+}));
+
+// Get mock references
+const getMocks = () => {
+  const mod = vi.mocked(BaseApiService);
+  const instance = mod.mock.results[0]?.value;
+  return {
+    mockGet: instance?.get as ReturnType<typeof vi.fn>,
+    mockPost: instance?.post as ReturnType<typeof vi.fn>,
+    mockCancelRequest: instance?.cancelRequest as ReturnType<typeof vi.fn>,
+  };
+};
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new UserService();
+  });
+
+  // ============================================================================
+  // Constructor
+  // ============================================================================
+
+  describe('constructor', () => {
+    test('initializes with default config url', () => {
+      expect(BaseApiService).toHaveBeenCalledWith(
+        'http://localhost:9080/users',
+        undefined,
+        undefined
+      );
+    });
+
+    test('accepts custom baseUrl and auth headers function', () => {
+      const customAuth = async () => ({ Authorization: 'Bearer custom' });
+      new UserService('http://custom:8080', customAuth);
+      expect(BaseApiService).toHaveBeenCalledWith(
+        'http://custom:8080',
+        undefined,
+        customAuth
+      );
+    });
+  });
+
+  // ============================================================================
+  // ensureUserExists
+  // ============================================================================
+
+  describe('ensureUserExists', () => {
+    const userData = {
+      auth0_id: 'auth0|123',
+      email: 'alice@example.com',
+      name: 'Alice',
+    };
+
+    test('calls post with correct endpoint and payload', async () => {
+      const mockUser = { auth0_id: 'auth0|123', email: 'alice@example.com', name: 'Alice', credits: 100 };
+      getMocks().mockPost.mockResolvedValue({ success: true, data: mockUser });
+
+      const result = await service.ensureUserExists(userData);
+
+      expect(getMocks().mockPost).toHaveBeenCalledWith('/api/v1/users/ensure', userData);
+      expect(result).toEqual(mockUser);
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockPost.mockResolvedValue({ success: false, error: 'Conflict' });
+
+      await expect(service.ensureUserExists(userData)).rejects.toThrow(
+        'User creation failed: Conflict'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockPost.mockRejectedValue(new Error('Network error'));
+
+      await expect(service.ensureUserExists(userData)).rejects.toThrow(
+        'User creation failed: Network error'
+      );
+    });
+  });
+
+  // ============================================================================
+  // getCurrentUser
+  // ============================================================================
+
+  describe('getCurrentUser', () => {
+    test('calls get with correct endpoint', async () => {
+      const mockUser = { auth0_id: 'auth0|123', email: 'alice@example.com', credits: 50 };
+      getMocks().mockGet.mockResolvedValue({ success: true, data: mockUser });
+
+      const result = await service.getCurrentUser();
+
+      expect(getMocks().mockGet).toHaveBeenCalledWith('/api/v1/users/me');
+      expect(result).toEqual(mockUser);
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockGet.mockResolvedValue({ success: false, error: 'Unauthorized' });
+
+      await expect(service.getCurrentUser()).rejects.toThrow(
+        'Get user failed: Unauthorized'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockGet.mockRejectedValue(new Error('Connection refused'));
+
+      await expect(service.getCurrentUser()).rejects.toThrow(
+        'Get user failed: Connection refused'
+      );
+    });
+  });
+
+  // ============================================================================
+  // consumeCredits
+  // ============================================================================
+
+  describe('consumeCredits', () => {
+    const auth0Id = 'auth0|456';
+    const consumption = { amount: 10, reason: 'chat_message' };
+
+    test('calls post with userId and consumption data', async () => {
+      const mockResult = { success: true, remaining_credits: 90 };
+      getMocks().mockPost.mockResolvedValue({ success: true, data: mockResult });
+
+      const result = await service.consumeCredits(auth0Id, consumption);
+
+      expect(getMocks().mockPost).toHaveBeenCalledWith(
+        '/api/v1/users/auth0|456/credits/consume',
+        consumption
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockPost.mockResolvedValue({ success: false, error: 'Insufficient credits' });
+
+      await expect(service.consumeCredits(auth0Id, consumption)).rejects.toThrow(
+        'Credit consumption failed: Insufficient credits'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockPost.mockRejectedValue(new Error('Timeout'));
+
+      await expect(service.consumeCredits(auth0Id, consumption)).rejects.toThrow(
+        'Credit consumption failed: Timeout'
+      );
+    });
+  });
+
+  // ============================================================================
+  // getUserSubscription
+  // ============================================================================
+
+  describe('getUserSubscription', () => {
+    const auth0Id = 'auth0|789';
+
+    test('calls get with userId', async () => {
+      const mockSub = { plan_type: 'pro', status: 'active' };
+      getMocks().mockGet.mockResolvedValue({ success: true, data: mockSub });
+
+      const result = await service.getUserSubscription(auth0Id);
+
+      expect(getMocks().mockGet).toHaveBeenCalledWith('/api/v1/users/auth0|789/subscription');
+      expect(result).toEqual(mockSub);
+    });
+
+    test('returns null when subscription not found (404)', async () => {
+      getMocks().mockGet.mockResolvedValue({ success: false, statusCode: 404 });
+
+      const result = await service.getUserSubscription(auth0Id);
+
+      expect(result).toBeNull();
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockGet.mockResolvedValue({ success: false, error: 'Server error' });
+
+      await expect(service.getUserSubscription(auth0Id)).rejects.toThrow(
+        'Get subscription failed: Server error'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(service.getUserSubscription(auth0Id)).rejects.toThrow(
+        'Get subscription failed: ECONNREFUSED'
+      );
+    });
+  });
+
+  // ============================================================================
+  // createCheckoutSession
+  // ============================================================================
+
+  describe('createCheckoutSession', () => {
+    beforeEach(() => {
+      // Mock window.location for checkout URL construction
+      Object.defineProperty(globalThis, 'window', {
+        value: { location: { origin: 'http://localhost:3000' } },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    test('calls post with planType as query parameter', async () => {
+      const mockSession = { url: 'https://checkout.stripe.com/session_123' };
+      getMocks().mockPost.mockResolvedValue({ success: true, data: mockSession });
+
+      const result = await service.createCheckoutSession('pro');
+
+      expect(getMocks().mockPost).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/payments/create-checkout?'),
+        {}
+      );
+      // Verify query params contain plan_type
+      const calledUrl = getMocks().mockPost.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('plan_type=pro');
+      expect(calledUrl).toContain('success_url=');
+      expect(calledUrl).toContain('cancel_url=');
+      expect(result).toEqual(mockSession);
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockPost.mockResolvedValue({ success: false, error: 'Invalid plan' });
+
+      await expect(service.createCheckoutSession('invalid')).rejects.toThrow(
+        'Checkout creation failed: Invalid plan'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockPost.mockRejectedValue(new Error('Service unavailable'));
+
+      await expect(service.createCheckoutSession('pro')).rejects.toThrow(
+        'Checkout creation failed: Service unavailable'
+      );
+    });
+  });
+
+  // ============================================================================
+  // checkServiceHealth
+  // ============================================================================
+
+  describe('checkServiceHealth', () => {
+    test('calls get on health endpoint', async () => {
+      const mockHealth = { status: 'healthy' };
+      getMocks().mockGet.mockResolvedValue({ success: true, data: mockHealth });
+
+      const result = await service.checkServiceHealth();
+
+      expect(getMocks().mockGet).toHaveBeenCalledWith('/health');
+      expect(result).toEqual(mockHealth);
+    });
+
+    test('throws on API failure', async () => {
+      getMocks().mockGet.mockResolvedValue({ success: false, error: 'Health check failed' });
+
+      await expect(service.checkServiceHealth()).rejects.toThrow(
+        'Health check failed: Health check failed'
+      );
+    });
+
+    test('throws on network error', async () => {
+      getMocks().mockGet.mockRejectedValue(new Error('ETIMEDOUT'));
+
+      await expect(service.checkServiceHealth()).rejects.toThrow(
+        'Health check failed: ETIMEDOUT'
+      );
+    });
+  });
+
+  // ============================================================================
+  // cancelAllRequests
+  // ============================================================================
+
+  describe('cancelAllRequests', () => {
+    test('delegates to apiService.cancelRequest', () => {
+      service.cancelAllRequests();
+      expect(getMocks().mockCancelRequest).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
156 new L2 component tests for BaseApiService, ChatService, UserService, SessionService, ExecutionControlService, StorageService. 329 total tests pass. Fixes #55, #56, #57, #58, #59, #60.