### PR TITLE
feat(ui): enable natural task scheduling through conversation

### DIFF
--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -221,22 +221,31 @@ export function adaptMateEvent(
       break;
     }
 
-    case 'memory_recall': {
+case 'memory_recall': {
       // Explicit memory recall event from Mate — map to custom_event
       const recallMeta = event.metadata || {};
+
+    case 'schedule_created': {
+      // A new scheduled job was created by Mate
       results.push({
         type: 'custom_event' as AGUIEventType,
         thread_id: threadId,
         timestamp: now,
         run_id: context.runId,
         metadata: {
-          custom_type: 'memory_recall',
+custom_type: 'memory_recall',
           memoryId: recallMeta.memoryId || recallMeta.memory_id || generateId('mem'),
           memoryType: recallMeta.memoryType || recallMeta.memory_type || 'factual',
           content: event.content || recallMeta.content || '',
           learnedAt: recallMeta.learnedAt || recallMeta.learned_at,
           confidence: recallMeta.confidence,
           sourceSessionId: recallMeta.sourceSessionId || recallMeta.source_session_id,
+
+    custom_type: 'schedule_created',
+          job_id: event.job_id,
+          name: (event.metadata?.name as string) || '',
+          cron_expression: (event.metadata?.cron_expression as string) || '',
+          next_run_at: (event.metadata?.next_run_at as string) || '',
         },
       });
       break;

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -35,6 +35,10 @@ import { ChatEmbeddedTaskPanel } from './ChatEmbeddedTaskPanel';
 import { MemoryCard } from './MemoryCard';
 import type { MemoryRecallData } from '../../../types/memoryTypes';
 
+import { ScheduleConfirmationCard } from './ScheduleConfirmationCard';
+import { ScheduleResultCard } from './ScheduleResultCard';
+import type { RegularMessage } from '../../../types/chatTypes';
+
 // MessageActions will be implemented later
 
 // Smart time formatting function
@@ -372,14 +376,31 @@ export const MessageList = memo<MessageListProps>(({
       );
     }
 
+    // Scheduled task result — autonomous messages from the scheduler
+    if (
+      message.type === 'regular' &&
+      (message as RegularMessage).isAutonomous &&
+      (message as RegularMessage).autonomousSource === 'scheduler'
+    ) {
+      return (
+        <div className="mb-6" onClick={() => onMessageClick?.(message)}>
+          <ScheduleResultCard message={message as RegularMessage} />
+        </div>
+      );
+    }
+
     // Default message rendering using GlassMessageBubble with TaskProgress
     return (
       <div className="mb-6" onClick={() => onMessageClick?.(message)}>
-        {/* Memory recall cards — rendered above the assistant bubble */}
+{/* Memory recall cards — rendered above the assistant bubble */}
         {message.role === 'assistant' && message.type === 'regular' && (message as RegularMessage).memoryRecalls && (message as RegularMessage).memoryRecalls!.length > 0 && (
           <MemoryRecallSection
             recalls={(message as RegularMessage).memoryRecalls!}
           />
+
+{/* Schedule confirmation card — inline in assistant messages */}
+        {message.type === 'regular' && (message as RegularMessage).scheduleData && (
+          <ScheduleConfirmationCard data={(message as RegularMessage).scheduleData!} />
         )}
 
         {/* AI Message with Enhanced Header */}

--- a/src/components/ui/chat/RightPanel.tsx
+++ b/src/components/ui/chat/RightPanel.tsx
@@ -20,6 +20,8 @@ import { HILStatusPanel } from '../hil/HILStatusPanel';
 import { HILInterruptData, HILCheckpointData, HILExecutionStatusData } from '../../../types/aguiTypes';
 import { ContextPanel } from '../sidepanel/ContextPanel';
 
+import { UpcomingSchedulePanel } from './UpcomingSchedulePanel';
+
 export interface RightPanelProps {
   className?: string;
   /** When true, render the contextual ContextPanel instead of the static tabs */
@@ -50,6 +52,7 @@ interface SessionMetrics {
 const TABS = [
   { id: 'overview', name: 'Overview', icon: '📊', color: '#22c55e' },
   { id: 'tasks', name: 'Tasks', icon: '⚡', color: '#3b82f6' },
+  { id: 'schedule', name: 'Schedule', icon: '🕐', color: '#06b6d4' },
   { id: 'billing', name: 'Credits', icon: '💰', color: '#f59e0b' },
   { id: 'memory', name: 'Memory', icon: '🧠', color: '#8b5cf6' },
   { id: 'events', name: 'Events', icon: '📡', color: '#ec4899' },
@@ -473,6 +476,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
         <div className="w-full max-w-full overflow-hidden">
           {activeTab === 'overview' && renderOverviewTab()}
           {activeTab === 'tasks' && renderTasksTab()}
+          {activeTab === 'schedule' && <UpcomingSchedulePanel />}
           {activeTab === 'billing' && renderBillingTab()}
           {activeTab === 'memory' && renderMemoryTab()}
           {activeTab === 'events' && renderEventsTab()}

--- a/src/components/ui/chat/ScheduleConfirmationCard.tsx
+++ b/src/components/ui/chat/ScheduleConfirmationCard.tsx
@@ -1,0 +1,106 @@
+/**
+ * ScheduleConfirmationCard — Inline card rendered in assistant messages
+ * when a scheduled job has been created.
+ *
+ * Shows job name, human-readable cron schedule, next run countdown,
+ * and a cancel button.
+ */
+
+import React, { useState, useEffect } from 'react';
+import type { ScheduleConfirmationData } from '../../../types/chatTypes';
+import { cronToHuman } from '../../../utils/cronToHuman';
+import { getMateService } from '../../../api/mateService';
+
+interface ScheduleConfirmationCardProps {
+  data: ScheduleConfirmationData;
+}
+
+function useCountdown(targetIso?: string): string {
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    if (!targetIso) {
+      setLabel('');
+      return;
+    }
+
+    function update() {
+      const diff = new Date(targetIso!).getTime() - Date.now();
+      if (diff <= 0) {
+        setLabel('now');
+        return;
+      }
+      const totalSec = Math.floor(diff / 1000);
+      const h = Math.floor(totalSec / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+      const s = totalSec % 60;
+
+      if (h > 0) {
+        setLabel(`${h}h ${m}m`);
+      } else if (m > 0) {
+        setLabel(`${m}m ${s}s`);
+      } else {
+        setLabel(`${s}s`);
+      }
+    }
+
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [targetIso]);
+
+  return label;
+}
+
+export const ScheduleConfirmationCard: React.FC<ScheduleConfirmationCardProps> = ({ data }) => {
+  const [cancelled, setCancelled] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const countdown = useCountdown(data.nextRunAt);
+
+  const handleCancel = async () => {
+    if (cancelling || cancelled) return;
+    setCancelling(true);
+    try {
+      await getMateService().deleteJob(data.jobId);
+      setCancelled(true);
+    } catch {
+      // Silently fail — the job may already be gone
+      setCancelled(true);
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <div className="my-3 rounded-2xl border-l-4 border-cyan-400 bg-cyan-500/10 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-cyan-400 text-sm font-semibold">Schedule created</span>
+      </div>
+
+      <div className="text-white text-sm font-medium mb-1">{data.name}</div>
+      <div className="text-white/60 text-xs mb-2">{cronToHuman(data.cronExpression)}</div>
+
+      {data.description && (
+        <div className="text-white/50 text-xs mb-2">{data.description}</div>
+      )}
+
+      {countdown && !cancelled && (
+        <div className="text-cyan-300/70 text-xs mb-3">
+          Next run in {countdown}
+        </div>
+      )}
+
+      {cancelled ? (
+        <div className="text-white/40 text-xs">Cancelled</div>
+      ) : (
+        <button
+          onClick={handleCancel}
+          disabled={cancelling}
+          className="text-xs text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
+        >
+          {cancelling ? 'Cancelling...' : 'Cancel schedule'}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/chat/ScheduleResultCard.tsx
+++ b/src/components/ui/chat/ScheduleResultCard.tsx
@@ -1,0 +1,77 @@
+/**
+ * ScheduleResultCard — Rendered for autonomous messages where
+ * autonomousSource === 'scheduler'. Shows the result of a scheduled
+ * task execution with a distinct visual treatment.
+ */
+
+import React, { useState } from 'react';
+import type { RegularMessage } from '../../../types/chatTypes';
+import { getMateService } from '../../../api/mateService';
+
+interface ScheduleResultCardProps {
+  message: RegularMessage;
+}
+
+export const ScheduleResultCard: React.FC<ScheduleResultCardProps> = ({ message }) => {
+  const [rerunning, setRerunning] = useState(false);
+
+  const jobId = message.jobId;
+  const jobName = (message.metadata?.job_name as string) || 'Scheduled Task';
+  const completedAt = message.completedAt || message.timestamp;
+
+  const handleRunAgain = async () => {
+    if (!jobId || rerunning) return;
+    setRerunning(true);
+    try {
+      await getMateService().triggerJob(jobId);
+    } catch {
+      // Silently handle — the job may no longer exist
+    } finally {
+      setRerunning(false);
+    }
+  };
+
+  const formattedTime = new Date(completedAt).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <div className="my-3 rounded-2xl bg-indigo-500/8 border border-indigo-400/20 p-4">
+      {/* Header */}
+      <div className="flex items-center gap-2 mb-3">
+        <svg
+          className="w-4 h-4 text-indigo-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 6v6l4 2" />
+        </svg>
+        <span className="text-indigo-400 text-sm font-semibold">Scheduled Task</span>
+        <span className="text-white/40 text-xs ml-auto">{formattedTime}</span>
+      </div>
+
+      {/* Job name */}
+      <div className="text-white/80 text-xs font-medium mb-2">{jobName}</div>
+
+      {/* Content */}
+      <div className="text-white/70 text-sm whitespace-pre-wrap">
+        {message.content}
+      </div>
+
+      {/* Run again button */}
+      {jobId && (
+        <button
+          onClick={handleRunAgain}
+          disabled={rerunning}
+          className="mt-3 text-xs text-indigo-400 hover:text-indigo-300 transition-colors disabled:opacity-50"
+        >
+          {rerunning ? 'Running...' : 'Run again'}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/chat/UpcomingSchedulePanel.tsx
+++ b/src/components/ui/chat/UpcomingSchedulePanel.tsx
@@ -1,0 +1,144 @@
+/**
+ * UpcomingSchedulePanel — Lightweight panel showing the next 5 scheduled tasks.
+ * Rendered inside the RightPanel "Schedule" tab.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useSchedulerJobs } from '../../../hooks/useSchedulerJobs';
+import { cronToHuman } from '../../../utils/cronToHuman';
+import { getMateService } from '../../../api/mateService';
+
+function Countdown({ targetIso }: { targetIso?: string }) {
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    if (!targetIso) {
+      setLabel('--');
+      return;
+    }
+
+    function update() {
+      const diff = new Date(targetIso!).getTime() - Date.now();
+      if (diff <= 0) {
+        setLabel('now');
+        return;
+      }
+      const totalSec = Math.floor(diff / 1000);
+      const h = Math.floor(totalSec / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+
+      if (h > 24) {
+        const d = Math.floor(h / 24);
+        setLabel(`${d}d ${h % 24}h`);
+      } else if (h > 0) {
+        setLabel(`${h}h ${m}m`);
+      } else {
+        setLabel(`${m}m`);
+      }
+    }
+
+    update();
+    const id = setInterval(update, 30_000);
+    return () => clearInterval(id);
+  }, [targetIso]);
+
+  return <span>{label}</span>;
+}
+
+export const UpcomingSchedulePanel: React.FC = () => {
+  const { jobs, isLoading, error, refetch } = useSchedulerJobs();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDelete = async (jobId: string) => {
+    setDeletingId(jobId);
+    try {
+      await getMateService().deleteJob(jobId);
+      refetch();
+    } catch {
+      // Silently handle
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="text-center py-8">
+        <div className="text-white/40 text-sm">Loading schedules...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-amber-500/10 rounded-lg p-3 border border-amber-500/20">
+        <div className="text-amber-400 text-xs mb-1">Mate may be offline</div>
+        <div className="text-white/50 text-xs">{error}</div>
+        <button
+          onClick={refetch}
+          className="mt-2 text-xs text-amber-400 hover:text-amber-300 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (jobs.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <div className="text-2xl mb-2">&#128337;</div>
+        <div className="text-white/40 text-sm">No scheduled tasks</div>
+        <div className="text-white/30 text-xs mt-1">
+          Ask Mate to schedule something.
+        </div>
+      </div>
+    );
+  }
+
+  const visible = jobs.slice(0, 5);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-white font-medium text-sm">Upcoming</h4>
+        <span className="text-white/40 text-xs">{jobs.length} total</span>
+      </div>
+
+      {visible.map((job) => (
+        <div
+          key={job.job_id}
+          className="bg-white/5 rounded-lg p-3 border border-white/10"
+        >
+          <div className="flex items-start justify-between mb-1">
+            <div className="text-white text-sm font-medium flex-1 mr-2 truncate">
+              {job.name}
+            </div>
+            <button
+              onClick={() => handleDelete(job.job_id)}
+              disabled={deletingId === job.job_id}
+              className="text-red-400/60 hover:text-red-400 text-xs transition-colors disabled:opacity-50 flex-shrink-0"
+              title="Delete schedule"
+            >
+              {deletingId === job.job_id ? '...' : '\u2715'}
+            </button>
+          </div>
+
+          <div className="text-white/50 text-xs mb-1">
+            {job.cron_expression ? cronToHuman(job.cron_expression) : 'One-time'}
+          </div>
+
+          <div className="text-cyan-400/70 text-xs">
+            Next: <Countdown targetIso={job.next_run_at} />
+          </div>
+        </div>
+      ))}
+
+      {jobs.length > 5 && (
+        <div className="text-center py-1">
+          <span className="text-white/40 text-xs">+{jobs.length - 5} more</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useSchedulerJobs.ts
+++ b/src/hooks/useSchedulerJobs.ts
@@ -1,0 +1,68 @@
+/**
+ * useSchedulerJobs — Fetches and polls scheduled jobs from Mate.
+ *
+ * - Calls getMateService().listJobs() on mount and every 60 seconds
+ * - Sorts jobs by next_run_at ascending
+ * - Handles errors gracefully when Mate is offline
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getMateService } from '../api/mateService';
+import type { MateSchedulerJob } from '../types/mateTypes';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useSchedulerJobs');
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseSchedulerJobsResult {
+  jobs: MateSchedulerJob[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useSchedulerJobs(): UseSchedulerJobsResult {
+  const [jobs, setJobs] = useState<MateSchedulerJob[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    try {
+      const mateService = getMateService();
+      const fetched = await mateService.listJobs();
+
+      // Sort by next_run_at ascending (soonest first), nulls last
+      const sorted = [...fetched].sort((a, b) => {
+        if (!a.next_run_at && !b.next_run_at) return 0;
+        if (!a.next_run_at) return 1;
+        if (!b.next_run_at) return -1;
+        return new Date(a.next_run_at).getTime() - new Date(b.next_run_at).getTime();
+      });
+
+      setJobs(sorted);
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn('Failed to fetch scheduler jobs — Mate may be offline', { error: msg });
+      setError(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Initial fetch + polling
+  useEffect(() => {
+    fetchJobs();
+    intervalRef.current = setInterval(fetchJobs, POLL_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [fetchJobs]);
+
+  return { jobs, isLoading, error, refetch: fetchJobs };
+}

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -22,6 +22,15 @@
  *   - 用户认证类型（由auth_types.ts处理）
  */
 
+// Schedule confirmation data — attached to assistant messages when a job is created
+export interface ScheduleConfirmationData {
+  jobId: string;
+  name: string;
+  cronExpression: string;
+  nextRunAt?: string;
+  description?: string;
+}
+
 // 基础消息接口
 export interface BaseMessage {
   id: string;
@@ -59,6 +68,9 @@ export interface RegularMessage extends BaseMessage {
   isAutonomous?: boolean;
   autonomousSource?: AutonomousSource;
   completedAt?: string; // ISO timestamp when the autonomous action finished
+  // Schedule fields — present when the message confirms a scheduled job
+  scheduleData?: ScheduleConfirmationData;
+  jobId?: string;
 }
 
 // 工件消息接口 - 用于显示小部件生成的工件

--- a/src/utils/cronToHuman.ts
+++ b/src/utils/cronToHuman.ts
@@ -1,0 +1,87 @@
+/**
+ * cronToHuman — Convert a cron expression to a human-readable string.
+ *
+ * Handles common patterns; falls back to the raw expression for anything exotic.
+ */
+
+export function cronToHuman(expr: string): string {
+  if (!expr || typeof expr !== 'string') return expr;
+
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return expr;
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+
+  // Every minute: * * * * *
+  if (minute === '*' && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    return 'Every minute';
+  }
+
+  // Every N minutes: */N * * * *
+  const everyNMin = minute.match(/^\*\/(\d+)$/);
+  if (everyNMin && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    const n = parseInt(everyNMin[1], 10);
+    return n === 1 ? 'Every minute' : `Every ${n} minutes`;
+  }
+
+  // Every N hours: 0 */N * * *
+  const everyNHour = hour.match(/^\*\/(\d+)$/);
+  if (minute === '0' && everyNHour && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    const n = parseInt(everyNHour[1], 10);
+    return n === 1 ? 'Every hour' : `Every ${n} hours`;
+  }
+
+  // Specific time patterns (minute and hour are numbers)
+  const m = parseInt(minute, 10);
+  const h = parseInt(hour, 10);
+  if (!isNaN(m) && !isNaN(h) && dayOfMonth === '*' && month === '*') {
+    const time = formatTime(h, m);
+
+    // Every day: 0 9 * * *
+    if (dayOfWeek === '*') {
+      return `Every day at ${time}`;
+    }
+
+    // Weekdays: 0 9 * * 1-5
+    if (dayOfWeek === '1-5') {
+      return `Weekdays at ${time}`;
+    }
+
+    // Weekends: 0 9 * * 0,6 or 0 9 * * 6,0
+    if (dayOfWeek === '0,6' || dayOfWeek === '6,0') {
+      return `Weekends at ${time}`;
+    }
+
+    // Specific days
+    const dayNames = parseDays(dayOfWeek);
+    if (dayNames) {
+      return `${dayNames} at ${time}`;
+    }
+  }
+
+  return expr;
+}
+
+function formatTime(hour: number, minute: number): string {
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  const displayMinute = minute.toString().padStart(2, '0');
+  return `${displayHour}:${displayMinute} ${period}`;
+}
+
+const DAY_NAMES: Record<string, string> = {
+  '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed',
+  '4': 'Thu', '5': 'Fri', '6': 'Sat', '7': 'Sun',
+};
+
+function parseDays(dayOfWeek: string): string | null {
+  // Handle comma-separated: 1,3,5
+  const dayParts = dayOfWeek.split(',');
+  const names: string[] = [];
+  for (const part of dayParts) {
+    const name = DAY_NAMES[part.trim()];
+    if (!name) return null;
+    names.push(name);
+  }
+  return names.join(', ');
+}


### PR DESCRIPTION
## Summary
Users can schedule tasks conversationally. Adds inline confirmation cards, schedule result cards for autonomous completions, upcoming tasks panel, and cron-to-human utility.

## Changes
- `src/components/ui/chat/ScheduleConfirmationCard.tsx` — inline schedule confirmation
- `src/components/ui/chat/ScheduleResultCard.tsx` — autonomous task result card
- `src/components/ui/chat/UpcomingSchedulePanel.tsx` — right panel schedule tab
- `src/hooks/useSchedulerJobs.ts` — polling hook for scheduler API
- `src/utils/cronToHuman.ts` — cron expression to human-readable text
- Adapter, store, and MessageList wiring

Fixes #128
**Parent Epic**: #106