### PR TITLE
feat(api): implement HttpOnly auth cookies with cross-zone SSO

### DIFF
--- a/src/api/BaseApiService.ts
+++ b/src/api/BaseApiService.ts
@@ -41,6 +41,7 @@ import axios, {
 } from 'axios';
 import { config } from '../config';
 import { createLogger, LogCategory } from '../utils/logger';
+import { getCredentialsMode } from '../utils/authCookieHelper';
 
 const log = createLogger('BaseApiService', LogCategory.API_REQUEST);
 
@@ -114,11 +115,12 @@ export class BaseApiService {
       'Accept': 'application/json'
     };
 
-    // 初始化axios实例
+    // 初始化axios实例 — withCredentials sends cookies cross-origin
     this.axiosInstance = axios.create({
       baseURL: this.baseUrl,
       timeout: this.timeout,
-      headers: this.defaultHeaders
+      headers: this.defaultHeaders,
+      withCredentials: true,
     });
 
     this.setupAxiosInterceptors();
@@ -287,7 +289,8 @@ export class BaseApiService {
           method,
           headers: requestHeaders,
           body: body ? JSON.stringify(body) : undefined,
-          signal: controller.signal
+          signal: controller.signal,
+          credentials: getCredentialsMode(),
         });
 
         clearTimeout(timeoutId);
@@ -393,7 +396,8 @@ export class BaseApiService {
         const response = await fetch(url, {
           method: 'POST',
           body: formData,
-          headers
+          headers,
+          credentials: getCredentialsMode(),
         });
 
         if (!response.ok) {

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -17,6 +17,7 @@
 
 import { getGatewayUrl } from './runtimeEnv';
 import { authTokenStore } from '../stores/authTokenStore';
+import { clearAuthCookies, getCredentialsMode, isHttpOnlyCookieMode } from '../utils/authCookieHelper';
 
 // ================================================================================
 // 网关基础配置
@@ -40,6 +41,14 @@ export const GATEWAY_CONFIG = {
     API_KEY_HEADER: 'X-API-Key',
   },
   
+  // Cross-zone SSO cookie config
+  COOKIE: {
+    /** Domain scope for auth cookies — all zones share the session */
+    DOMAIN: process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || '.iapro.ai',
+    /** Credentials mode for fetch/axios — 'include' sends cookies cross-origin */
+    CREDENTIALS_MODE: (process.env.NEXT_PUBLIC_AUTH_CREDENTIALS_MODE as RequestCredentials) || 'include',
+  },
+
   // 超时配置
   TIMEOUT: {
     DEFAULT: 30000,      // 30秒
@@ -328,6 +337,7 @@ export const saveAuthToken = (token: string): void => {
  */
 export const clearAuth = (): void => {
   authTokenStore.clearToken();
+  clearAuthCookies();
   // Clean up legacy localStorage entries from pre-migration
   if (typeof window !== 'undefined') {
     localStorage.removeItem(GATEWAY_CONFIG.AUTH.TOKEN_KEY);

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -11,6 +11,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback } fr
 import { GATEWAY_ENDPOINTS, GATEWAY_CONFIG } from '../config/gatewayConfig';
 import { getAuthHeaders, saveAuthToken, clearAuth } from '../config/gatewayConfig';
 import { authTokenStore } from '../stores/authTokenStore';
+import { isHttpOnlyCookieMode, clearAuthCookies, getCredentialsMode } from '../utils/authCookieHelper';
 import { logger, LogCategory } from '../utils/logger';
 
 // ================================================================================
@@ -143,10 +144,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const data = await res.json();
       const tokenValue = data.token || data.access_token;
-      if (!tokenValue) {
+      // In cookie mode the gateway sets the auth cookie via Set-Cookie header.
+      // We still cache the token in memory as a fallback for Bearer header auth
+      // and for non-cookie environments (development).
+      if (tokenValue) {
+        saveAuthToken(tokenValue);
+      } else if (!isHttpOnlyCookieMode()) {
         throw new Error('Server did not return an auth token');
       }
-      saveAuthToken(tokenValue);
       const user = data.user || {};
       setAuthUser({
         ...user,
@@ -243,7 +248,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const logout = useCallback(() => {
+    // Fire-and-forget gateway logout so the server can clear the HttpOnly cookie
+    fetch(GATEWAY_ENDPOINTS.AUTH.BASE + '/logout', {
+      method: 'POST',
+      credentials: getCredentialsMode(),
+    }).catch(() => {
+      // Best-effort — don't block client-side logout on network errors
+    });
     clearAuth();
+    clearAuthCookies();
     setAuthUser(null);
     setError(null);
     logger.info(LogCategory.USER_AUTH, 'User logged out');

--- a/src/stores/authTokenStore.ts
+++ b/src/stores/authTokenStore.ts
@@ -4,13 +4,27 @@
  * Replaces localStorage token storage to prevent XSS token theft.
  * Access tokens live only in memory; a refresh-token HttpOnly cookie
  * (set by the gateway) restores the session on page reload.
+ *
+ * In development (non-HttpOnly) mode the store can fall back to reading
+ * the access token from a regular cookie set by the gateway.
  */
+
+import { getTokenFromCookie } from '../utils/authCookieHelper';
 
 let _accessToken: string | null = null;
 
 export const authTokenStore = {
-  getToken: (): string | null => _accessToken,
+  /** Return the cached in-memory token, falling back to a dev cookie. */
+  getToken: (): string | null => {
+    if (_accessToken) return _accessToken;
+    // In dev the cookie is not HttpOnly so we can read it as a fallback
+    const fromCookie = getTokenFromCookie();
+    if (fromCookie) {
+      _accessToken = fromCookie;
+    }
+    return _accessToken;
+  },
   setToken: (token: string | null): void => { _accessToken = token; },
   clearToken: (): void => { _accessToken = null; },
-  hasToken: (): boolean => _accessToken !== null,
+  hasToken: (): boolean => authTokenStore.getToken() !== null,
 };

--- a/src/utils/authCookieHelper.ts
+++ b/src/utils/authCookieHelper.ts
@@ -1,0 +1,71 @@
+/**
+ * Auth Cookie Helpers
+ *
+ * Utilities for cookie-based auth in production (HttpOnly cookies managed
+ * by the gateway via Set-Cookie headers) and development (regular cookies
+ * readable by JavaScript).
+ *
+ * In production the gateway sets HttpOnly cookies on `.iapro.ai` so all
+ * zones (/, /console, /docs) share the session automatically. The frontend
+ * only needs `credentials: 'include'` on fetch calls.
+ *
+ * In development (localhost) cookies are not HttpOnly, so these helpers
+ * can read/clear them for debugging and fallback purposes.
+ */
+
+const AUTH_COOKIE_NAME = 'isa_access_token';
+const REFRESH_COOKIE_NAME = 'isa_refresh_token';
+
+/**
+ * Returns true when the app is running in production cookie mode where
+ * the gateway manages HttpOnly Set-Cookie headers. In this mode the
+ * frontend cannot read the cookie value directly — it just sends
+ * `credentials: 'include'` and trusts the gateway.
+ */
+export function isHttpOnlyCookieMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  const domain = process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || '.iapro.ai';
+  // In production the hostname will be under .iapro.ai
+  return window.location.hostname.endsWith(domain.replace(/^\./, ''));
+}
+
+/**
+ * Read the access token cookie (only works in dev mode where the cookie
+ * is NOT HttpOnly). Returns null when HttpOnly or absent.
+ */
+export function getTokenFromCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${AUTH_COOKIE_NAME}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Clear auth cookies on logout by setting their expiry to the past.
+ * Works for non-HttpOnly cookies (dev). For HttpOnly cookies the
+ * gateway logout endpoint must clear them via Set-Cookie.
+ */
+export function clearAuthCookies(): void {
+  if (typeof document === 'undefined') return;
+  const domain = process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || '.iapro.ai';
+  const expires = 'Thu, 01 Jan 1970 00:00:00 GMT';
+
+  // Clear with domain scope (production)
+  document.cookie = `${AUTH_COOKIE_NAME}=; expires=${expires}; path=/; domain=${domain}`;
+  document.cookie = `${REFRESH_COOKIE_NAME}=; expires=${expires}; path=/; domain=${domain}`;
+
+  // Clear without domain scope (localhost dev)
+  document.cookie = `${AUTH_COOKIE_NAME}=; expires=${expires}; path=/`;
+  document.cookie = `${REFRESH_COOKIE_NAME}=; expires=${expires}; path=/`;
+}
+
+/**
+ * Return the credentials mode appropriate for the current environment.
+ * - `'include'` in production so cross-origin cookies are sent to the gateway.
+ * - `'include'` in development too (gateway on different port counts as
+ *   cross-origin), but can be overridden via env var if needed.
+ */
+export function getCredentialsMode(): RequestCredentials {
+  return (process.env.NEXT_PUBLIC_AUTH_CREDENTIALS_MODE as RequestCredentials) || 'include';
+}


### PR DESCRIPTION
Fixes #113. Parent Epic #105. Auth cookies on .iapro.ai domain, credentials:include, cookie helpers.