### PR TITLE
feat(api): add Mate API client for scheduler, memory, and health

### DIFF
--- a/src/api/mateService.ts
+++ b/src/api/mateService.ts
@@ -1,0 +1,266 @@
+/**
+ * ============================================================================
+ * Mate Service (mateService.ts) - isA_Mate REST API Client
+ * ============================================================================
+ *
+ * Core Responsibilities:
+ * - Uses BaseApiService for robust network transport
+ * - Provides REST client for Mate's health, memory, scheduler, and tools endpoints
+ * - All requests route through the gateway (or direct NEXT_PUBLIC_MATE_URL)
+ *
+ * Architecture:
+ * - Transport: BaseApiService with retry/timeout/auth
+ * - Types: src/types/mateTypes.ts
+ * - Endpoints: GATEWAY_ENDPOINTS.MATE.*
+ */
+
+import { BaseApiService } from './BaseApiService';
+import { GATEWAY_ENDPOINTS, buildUrlWithParams } from '../config/gatewayConfig';
+import { createLogger, LogCategory } from '../utils/logger';
+import type {
+  MateHealthResponse,
+  MateMemorySession,
+  MateMemoryMessage,
+  MateMemorySessionsResponse,
+  MateMemoryMessagesResponse,
+  MateSchedulerJob,
+  MateJobRun,
+  MateSchedulerJobsResponse,
+  CreateSchedulerJobData,
+  MateTool,
+  MateToolsResponse,
+} from '../types/mateTypes';
+
+const log = createLogger('MateService', LogCategory.API_REQUEST);
+
+// ================================================================================
+// MateService Class
+// ================================================================================
+
+export class MateService {
+  private apiService: BaseApiService;
+
+  constructor(getAuthHeaders?: () => Promise<Record<string, string>>) {
+    this.apiService = new BaseApiService(
+      GATEWAY_ENDPOINTS.MATE.BASE,
+      undefined,
+      getAuthHeaders
+    );
+    log.info('MateService initialized');
+  }
+
+  // ================================================================================
+  // Health
+  // ================================================================================
+
+  /**
+   * Check Mate health status including stack health and channels.
+   */
+  async healthCheck(): Promise<MateHealthResponse> {
+    try {
+      log.info('Checking Mate health');
+      const response = await this.apiService.get<MateHealthResponse>(
+        GATEWAY_ENDPOINTS.MATE.HEALTH
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Health check failed');
+      }
+      return response.data!;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Mate health check failed', { error: msg });
+      throw new Error(`Mate health check failed: ${msg}`);
+    }
+  }
+
+  // ================================================================================
+  // Memory — Sessions & Messages
+  // ================================================================================
+
+  /**
+   * List memory sessions.
+   */
+  async listSessions(): Promise<MateMemorySession[]> {
+    try {
+      log.info('Fetching Mate memory sessions');
+      const response = await this.apiService.get<MateMemorySessionsResponse>(
+        GATEWAY_ENDPOINTS.MATE.MEMORY.SESSIONS
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to fetch sessions');
+      }
+      // Handle both array and wrapped responses
+      const data = response.data;
+      if (Array.isArray(data)) return data;
+      return data?.sessions ?? [];
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to fetch Mate sessions', { error: msg });
+      throw new Error(`Fetch Mate sessions failed: ${msg}`);
+    }
+  }
+
+  /**
+   * Get messages for a specific session.
+   */
+  async getSessionMessages(sessionId: string): Promise<MateMemoryMessage[]> {
+    try {
+      log.info('Fetching Mate session messages', { sessionId });
+      const url = buildUrlWithParams(
+        GATEWAY_ENDPOINTS.MATE.MEMORY.SESSION_MESSAGES,
+        { sessionId }
+      );
+      const response = await this.apiService.get<MateMemoryMessagesResponse>(url);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to fetch session messages');
+      }
+      const data = response.data;
+      if (Array.isArray(data)) return data;
+      return data?.messages ?? [];
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to fetch Mate session messages', { error: msg, sessionId });
+      throw new Error(`Fetch Mate session messages failed: ${msg}`);
+    }
+  }
+
+  // ================================================================================
+  // Scheduler — Jobs
+  // ================================================================================
+
+  /**
+   * List scheduled jobs.
+   */
+  async listJobs(): Promise<MateSchedulerJob[]> {
+    try {
+      log.info('Fetching Mate scheduler jobs');
+      const response = await this.apiService.get<MateSchedulerJobsResponse>(
+        GATEWAY_ENDPOINTS.MATE.SCHEDULER.JOBS
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to fetch scheduler jobs');
+      }
+      const data = response.data;
+      if (Array.isArray(data)) return data;
+      return data?.jobs ?? [];
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to fetch Mate scheduler jobs', { error: msg });
+      throw new Error(`Fetch Mate scheduler jobs failed: ${msg}`);
+    }
+  }
+
+  /**
+   * Create a new scheduled job.
+   */
+  async createJob(jobData: CreateSchedulerJobData): Promise<MateSchedulerJob> {
+    try {
+      log.info('Creating Mate scheduler job', { name: jobData.name });
+      const response = await this.apiService.post<MateSchedulerJob>(
+        GATEWAY_ENDPOINTS.MATE.SCHEDULER.JOBS,
+        jobData
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to create scheduler job');
+      }
+      return response.data!;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to create Mate scheduler job', { error: msg });
+      throw new Error(`Create Mate scheduler job failed: ${msg}`);
+    }
+  }
+
+  /**
+   * Manually trigger a scheduled job.
+   */
+  async triggerJob(jobId: string): Promise<MateJobRun> {
+    try {
+      log.info('Triggering Mate scheduler job', { jobId });
+      const url = buildUrlWithParams(
+        GATEWAY_ENDPOINTS.MATE.SCHEDULER.JOB_RUN,
+        { jobId }
+      );
+      const response = await this.apiService.post<MateJobRun>(url);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to trigger scheduler job');
+      }
+      return response.data!;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to trigger Mate scheduler job', { error: msg, jobId });
+      throw new Error(`Trigger Mate scheduler job failed: ${msg}`);
+    }
+  }
+
+  /**
+   * Delete a scheduled job.
+   */
+  async deleteJob(jobId: string): Promise<void> {
+    try {
+      log.info('Deleting Mate scheduler job', { jobId });
+      const url = buildUrlWithParams(
+        GATEWAY_ENDPOINTS.MATE.SCHEDULER.JOB,
+        { jobId }
+      );
+      const response = await this.apiService.delete(url);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to delete scheduler job');
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to delete Mate scheduler job', { error: msg, jobId });
+      throw new Error(`Delete Mate scheduler job failed: ${msg}`);
+    }
+  }
+
+  // ================================================================================
+  // Tools
+  // ================================================================================
+
+  /**
+   * List available tools.
+   */
+  async listTools(): Promise<MateTool[]> {
+    try {
+      log.info('Fetching Mate tools');
+      const response = await this.apiService.get<MateToolsResponse>(
+        GATEWAY_ENDPOINTS.MATE.TOOLS
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to fetch tools');
+      }
+      const data = response.data;
+      if (Array.isArray(data)) return data;
+      return data?.tools ?? [];
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to fetch Mate tools', { error: msg });
+      throw new Error(`Fetch Mate tools failed: ${msg}`);
+    }
+  }
+}
+
+// ================================================================================
+// Export Functions and Default Instance
+// ================================================================================
+
+/**
+ * Create authenticated MateService
+ */
+export const createAuthenticatedMateService = (
+  getAuthHeadersFn?: () => Promise<Record<string, string>>
+): MateService => {
+  return new MateService(getAuthHeadersFn);
+};
+
+// Lazy-initialized default instance
+let _defaultInstance: MateService | null = null;
+export const getMateService = (): MateService => {
+  if (!_defaultInstance) {
+    _defaultInstance = createAuthenticatedMateService();
+  }
+  return _defaultInstance;
+};
+
+export default MateService;

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -132,7 +132,13 @@ export const GATEWAY_ENDPOINTS = {
       TEAMS: buildMateEndpoint('/v1/teams'),
       MEMORY: {
         SESSIONS: buildMateEndpoint('/v1/memory/sessions'),
+        SESSION_MESSAGES: buildMateEndpoint('/v1/memory/sessions/{sessionId}/messages'),
         TURNS: buildMateEndpoint('/v1/memory/turns'),
+      },
+      SCHEDULER: {
+        JOBS: buildMateEndpoint('/v1/scheduler/jobs'),
+        JOB: buildMateEndpoint('/v1/scheduler/jobs/{jobId}'),
+        JOB_RUN: buildMateEndpoint('/v1/scheduler/jobs/{jobId}/run'),
       },
       HEALTH: buildMateEndpoint('/health'),
     };

--- a/src/types/mateTypes.ts
+++ b/src/types/mateTypes.ts
@@ -1,0 +1,119 @@
+/**
+ * ============================================================================
+ * Mate Types - TypeScript types for isA_Mate REST API responses
+ * ============================================================================
+ *
+ * Covers: health, memory, scheduler, and tools endpoints.
+ * Used by mateService.ts for type-safe API interactions.
+ */
+
+// ================================================================================
+// Health
+// ================================================================================
+
+export interface MateStackHealth {
+  name: string;
+  status: 'healthy' | 'degraded' | 'unhealthy' | string;
+  latency_ms?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface MateHealthResponse {
+  status: 'healthy' | 'degraded' | 'unhealthy' | string;
+  version?: string;
+  uptime_seconds?: number;
+  stack?: MateStackHealth[];
+  channels?: string[];
+  timestamp?: string;
+}
+
+// ================================================================================
+// Memory — Sessions & Messages
+// ================================================================================
+
+export interface MateMemorySession {
+  session_id: string;
+  user_id?: string;
+  title?: string;
+  created_at: string;
+  updated_at?: string;
+  message_count?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MateMemoryMessage {
+  message_id: string;
+  session_id: string;
+  role: string;
+  content: string;
+  created_at: string;
+  metadata?: Record<string, unknown>;
+  tokens_used?: number;
+}
+
+export interface MateMemorySessionsResponse {
+  sessions: MateMemorySession[];
+  total: number;
+}
+
+export interface MateMemoryMessagesResponse {
+  messages: MateMemoryMessage[];
+  total: number;
+}
+
+// ================================================================================
+// Scheduler — Jobs
+// ================================================================================
+
+export interface MateSchedulerJob {
+  job_id: string;
+  name: string;
+  description?: string;
+  cron_expression?: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at?: string;
+  last_run_at?: string;
+  next_run_at?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MateJobRun {
+  run_id: string;
+  job_id: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | string;
+  started_at: string;
+  completed_at?: string;
+  result?: unknown;
+  error?: string;
+}
+
+export interface CreateSchedulerJobData {
+  name: string;
+  description?: string;
+  cron_expression?: string;
+  enabled?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MateSchedulerJobsResponse {
+  jobs: MateSchedulerJob[];
+  total: number;
+}
+
+// ================================================================================
+// Tools
+// ================================================================================
+
+export interface MateTool {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  category?: string;
+  enabled?: boolean;
+}
+
+export interface MateToolsResponse {
+  tools: MateTool[];
+  total: number;
+}


### PR DESCRIPTION
## Summary
Add REST client for isA Mate's scheduler, memory, health, and tools endpoints. Foundation for surfacing Mate's full capabilities in the companion UI.

## Changes
- `src/api/mateService.ts` — new service with health, memory, scheduler, tools methods
- `src/types/mateTypes.ts` — TypeScript types for all Mate API responses
- `src/config/gatewayConfig.ts` — added Mate REST endpoint mappings

## Related Issues
Fixes #125
**Parent Epic**: #108