### PR TITLE
feat(ui): add proactive memory recall inline during conversation

### DIFF
--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -94,15 +94,39 @@ export function adaptMateEvent(
     }
 
     case 'tool_use': {
+      // Detect memory/recall tool invocations and synthesize a memory_recall custom event
+      const toolName = event.tool_name || 'unknown';
+      const isMemoryTool = /memory|recall/i.test(toolName);
+
       results.push({
         type: 'tool_call_start',
         thread_id: threadId,
         timestamp: now,
         run_id: context.runId,
-        tool_name: event.tool_name || 'unknown',
+        tool_name: toolName,
         tool_call_id: event.tool_call_id || generateId('tool'),
         parameters: event.parameters,
       });
+
+      if (isMemoryTool && event.result) {
+        // Synthesize a memory_recall custom event from the tool result
+        const resultData = typeof event.result === 'object' ? event.result as Record<string, unknown> : {};
+        results.push({
+          type: 'custom_event' as AGUIEventType,
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          metadata: {
+            custom_type: 'memory_recall',
+            memoryId: resultData.memoryId || resultData.memory_id || generateId('mem'),
+            memoryType: resultData.memoryType || resultData.memory_type || 'factual',
+            content: resultData.content || (typeof event.result === 'string' ? event.result : JSON.stringify(event.result)),
+            learnedAt: resultData.learnedAt || resultData.learned_at,
+            confidence: resultData.confidence,
+            sourceSessionId: resultData.sourceSessionId || resultData.source_session_id,
+          },
+        });
+      }
       break;
     }
 
@@ -194,6 +218,27 @@ export function adaptMateEvent(
 
     case 'node_exit': {
       // LangGraph node transition — no UI action needed
+      break;
+    }
+
+    case 'memory_recall': {
+      // Explicit memory recall event from Mate — map to custom_event
+      const recallMeta = event.metadata || {};
+      results.push({
+        type: 'custom_event' as AGUIEventType,
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        metadata: {
+          custom_type: 'memory_recall',
+          memoryId: recallMeta.memoryId || recallMeta.memory_id || generateId('mem'),
+          memoryType: recallMeta.memoryType || recallMeta.memory_type || 'factual',
+          content: event.content || recallMeta.content || '',
+          learnedAt: recallMeta.learnedAt || recallMeta.learned_at,
+          confidence: recallMeta.confidence,
+          sourceSessionId: recallMeta.sourceSessionId || recallMeta.source_session_id,
+        },
+      });
       break;
     }
 

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -436,6 +436,32 @@ export class ChatService {
         });
         break;
         
+      case 'memory_recall': {
+        // Attach the recalled memory to the current streaming message
+        const { useMessageStore } = require('../stores/useMessageStore');
+        const msgStore = useMessageStore.getState();
+        // Find the last streaming assistant message
+        const streamingMsg = [...msgStore.messages].reverse().find(
+          (m: any) => m.role === 'assistant' && m.isStreaming
+        );
+        const currentMsgId = streamingMsg?.id;
+        if (currentMsgId) {
+          msgStore.attachMemoryRecall(currentMsgId, {
+            memoryId: customData.memoryId || event.metadata?.memoryId,
+            memoryType: customData.memoryType || event.metadata?.memoryType || 'factual',
+            content: customData.content || event.metadata?.content || '',
+            learnedAt: customData.learnedAt || event.metadata?.learnedAt,
+            confidence: customData.confidence || event.metadata?.confidence,
+            sourceSessionId: customData.sourceSessionId || event.metadata?.sourceSessionId,
+          });
+        }
+        log.info('Memory recall event dispatched', {
+          memoryType: customData.memoryType || event.metadata?.memoryType,
+          messageId: currentMsgId,
+        });
+        break;
+      }
+
       case 'autonomous_result': {
         // Background autonomous event received via the active chat stream.
         // Dispatch directly to the chat store so it appears in the timeline.

--- a/src/components/ui/chat/MemoryCard.tsx
+++ b/src/components/ui/chat/MemoryCard.tsx
@@ -1,0 +1,111 @@
+/**
+ * MemoryCard — Inline card showing a proactive memory recall.
+ *
+ * Renders above the assistant message bubble to surface remembered context.
+ * Color-coded by memory type with dismiss/correct actions on hover.
+ */
+import React, { memo, useState } from 'react';
+import type { MemoryRecallData, MemoryType } from '../../../types/memoryTypes';
+
+// ── colour & icon mapping per memory type ─────────────────────────────
+const TYPE_STYLES: Record<MemoryType, { border: string; bg: string; text: string; icon: string }> = {
+  factual:    { border: 'border-amber-500/20',  bg: 'bg-amber-500/5',   text: 'text-amber-400', icon: '📌' },
+  episodic:   { border: 'border-blue-500/20',   bg: 'bg-blue-500/5',    text: 'text-blue-400',  icon: '🕰️' },
+  semantic:   { border: 'border-purple-500/20',  bg: 'bg-purple-500/5',  text: 'text-purple-400', icon: '🔗' },
+  procedural: { border: 'border-green-500/20',   bg: 'bg-green-500/5',   text: 'text-green-400', icon: '⚙️' },
+  working:    { border: 'border-gray-500/20',    bg: 'bg-gray-500/5',    text: 'text-gray-400',  icon: '💭' },
+};
+
+// ── relative-time helper ──────────────────────────────────────────────
+function relativeTime(iso?: string): string {
+  if (!iso) return '';
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ── props ─────────────────────────────────────────────────────────────
+export interface MemoryCardProps extends MemoryRecallData {
+  onDismiss?: () => void;
+  onCorrect?: () => void;
+}
+
+export const MemoryCard = memo<MemoryCardProps>(({
+  memoryType,
+  content,
+  learnedAt,
+  confidence,
+  onDismiss,
+  onCorrect,
+}) => {
+  const [hovered, setHovered] = useState(false);
+  const style = TYPE_STYLES[memoryType] ?? TYPE_STYLES.factual;
+
+  // Truncate content to ~120 chars (roughly 1-2 lines)
+  const truncated = content.length > 120 ? content.slice(0, 117) + '...' : content;
+
+  return (
+    <div
+      className={`relative flex items-start gap-2 px-3 py-2 rounded-2xl border ${style.border} ${style.bg} transition-all duration-150`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Left accent border */}
+      <span className={`shrink-0 text-base leading-none mt-0.5 ${style.text}`}>
+        {style.icon}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        {/* Content snippet */}
+        <p className="text-sm text-white/80 leading-snug line-clamp-2">
+          {truncated}
+        </p>
+
+        {/* Caption */}
+        <p className={`mt-0.5 text-xs ${style.text} opacity-70`}>
+          {learnedAt ? `Remembered from ${relativeTime(learnedAt)}` : 'Recalled from memory'}
+          {typeof confidence === 'number' && ` · ${Math.round(confidence * 100)}%`}
+        </p>
+      </div>
+
+      {/* Hover actions */}
+      {hovered && (
+        <div className="absolute top-1 right-1 flex gap-1">
+          {onCorrect && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onCorrect(); }}
+              className="p-1 rounded-lg bg-white/10 hover:bg-white/20 text-white/60 hover:text-white/90 transition-colors"
+              title="Correct this memory"
+              aria-label="Correct this memory"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+              </svg>
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onDismiss(); }}
+              className="p-1 rounded-lg bg-white/10 hover:bg-white/20 text-white/60 hover:text-white/90 transition-colors"
+              title="Dismiss"
+              aria-label="Dismiss memory"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+MemoryCard.displayName = 'MemoryCard';

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -22,7 +22,7 @@
  */
 import React, { memo, useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import { createLogger } from '../../../utils/logger';
-import { ChatMessage, ArtifactMessage } from '../../../types/chatTypes';
+import { ChatMessage, ArtifactMessage, RegularMessage } from '../../../types/chatTypes';
 const log = createLogger('MessageList');
 import { ArtifactComponent } from './ArtifactComponent';
 import { ArtifactMessageComponent } from './ArtifactMessageComponent';
@@ -32,6 +32,8 @@ import { ChatWelcome } from './ChatWelcome';
 import { TaskProgressMessage } from './TaskProgressMessage';
 import { TaskHandler } from '../../core/TaskHandler';
 import { ChatEmbeddedTaskPanel } from './ChatEmbeddedTaskPanel';
+import { MemoryCard } from './MemoryCard';
+import type { MemoryRecallData } from '../../../types/memoryTypes';
 
 // MessageActions will be implemented later
 
@@ -147,6 +149,40 @@ const useVirtualScrolling = (
     visibleRange
   };
 };
+
+/**
+ * MemoryRecallSection — Shows up to 3 MemoryCards with "Show N more" expansion.
+ */
+const MAX_VISIBLE_RECALLS = 3;
+
+const MemoryRecallSection = memo<{ recalls: MemoryRecallData[] }>(({ recalls }) => {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? recalls : recalls.slice(0, MAX_VISIBLE_RECALLS);
+  const hiddenCount = recalls.length - MAX_VISIBLE_RECALLS;
+
+  return (
+    <div className="ml-12 mb-2 flex flex-col gap-1.5 max-w-[80%]">
+      {visible.map((recall, idx) => (
+        <MemoryCard
+          key={recall.memoryId || `recall-${idx}`}
+          {...recall}
+          onDismiss={() => { /* dismiss handled upstream */ }}
+          onCorrect={() => { /* correct handled upstream */ }}
+        />
+      ))}
+      {!expanded && hiddenCount > 0 && (
+        <button
+          onClick={() => setExpanded(true)}
+          className="text-xs text-white/50 hover:text-white/80 transition-colors self-start px-2 py-0.5"
+        >
+          Show {hiddenCount} more
+        </button>
+      )}
+    </div>
+  );
+});
+
+MemoryRecallSection.displayName = 'MemoryRecallSection';
 
 /**
  * MessageList - Pure UI component for displaying chat messages
@@ -339,6 +375,13 @@ export const MessageList = memo<MessageListProps>(({
     // Default message rendering using GlassMessageBubble with TaskProgress
     return (
       <div className="mb-6" onClick={() => onMessageClick?.(message)}>
+        {/* Memory recall cards — rendered above the assistant bubble */}
+        {message.role === 'assistant' && message.type === 'regular' && (message as RegularMessage).memoryRecalls && (message as RegularMessage).memoryRecalls!.length > 0 && (
+          <MemoryRecallSection
+            recalls={(message as RegularMessage).memoryRecalls!}
+          />
+        )}
+
         {/* AI Message with Enhanced Header */}
         {message.role === 'assistant' && (
           <div className="flex items-center mb-3">

--- a/src/stores/useMessageStore.ts
+++ b/src/stores/useMessageStore.ts
@@ -30,6 +30,7 @@ import { GATEWAY_CONFIG, GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { authTokenStore } from './authTokenStore';
 import { TaskItem, TaskProgress } from '../types/taskTypes';
 import { HILInterruptDetectedEvent, HILCheckpointCreatedEvent, HILExecutionStatusData } from '../types/aguiTypes';
+import type { MemoryRecallData } from '../types/memoryTypes';
 
 // ---------------------------------------------------------------------------
 // State & Action interfaces
@@ -69,6 +70,9 @@ export interface MessageActions {
   setExecutingPlan: (executing: boolean) => void;
   clearTasks: () => void;
   resetTaskHistory: () => void;
+
+  // Memory recall
+  attachMemoryRecall: (messageId: string, recall: MemoryRecallData) => void;
 
   // HIL
   setHILStatus: (status: 'idle' | 'waiting_for_human' | 'processing_response' | 'error') => void;
@@ -272,6 +276,30 @@ export const useMessageStore = create<MessageStore>()(
         currentThreadId: null
       });
       logger.info(LogCategory.CHAT_FLOW, 'Task history and HIL state reset for new session');
+    },
+
+    // -------------------------------------------------------------------
+    // Memory recall
+    // -------------------------------------------------------------------
+
+    attachMemoryRecall: (messageId: string, recall: MemoryRecallData) => {
+      set((state) => {
+        const idx = state.messages.findIndex(m => m.id === messageId);
+        if (idx < 0) return state;
+
+        const msg = state.messages[idx];
+        if (msg.type !== 'regular') return state;
+
+        const existing = msg.memoryRecalls ?? [];
+        const updated = { ...msg, memoryRecalls: [...existing, recall] };
+        const newMessages = [...state.messages];
+        newMessages[idx] = updated;
+        return { messages: newMessages };
+      });
+      logger.info(LogCategory.CHAT_FLOW, 'Memory recall attached to message', {
+        messageId,
+        memoryType: recall.memoryType,
+      });
     },
 
     // -------------------------------------------------------------------

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -50,6 +50,8 @@ export interface RegularMessage extends BaseMessage {
     }>;
     [key: string]: unknown;
   };
+  // Memory recall references attached by the memory_recall event pipeline
+  memoryRecalls?: import('./memoryTypes').MemoryRecallData[];
   // Store相关字段
   processed?: boolean; // 标记用户消息是否已发送到API
   files?: File[]; // 用户上传的文件

--- a/src/types/memoryTypes.ts
+++ b/src/types/memoryTypes.ts
@@ -1,0 +1,10 @@
+export type MemoryType = 'factual' | 'episodic' | 'semantic' | 'procedural' | 'working';
+
+export interface MemoryRecallData {
+  memoryId?: string;
+  memoryType: MemoryType;
+  content: string;
+  learnedAt?: string;
+  confidence?: number;
+  sourceSessionId?: string;
+}


### PR DESCRIPTION
## Summary
Render Mate's memory references as distinct inline cards above assistant messages. Adds MemoryCard component with color-coded memory types, event mapping, and store integration.

## Changes
- `src/types/memoryTypes.ts` — MemoryType and MemoryRecallData types
- `src/components/ui/chat/MemoryCard.tsx` — inline memory card with type-colored borders
- `src/api/adapters/MateEventAdapter.ts` — memory_recall event + tool_use detection
- `src/stores/useMessageStore.ts` — attachMemoryRecall action
- `src/api/chatService.ts` — memory_recall custom event handling
- `src/components/ui/chat/MessageList.tsx` — render MemoryCards above messages

Fixes #127
**Parent Epic**: #106