### PR TITLE
feat(ui): show transparent delegation with live progress

### DIFF
--- a/src/components/ui/chat/DelegationCard.tsx
+++ b/src/components/ui/chat/DelegationCard.tsx
@@ -1,0 +1,121 @@
+/**
+ * DelegationCard — inline progress card for Mate team delegation.
+ *
+ * Shows 3 states:
+ *   - delegating: "Asking the [team] to help..." with pulsing bar
+ *   - working:    "[team] is working on it..." with progress animation
+ *   - completed / failed: "[team] Done / Failed" (static)
+ */
+import React, { memo, useState } from 'react';
+import { DelegationState } from '../../../types/chatTypes';
+import { DELEGATION_TEAMS } from '../../../constants/delegationTeams';
+
+export interface DelegationCardProps {
+  delegation: DelegationState;
+}
+
+export const DelegationCard = memo<DelegationCardProps>(({ delegation }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const team = DELEGATION_TEAMS[delegation.teamId];
+  if (!team) return null;
+
+  const isActive = delegation.status === 'delegating' || delegation.status === 'working';
+  const isDone = delegation.status === 'completed';
+  const isFailed = delegation.status === 'failed';
+
+  const statusText = (() => {
+    switch (delegation.status) {
+      case 'delegating':
+        return `Asking the ${team.label} to help...`;
+      case 'working':
+        return `${team.label} is working on it...`;
+      case 'completed':
+        return `${team.label} \u2713 Done`;
+      case 'failed':
+        return `${team.label} \u2717 Failed`;
+    }
+  })();
+
+  return (
+    <div
+      className="my-3 ml-12 rounded-xl border border-white/10 overflow-hidden transition-all duration-300"
+      style={{
+        borderLeftWidth: 3,
+        borderLeftColor: team.color,
+        background: 'rgba(255, 255, 255, 0.04)',
+        backdropFilter: 'blur(8px)',
+      }}
+    >
+      <div
+        className="flex items-center gap-3 px-4 py-3 cursor-pointer select-none"
+        onClick={() => (isDone || isFailed) && setExpanded((e) => !e)}
+      >
+        {/* Team icon */}
+        <span className="text-lg flex-shrink-0">{team.icon}</span>
+
+        {/* Status text */}
+        <span className="text-sm font-medium text-white/90 flex-1">
+          {statusText}
+        </span>
+
+        {/* Expand chevron for completed / failed */}
+        {(isDone || isFailed) && (
+          <svg
+            className={`w-4 h-4 text-white/50 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+
+      {/* Animated progress bar for active states */}
+      {isActive && (
+        <div className="h-0.5 w-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.05)' }}>
+          <div
+            className="h-full animate-pulse"
+            style={{
+              width: delegation.status === 'delegating' ? '40%' : '70%',
+              background: `linear-gradient(90deg, ${team.color}00, ${team.color}, ${team.color}00)`,
+              animation: 'delegation-slide 1.8s ease-in-out infinite',
+            }}
+          />
+        </div>
+      )}
+
+      {/* Expandable detail section */}
+      {expanded && (isDone || isFailed) && (
+        <div className="px-4 pb-3 pt-1 text-xs text-white/50 border-t border-white/5">
+          {delegation.error && (
+            <p className="text-red-400/80">{delegation.error}</p>
+          )}
+          {delegation.result != null && !delegation.error ? (
+            <pre className="whitespace-pre-wrap break-words max-h-40 overflow-y-auto">
+              {typeof delegation.result === 'string'
+                ? delegation.result
+                : JSON.stringify(delegation.result, null, 2)}
+            </pre>
+          ) : null}
+          {delegation.result == null && !delegation.error && (
+            <p>Completed with no output.</p>
+          )}
+        </div>
+      )}
+
+      {/* Inline keyframes for the sliding animation */}
+      <style>{`
+        @keyframes delegation-slide {
+          0% { transform: translateX(-100%); }
+          50% { transform: translateX(150%); }
+          100% { transform: translateX(-100%); }
+        }
+      `}</style>
+    </div>
+  );
+});
+
+DelegationCard.displayName = 'DelegationCard';

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -39,6 +39,9 @@ import { ScheduleConfirmationCard } from './ScheduleConfirmationCard';
 import { ScheduleResultCard } from './ScheduleResultCard';
 import type { RegularMessage } from '../../../types/chatTypes';
 
+import { DelegationCard } from './DelegationCard';
+import { useMessageStore } from '../../../stores/useMessageStore';
+
 // MessageActions will be implemented later
 
 // Smart time formatting function
@@ -155,7 +158,7 @@ const useVirtualScrolling = (
 };
 
 /**
- * MemoryRecallSection — Shows up to 3 MemoryCards with "Show N more" expansion.
+* MemoryRecallSection — Shows up to 3 MemoryCards with "Show N more" expansion.
  */
 const MAX_VISIBLE_RECALLS = 3;
 
@@ -187,6 +190,22 @@ const MemoryRecallSection = memo<{ recalls: MemoryRecallData[] }>(({ recalls }) 
 });
 
 MemoryRecallSection.displayName = 'MemoryRecallSection';
+
+* DelegationCards — renders active delegations from the message store.
+ * Only displayed after the last assistant message in the stream.
+ */
+const DelegationCards = memo(() => {
+  const activeDelegations = useMessageStore((s) => s.activeDelegations);
+  if (activeDelegations.length === 0) return null;
+  return (
+    <>
+      {activeDelegations.map((d) => (
+        <DelegationCard key={d.toolCallId} delegation={d} />
+      ))}
+    </>
+  );
+});
+DelegationCards.displayName = 'DelegationCards';
 
 /**
  * MessageList - Pure UI component for displaying chat messages
@@ -407,7 +426,7 @@ export const MessageList = memo<MessageListProps>(({
         {message.role === 'assistant' && (
           <div className="flex items-center mb-3">
             {showAvatars && (
-              <div className="relative">
+<div className="relative">
                 <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white shadow-lg ${
                   isStreaming
                     ? 'bg-gradient-to-br from-[#7c8cf5] to-[#a78bfa] shadow-[#7c8cf5]/30'
@@ -422,7 +441,16 @@ export const MessageList = memo<MessageListProps>(({
               </div>
             )}
             <span className="ml-2 text-sm font-display font-semibold text-[var(--mate-accent)]">Mate</span>
-            
+
+<div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm backdrop-blur-sm border border-white/20 text-white/90 shadow-lg ${
+                isStreaming
+                  ? 'bg-gradient-to-br from-blue-500 to-purple-500 shadow-blue-500/30'
+                  : 'bg-white/10'
+              }`}>
+                🤖
+              </div>
+            )}
+            <span className="ml-2 text-sm font-medium text-white/90">AI Assistant</span>
             {/* Streaming Status */}
             {isStreaming && (
               <div className="ml-3 flex items-center space-x-2 bg-blue-500/20 px-3 py-1.5 rounded-full border border-blue-400/40 shadow-lg">
@@ -436,10 +464,10 @@ export const MessageList = memo<MessageListProps>(({
                 </span>
               </div>
             )}
-            
+
             {/* Task Progress for ALL AI messages */}
             <div className="ml-3">
-              <TaskProgressMessage 
+              <TaskProgressMessage
                 messageId={message.id}
                 compact={true}
                 showControls={false}
@@ -450,7 +478,7 @@ export const MessageList = memo<MessageListProps>(({
             </div>
           </div>
         )}
-        
+
         {/* Message Content */}
         <div className={message.role === 'assistant' ? 'ml-12' : ''}>
           <GlassMessageBubble
@@ -468,6 +496,9 @@ export const MessageList = memo<MessageListProps>(({
             onCopy={() => navigator.clipboard.writeText(message.content)}
           />
         </div>
+
+        {/* Delegation Cards — show after the last assistant message */}
+        {message.role === 'assistant' && <DelegationCards />}
       </div>
     );
   };

--- a/src/constants/delegationTeams.ts
+++ b/src/constants/delegationTeams.ts
@@ -1,0 +1,18 @@
+/**
+ * Delegation Teams Registry
+ *
+ * Maps tool names that represent team delegation to their display metadata.
+ * When Mate delegates work to a sub-team (e.g. isa_vibe, isa_trade),
+ * these entries power the inline DelegationCard UI.
+ */
+
+export const DELEGATION_TEAMS: Record<string, { label: string; icon: string; color: string }> = {
+  isa_vibe: { label: 'Dev Team', icon: '\u{1F4BB}', color: '#3b82f6' },
+  isa_trade: { label: 'Trading Team', icon: '\u{1F4C8}', color: '#10b981' },
+  isa_creative: { label: 'Creative Team', icon: '\u{1F3A8}', color: '#8b5cf6' },
+  isa_marketing: { label: 'Marketing Team', icon: '\u{1F4E3}', color: '#f59e0b' },
+};
+
+export function isDelegationTool(toolName: string): boolean {
+  return toolName in DELEGATION_TEAMS;
+}

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -5,10 +5,12 @@
  * All handler logic is identical to the original — this is a move, not a refactor.
  */
 import { useChatStore } from '../../stores/useChatStore';
+import { useMessageStore } from '../../stores/useMessageStore';
 import { logger, LogCategory, createLogger } from '../../utils/logger';
 import { detectPluginTrigger, executePlugin } from '../../plugins';
 import { ArtifactMessage } from '../../types/chatTypes';
 import { AppId } from '../../types/appTypes';
+import { isDelegationTool } from '../../constants/delegationTeams';
 
 const log = createLogger('ChatModule:Message');
 
@@ -202,6 +204,20 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
             useChatStore.getState().setIsTyping(false);
             useChatStore.getState().setExecutingPlan(false);
             logger.info(LogCategory.CHAT_FLOW, 'Message sending completed successfully');
+          },
+          onToolStart: (toolName: string, toolCallId?: string) => {
+            if (isDelegationTool(toolName) && toolCallId) {
+              useMessageStore.getState().startDelegation(toolName, toolCallId);
+            }
+          },
+          onToolCompleted: (toolName: string, result?: any, error?: string) => {
+            const delegations = useMessageStore.getState().activeDelegations;
+            const active = delegations.find(
+              (d) => d.teamId === toolName && (d.status === 'delegating' || d.status === 'working')
+            );
+            if (active) {
+              useMessageStore.getState().completeDelegation(active.toolCallId, result, error);
+            }
           },
           onError: (error: Error) => {
             logger.error(LogCategory.CHAT_FLOW, 'Message sending failed', { error: error.message });

--- a/src/stores/useMessageStore.ts
+++ b/src/stores/useMessageStore.ts
@@ -23,7 +23,7 @@ import { logger, LogCategory, createLogger } from '../utils/logger';
 const log = createLogger('MessageStore', LogCategory.CHAT_FLOW);
 
 import { getChatServiceInstance } from '../hooks/useChatService';
-import { ChatMessage, StreamingStatus } from '../types/chatTypes';
+import { ChatMessage, StreamingStatus, DelegationState } from '../types/chatTypes';
 import { useUserStore } from './useUserStore';
 import { useSessionStore } from './useSessionStore';
 import { GATEWAY_CONFIG, GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
@@ -52,6 +52,9 @@ export interface MessageStoreState {
   hilHistory: HILInterruptDetectedEvent[];
   hilCheckpoints: HILCheckpointCreatedEvent[];
   currentThreadId: string | null;
+
+  // Delegation tracking (Mate -> sub-team tool calls)
+  activeDelegations: DelegationState[];
 }
 
 export interface MessageActions {
@@ -83,6 +86,11 @@ export interface MessageActions {
   clearHILState: () => void;
   resumeHILExecution: (sessionId: string, resumeValue: any, token?: string) => Promise<void>;
   checkExecutionStatus: (sessionId: string, token?: string) => Promise<any>;
+
+  // Delegation actions
+  startDelegation: (toolName: string, toolCallId: string) => void;
+  completeDelegation: (toolCallId: string, result?: unknown, error?: string) => void;
+  clearDelegations: () => void;
 }
 
 export type MessageStore = MessageStoreState & MessageActions;
@@ -106,6 +114,8 @@ export const useMessageStore = create<MessageStore>()(
     hilHistory: [],
     hilCheckpoints: [],
     currentThreadId: null,
+
+    activeDelegations: [],
 
     // -------------------------------------------------------------------
     // Message operations
@@ -536,6 +546,59 @@ export const useMessageStore = create<MessageStore>()(
         });
         throw error;
       }
-    }
+    },
+
+    // -------------------------------------------------------------------
+    // Delegation operations
+    // -------------------------------------------------------------------
+
+    startDelegation: (toolName: string, toolCallId: string) => {
+      const delegation: DelegationState = {
+        toolCallId,
+        teamId: toolName,
+        status: 'delegating',
+        startedAt: new Date().toISOString(),
+      };
+      set((state) => ({
+        activeDelegations: [...state.activeDelegations, delegation],
+      }));
+      // Transition to 'working' after a short delay to show the delegating phase
+      setTimeout(() => {
+        set((state) => ({
+          activeDelegations: state.activeDelegations.map((d) =>
+            d.toolCallId === toolCallId && d.status === 'delegating'
+              ? { ...d, status: 'working' as const }
+              : d
+          ),
+        }));
+      }, 1200);
+      logger.info(LogCategory.CHAT_FLOW, 'Delegation started', { toolName, toolCallId });
+    },
+
+    completeDelegation: (toolCallId: string, result?: unknown, error?: string) => {
+      set((state) => ({
+        activeDelegations: state.activeDelegations.map((d) =>
+          d.toolCallId === toolCallId
+            ? {
+                ...d,
+                status: (error ? 'failed' : 'completed') as DelegationState['status'],
+                completedAt: new Date().toISOString(),
+                result,
+                error,
+              }
+            : d
+        ),
+      }));
+      logger.info(LogCategory.CHAT_FLOW, 'Delegation completed', { toolCallId, hasError: !!error });
+    },
+
+    clearDelegations: () => {
+      set((state) => ({
+        activeDelegations: state.activeDelegations.filter(
+          (d) => d.status !== 'completed' && d.status !== 'failed'
+        ),
+      }));
+      logger.info(LogCategory.CHAT_FLOW, 'Completed delegations cleared');
+    },
   }))
 );

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -126,6 +126,17 @@ export function getMessageContent(message: ChatMessage): string {
   return `Generated ${message.artifact.widgetName ?? message.artifact.widgetType} content`;
 }
 
+// Delegation state — tracks when Mate delegates to a sub-team tool
+export interface DelegationState {
+  toolCallId: string;
+  teamId: string;
+  status: 'delegating' | 'working' | 'completed' | 'failed';
+  startedAt: string;
+  completedAt?: string;
+  result?: unknown;
+  error?: string;
+}
+
 // 流式消息状态枚举
 export type StreamingStatus = 
   | 'connecting'


### PR DESCRIPTION
## Summary
When Mate delegates to specialist teams, the chat shows inline progress cards with team identity, animated states, and result attribution.

## Changes
- `src/constants/delegationTeams.ts` — team registry and isDelegationTool helper
- `src/components/ui/chat/DelegationCard.tsx` — 3-state inline delegation card
- `src/stores/useMessageStore.ts` — activeDelegations state and actions
- `src/modules/handlers/messageHandlers.ts` — onToolStart/onToolCompleted wiring
- `src/components/ui/chat/MessageList.tsx` — DelegationCards rendering

Fixes #129
**Parent Epic**: #106