### PR TITLE
fix(ui): unify responsive layout, fix i18n locale

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -32,10 +32,9 @@
 import React from 'react';
 import { PlatformNav } from '@isa/ui-web';
 import { AppHeader } from './ui/AppHeader';
-import { useDeviceType } from '../hooks/useDeviceType';
+import { useBreakpoint } from '@isa/ui-web';
 import { useAuthContext } from '../providers/AuthProvider';
 import { surfaceUrls } from '../config/surfaceConfig';
-import { THEME_COLORS } from '../constants/theme';
 
 export interface AppLayoutProps {
   className?: string;
@@ -69,8 +68,7 @@ export interface AppLayoutProps {
  * No business logic or direct state management
  */
 export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }) => {
-  // Get device type to determine whether to show desktop header
-  const { isMobile } = useDeviceType();
+  const { isMobile } = useBreakpoint();
   const { authUser, isAuthenticated, logout } = useAuthContext();
 
   // Get rendered modules and data from AppModule via render props
@@ -90,16 +88,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
   const { chatModule, appData, userPortal } = moduleData;
 
   return (
-    <div 
-      className={`h-screen w-full flex flex-col text-white relative ${className}`} 
-      style={{ background: THEME_COLORS.primaryGradient }}
+    <div
+      className={`min-h-dvh w-full flex flex-col bg-[var(--surface-bg,#0f172a)] text-[var(--text-primary,#fff)] relative ${className}`}
     >
-      {/* Ambient Glass Orbs */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-white/5 rounded-full blur-3xl opacity-40 animate-pulse"></div>
-        <div className="absolute bottom-1/3 right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl opacity-30 animate-pulse" style={{ animationDelay: '2s' }}></div>
-        <div className="absolute top-3/4 left-3/4 w-48 h-48 bg-purple-500/8 rounded-full blur-3xl opacity-50 animate-pulse" style={{ animationDelay: '4s' }}></div>
-      </div>
       {/* Platform Navigation - Surface switcher for authenticated users */}
       {isAuthenticated && (
         <PlatformNav
@@ -114,15 +105,13 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
           onLogout={logout}
         />
       )}
-      {/* Application Header - Only show on desktop, hidden on mobile */}
-      {!isMobile && (
-        <div className="h-16 flex-shrink-0 p-2">
-          <AppHeader
-            currentApp={appData.currentApp}
-            availableApps={appData.availableApps}
-          />
-        </div>
-      )}
+      {/* Application Header - responsive on all viewports */}
+      <div className="h-14 md:h-16 flex-shrink-0 p-1.5 md:p-2">
+        <AppHeader
+          currentApp={appData.currentApp}
+          availableApps={appData.availableApps}
+        />
+      </div>
       
       {/* Main Content Area */}
       <div className="flex-1 flex overflow-hidden w-full">

--- a/src/components/ui/adaptive/ResponsiveChatLayout.tsx
+++ b/src/components/ui/adaptive/ResponsiveChatLayout.tsx
@@ -1,163 +1,35 @@
 /**
  * ============================================================================
- * Responsive Chat Layout - Adaptive wrapper component
+ * Responsive Chat Layout - Unified wrapper component
  * ============================================================================
- * 
- * Automatically switches between desktop and mobile layouts based on:
- * - Screen size and device type
- * - Touch capabilities
- * - User preferences
- * - Native app context
+ *
+ * Uses a SINGLE ChatLayout for all viewports. Responsive behavior is handled
+ * via CSS (Tailwind breakpoints) — no separate mobile component tree.
+ *
+ * The sidebar becomes a drawer on mobile via the SDK ResponsiveSidebar pattern,
+ * and all content (welcome screen, header, etc.) is consistent across viewports.
  */
-import React, { useMemo } from 'react';
-import { createLogger } from '../../../utils/logger';
+import React from 'react';
 import { ChatLayout, ChatLayoutProps } from '../chat/ChatLayout';
 
-const log = createLogger('ResponsiveChatLayout');
-import { ModernMobileChatLayout } from '../mobile/ModernMobileChatLayout';
-import { useDeviceType } from '../../../hooks/useDeviceType';
-
 export interface ResponsiveChatLayoutProps extends Omit<ChatLayoutProps, 'className'> {
-  // Force specific layout (override auto-detection)
-  forceLayout?: 'desktop' | 'mobile' | 'auto';
-  
-  // Mobile-specific props
-  enableSwipeGestures?: boolean;
-  enablePullToRefresh?: boolean;
-  
-  // Native app compatibility
-  isNativeApp?: boolean;
-  nativeStatusBarHeight?: number;
-  nativeBottomSafeArea?: number;
-  
-  // Layout preferences
-  mobileBreakpoint?: number;
-  adaptiveThreshold?: number;
-  
-  // Additional styling
   className?: string;
   style?: React.CSSProperties;
-  
-  // Mobile interaction callbacks
   onNewChat?: () => void;
 }
 
 export const ResponsiveChatLayout: React.FC<ResponsiveChatLayoutProps> = ({
-  forceLayout = 'auto',
-  enableSwipeGestures = true,
-  enablePullToRefresh = true,
-  isNativeApp = false,
-  nativeStatusBarHeight = 0,
-  nativeBottomSafeArea = 0,
-  mobileBreakpoint = 768,
-  adaptiveThreshold = 0.75,
   className = '',
   style = {},
   onNewChat,
   ...props
 }) => {
-  const { isMobile, isTablet, screenWidth, touchSupport, isPortrait } = useDeviceType();
-
-  // Determine which layout to use
-  const layoutType = useMemo(() => {
-    // Layout decision logic
-
-    if (forceLayout !== 'auto') {
-      // Using forced layout
-      return forceLayout;
-    }
-
-    // Check for native app context
-    if (isNativeApp) {
-      log.info('Native app detected, using mobile layout');
-      return 'mobile';
-    }
-
-    // Check screen width
-    if (screenWidth <= mobileBreakpoint) {
-      log.info('Screen width <= breakpoint, using mobile layout');
-      return 'mobile';
-    }
-
-    // Tablet portrait mode prefers the mobile-optimized layout for better ergonomics
-    if (isTablet && touchSupport && isPortrait) {
-      return 'mobile';
-    }
-
-    // Check for explicit mobile device
-    if (isMobile) {
-      // Mobile device detected, using mobile layout
-      return 'mobile';
-    }
-
-    // Default to desktop
-    // Using desktop layout
-    return 'desktop';
-  }, [
-    forceLayout,
-    isNativeApp,
-    screenWidth,
-    mobileBreakpoint,
-    isTablet,
-    touchSupport,
-    isMobile,
-    isPortrait
-  ]);
-
-  // Common props for both layouts
-  const commonProps = {
-    messages: props.messages,
-    isLoading: props.isLoading,
-    isTyping: props.isTyping,
-    onSendMessage: props.onSendMessage,
-    onSendMultimodal: props.onSendMultimodal,
-  };
-
-  // Modern mobile layout props
-  const handleNewChat = React.useCallback(() => {
-    // Call the onNewChat prop if provided by parent module
-    if (onNewChat) {
-      onNewChat();
-    } else {
-      // Default fallback - refresh the page to create new chat
-      log.info('New chat requested - no onNewChat handler, refreshing');
-      window.location.reload();
-    }
-  }, [onNewChat]);
-
-  const modernMobileProps = {
-    ...commonProps,
-    onNewChat: handleNewChat,
-    isNativeApp,
-    // Add user info if available from props
-    userAvatarUrl: (props as any).userAvatarUrl,
-    userName: (props as any).userName,
-  };
-
-  // Container styles
-  const containerStyles = {
-    ...style,
-    width: '100%',
-    height: '100%',
-  };
-
-  if (layoutType === 'mobile') {
-    return (
-      <div className={`responsive-chat-layout mobile ${className}`} style={containerStyles}>
-        <ModernMobileChatLayout {...modernMobileProps} />
-      </div>
-    );
-  }
-
-  // Desktop layout - disable header if we're forcing mobile layout on desktop
-  const desktopProps = {
-    ...props,
-    showHeader: layoutType === 'desktop' ? props.showHeader : false,
-  };
-
   return (
-    <div className={`responsive-chat-layout desktop ${className}`} style={containerStyles}>
-      <ChatLayout {...desktopProps} />
+    <div
+      className={`responsive-chat-layout w-full h-full ${className}`}
+      style={style}
+    >
+      <ChatLayout {...props} />
     </div>
   );
 };

--- a/src/stores/useLanguageStore.ts
+++ b/src/stores/useLanguageStore.ts
@@ -49,6 +49,25 @@ export interface LanguageState {
 }
 
 // ================================================================================
+// Utilities (defined before store so they can be used in initialization)
+// ================================================================================
+
+/**
+ * Get browser preferred language, fallback to English
+ */
+export const getBrowserLanguage = (): SupportedLanguage => {
+  if (typeof navigator === 'undefined') return 'en-US';
+
+  const browserLang = navigator.language || navigator.languages?.[0];
+
+  if (browserLang?.startsWith('zh')) {
+    return 'zh-CN';
+  }
+
+  return 'en-US'; // Default fallback
+};
+
+// ================================================================================
 // Language Configuration
 // ================================================================================
 
@@ -74,8 +93,8 @@ const AVAILABLE_LANGUAGES: LanguageConfig[] = [
 export const useLanguageStore = create<LanguageState>()(
   persist(
     (set) => ({
-      // Default to Chinese
-      currentLanguage: 'zh-CN',
+      // Default to browser language (detected synchronously before first render)
+      currentLanguage: getBrowserLanguage(),
       
       // Available languages
       availableLanguages: AVAILABLE_LANGUAGES,
@@ -120,23 +139,6 @@ export const useLanguageStore = create<LanguageState>()(
 // ================================================================================
 // Utilities
 // ================================================================================
-
-/**
- * Get browser preferred language, fallback to Chinese
- */
-export const getBrowserLanguage = (): SupportedLanguage => {
-  if (typeof navigator === 'undefined') return 'zh-CN';
-  
-  const browserLang = navigator.language || navigator.languages?.[0];
-  
-  if (browserLang?.startsWith('zh')) {
-    return 'zh-CN';
-  } else if (browserLang?.startsWith('en')) {
-    return 'en-US';
-  }
-  
-  return 'zh-CN'; // Default fallback
-};
 
 /**
  * Initialize language based on browser preference


### PR DESCRIPTION
## Summary
- Remove dual mobile/desktop layout switch — always use ChatLayout
- Show header on all viewports (was hidden on mobile)
- Fix i18n locale flash (zh-CN → browser language detection)

## Test plan
- [ ] Same layout at all viewports
- [ ] No Chinese text on English browsers
- [ ] Header visible on mobile

Fixes #94, #95, #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)