### PR TITLE
fix(ui): resolve hydration errors on /app page

### DIFF
--- a/src/components/shared/ui/Modal.tsx
+++ b/src/components/shared/ui/Modal.tsx
@@ -16,7 +16,7 @@
  * - 用户体验：流畅的动画和交互
  */
 
-import React, { memo, useEffect, useRef, useCallback, forwardRef, useMemo } from 'react';
+import React, { memo, useState, useEffect, useRef, useCallback, forwardRef, useMemo } from 'react';
 import { createLogger } from '../../../utils/logger';
 import { createPortal } from 'react-dom';
 
@@ -252,6 +252,10 @@ export const Modal = memo(forwardRef<HTMLDivElement, ModalProps>(({
   'aria-describedby': ariaDescribedBy
 }, ref) => {
   const modalRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  // Delay portal rendering until after hydration to prevent mismatch
+  useEffect(() => { setMounted(true); }, []);
 
   // Enhanced focus management with accessibility
   useFocusTrap(isOpen, modalRef, initialFocus);
@@ -373,10 +377,9 @@ export const Modal = memo(forwardRef<HTMLDivElement, ModalProps>(({
     </>
   );
 
-  // 使用Portal渲染到body
-  return typeof document !== 'undefined' 
-    ? createPortal(modalContent, document.body)
-    : null;
+  // Render portal only after hydration to prevent server/client mismatch
+  if (!mounted) return null;
+  return createPortal(modalContent, document.body);
 }));
 
 // ================================================================================

--- a/src/config/surfaceConfig.ts
+++ b/src/config/surfaceConfig.ts
@@ -48,7 +48,7 @@ export const extractHostname = (hostOrUrl: string): string => {
 const DEFAULT_MARKETING_HOSTS = ['www.iapro.ai', 'iapro.ai', 'localhost', '127.0.0.1'];
 
 const marketingHostSet = parseHostCsv(
-  getEnv('NEXT_PUBLIC_MARKETING_HOSTS', DEFAULT_MARKETING_HOSTS.join(',')),
+  process.env.NEXT_PUBLIC_MARKETING_HOSTS || DEFAULT_MARKETING_HOSTS.join(','),
   DEFAULT_MARKETING_HOSTS
 );
 
@@ -60,15 +60,19 @@ export const getMarketingHostnames = (): string[] => Array.from(marketingHostSet
  * Surface URLs default to relative paths for Multi-Zone routing (same domain).
  * In production, all zones are served under one domain via APISIX gateway.
  * In development, override with absolute URLs via env vars (.env.local).
+ *
+ * IMPORTANT: Next.js only inlines NEXT_PUBLIC_* when accessed as literal strings
+ * (process.env.NEXT_PUBLIC_X), not via bracket notation (process.env[key]).
+ * Using direct access ensures server and client get the same values.
  */
 export const surfaceUrls = Object.freeze({
-  marketing: trimTrailingSlash(getEnv('NEXT_PUBLIC_MARKETING_URL', '/')),
-  app: trimTrailingSlash(getEnv('NEXT_PUBLIC_APP_URL', '/app')),
+  marketing: trimTrailingSlash(process.env.NEXT_PUBLIC_MARKETING_URL || '/'),
+  app: trimTrailingSlash(process.env.NEXT_PUBLIC_APP_URL || '/app'),
   appDashboard: trimTrailingSlash(
-    getEnv('NEXT_PUBLIC_APP_DASHBOARD_URL', getEnv('NEXT_PUBLIC_APP_URL', '/app'))
+    process.env.NEXT_PUBLIC_APP_DASHBOARD_URL || process.env.NEXT_PUBLIC_APP_URL || '/app'
   ),
-  console: trimTrailingSlash(getEnv('NEXT_PUBLIC_CONSOLE_URL', '/console')),
-  docs: trimTrailingSlash(getEnv('NEXT_PUBLIC_DOCS_URL', '/docs')),
+  console: trimTrailingSlash(process.env.NEXT_PUBLIC_CONSOLE_URL || '/console'),
+  docs: trimTrailingSlash(process.env.NEXT_PUBLIC_DOCS_URL || '/docs'),
 });
 
 const appendPath = (base: string, path: string): string => {

--- a/tests/e2e/isa-app-functional.spec.ts
+++ b/tests/e2e/isa-app-functional.spec.ts
@@ -198,6 +198,21 @@ test.describe('App page — main application', () => {
     const children = await nextRoot.locator('> *').count();
     expect(children).toBeGreaterThan(0);
   });
+
+  test('no hydration errors on /app', async ({ page }) => {
+    const hydrationErrors: string[] = [];
+    page.on('console', msg => {
+      const text = msg.text();
+      if (text.includes('Hydration failed') || text.includes('did not match')) {
+        hydrationErrors.push(text.slice(0, 200));
+      }
+    });
+
+    await page.goto(`${BASE}/app`, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(3000);
+
+    expect(hydrationErrors, `Hydration errors found:\n${hydrationErrors.join('\n')}`).toHaveLength(0);
+  });
 });
 
 // ─── CROSS-PAGE NAVIGATION ──────────────────────────────────────


### PR DESCRIPTION
Fixes 3 hydration errors on /app: surfaceConfig env var inlining (bracket→direct access) and Modal portal timing (delay until after hydration). Adds hydration error detection to E2E tests.