### PR TITLE
feat(ui): integrate @isa/theme dark/light toggle (#195)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@isa/core": "^0.1.0",
     "@isa/transport": "^0.1.0",
+    "@isa/theme": "^2.0.0",
     "@isa/ui-web": "^0.1.0",
     "@rudderstack/analytics-js": "^3.23.2",
     "@supabase/supabase-js": "^2.57.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
+import { ThemeProvider } from '../src/providers/ThemeProvider'
 import { AnalyticsProvider } from '../src/providers/AnalyticsProvider'
 import { isMarketingHostname } from '../src/config/surfaceConfig'
 import { createLogger } from '@/utils/logger'
@@ -18,10 +19,12 @@ export default function App({ Component, pageProps }: AppProps) {
   }, [])
 
   // Auth is handled by AuthProvider in src/app.tsx — not duplicated here
-  
+
   return (
-    <AnalyticsProvider>
-      <Component {...pageProps} />
-    </AnalyticsProvider>
+    <ThemeProvider>
+      <AnalyticsProvider>
+        <Component {...pageProps} />
+      </AnalyticsProvider>
+    </ThemeProvider>
   )
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,31 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
+/**
+ * Inline script that runs before React hydration to prevent theme FOUC.
+ * Reads the stored preference from localStorage and applies the correct
+ * class/attribute so the first paint matches the user's preference.
+ */
+const themeInitScript = `
+(function() {
+  try {
+    var pref = localStorage.getItem('theme');
+    var resolved = pref;
+    if (!pref || pref === 'system') {
+      resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    var d = document.documentElement;
+    if (resolved === 'dark') {
+      d.classList.add('dark');
+      d.style.colorScheme = 'dark';
+    } else {
+      d.classList.remove('dark');
+      d.setAttribute('data-theme', 'light');
+      d.style.colorScheme = 'light';
+    }
+  } catch(e) {}
+})();
+`;
+
 export default function Document() {
   return (
     <Html lang="en">
@@ -8,6 +34,7 @@ export default function Document() {
         <meta charSet="utf-8" />
       </Head>
       <body>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <Main />
         <NextScript />
       </body>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,111 +1,35 @@
 /**
  * ============================================================================
- * Theme Hook (useTheme.ts) - 主题管理 Hook
+ * Theme Hook (useTheme.ts) - Backward-compatible re-export
  * ============================================================================
- * 
- * 功能：
- * - 管理应用主题状态
- * - 同步localStorage
- * - 响应系统主题变化
+ *
+ * Delegates to useThemePreference. Existing consumers that import useTheme
+ * continue to work without changes.
+ *
+ * Prefer useThemePreference or useThemeContext for new code.
  */
 
-import { useState, useEffect } from 'react';
-import { createLogger } from '../utils/logger';
+import { useThemePreference } from './useThemePreference';
+import type { ResolvedTheme } from './useThemePreference';
 
-const log = createLogger('useTheme');
-
-export type Theme = 'light' | 'dark';
+export type Theme = ResolvedTheme;
 
 export const useTheme = () => {
-  const [theme, setTheme] = useState<Theme>('dark');
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    // 获取初始主题
-    const initializeTheme = () => {
-      try {
-        // 1. 检查localStorage中的保存值
-        const savedTheme = localStorage.getItem('theme') as Theme | null;
-        
-        // 2. 检查系统偏好
-        const systemPreference = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        
-        // 3. 决定最终主题
-        const initialTheme = savedTheme || systemPreference;
-        
-        setTheme(initialTheme);
-        applyTheme(initialTheme);
-        setIsLoading(false);
-      } catch (error) {
-        log.warn('Failed to initialize theme:', error);
-        setTheme('dark'); // 默认深色主题
-        applyTheme('dark');
-        setIsLoading(false);
-      }
-    };
-
-    initializeTheme();
-
-    // 监听系统主题变化
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleSystemThemeChange = (e: MediaQueryListEvent) => {
-      // 只有当用户没有手动设置主题时才跟随系统
-      const savedTheme = localStorage.getItem('theme');
-      if (!savedTheme) {
-        const newTheme = e.matches ? 'dark' : 'light';
-        setTheme(newTheme);
-        applyTheme(newTheme);
-      }
-    };
-
-    mediaQuery.addEventListener('change', handleSystemThemeChange);
-    
-    return () => {
-      mediaQuery.removeEventListener('change', handleSystemThemeChange);
-    };
-  }, []);
-
-  const applyTheme = (newTheme: Theme) => {
-    const root = document.documentElement;
-    
-    if (newTheme === 'light') {
-      root.setAttribute('data-theme', 'light');
-      root.style.colorScheme = 'light';
-    } else {
-      root.removeAttribute('data-theme');
-      root.style.colorScheme = 'dark';
-    }
-  };
-
-  const toggleTheme = () => {
-    const newTheme = theme === 'dark' ? 'light' : 'dark';
-    setTheme(newTheme);
-    applyTheme(newTheme);
-    
-    try {
-      localStorage.setItem('theme', newTheme);
-    } catch (error) {
-      log.warn('Failed to save theme to localStorage:', error);
-    }
-  };
-
-  const setThemeDirectly = (newTheme: Theme) => {
-    setTheme(newTheme);
-    applyTheme(newTheme);
-    
-    try {
-      localStorage.setItem('theme', newTheme);
-    } catch (error) {
-      log.warn('Failed to save theme to localStorage:', error);
-    }
-  };
+  const {
+    resolvedTheme,
+    isReady,
+    toggle,
+    setPreference,
+    isDark,
+    isLight,
+  } = useThemePreference();
 
   return {
-    theme,
-    isLoading,
-    toggleTheme,
-    setTheme: setThemeDirectly,
-    isDark: theme === 'dark',
-    isLight: theme === 'light'
+    theme: resolvedTheme,
+    isLoading: !isReady,
+    toggleTheme: toggle,
+    setTheme: (t: Theme) => setPreference(t),
+    isDark,
+    isLight,
   };
 };

--- a/src/hooks/useThemePreference.ts
+++ b/src/hooks/useThemePreference.ts
@@ -1,0 +1,185 @@
+/**
+ * ============================================================================
+ * useThemePreference Hook - Theme preference management
+ * ============================================================================
+ *
+ * Integrates @isa/theme dark/light token sets with:
+ * - Three-way preference: 'light', 'dark', 'system'
+ * - localStorage persistence (key: 'theme')
+ * - System preference detection via matchMedia
+ * - Toggles 'dark' class on <html> for Tailwind dark mode
+ * - Sets data-theme attribute for CSS variable overrides
+ * - Exposes resolved theme tokens from @isa/theme
+ *
+ * Related: #195
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { lightTheme, darkTheme } from '@isa/theme';
+import type { Theme as ThemeTokens } from '@isa/theme';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useThemePreference');
+
+const STORAGE_KEY = 'theme';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+export interface UseThemePreferenceReturn {
+  /** The user's stored preference ('light' | 'dark' | 'system') */
+  preference: ThemePreference;
+  /** The resolved theme after evaluating system preference ('light' | 'dark') */
+  resolvedTheme: ResolvedTheme;
+  /** Set the theme preference */
+  setPreference: (pref: ThemePreference) => void;
+  /** Toggle between light and dark (skips system) */
+  toggle: () => void;
+  /** Whether the hook has finished initializing */
+  isReady: boolean;
+  /** Convenience: true when resolved theme is dark */
+  isDark: boolean;
+  /** Convenience: true when resolved theme is light */
+  isLight: boolean;
+  /** The active @isa/theme token set for the resolved theme */
+  tokens: ThemeTokens;
+}
+
+/**
+ * Read the system color-scheme preference.
+ */
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+/**
+ * Read stored preference from localStorage. Returns null when absent or invalid.
+ */
+function readStoredPreference(): ThemePreference | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  } catch {
+    // SSR or storage unavailable
+  }
+  return null;
+}
+
+/**
+ * Persist preference to localStorage.
+ */
+function writeStoredPreference(pref: ThemePreference): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, pref);
+  } catch (err) {
+    log.warn('Failed to persist theme preference:', err);
+  }
+}
+
+/**
+ * Resolve a preference to a concrete theme.
+ */
+function resolveTheme(pref: ThemePreference): ResolvedTheme {
+  if (pref === 'system') return getSystemTheme();
+  return pref;
+}
+
+/**
+ * Apply the resolved theme to the DOM:
+ * - Adds/removes 'dark' class on <html> (Tailwind darkMode: 'class')
+ * - Sets/removes data-theme attribute (CSS variable overrides)
+ * - Sets color-scheme meta for native browser widgets
+ */
+function applyThemeToDOM(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined') return;
+
+  const root = document.documentElement;
+
+  if (resolved === 'dark') {
+    root.classList.add('dark');
+    root.removeAttribute('data-theme');
+    root.style.colorScheme = 'dark';
+  } else {
+    root.classList.remove('dark');
+    root.setAttribute('data-theme', 'light');
+    root.style.colorScheme = 'light';
+  }
+}
+
+export function useThemePreference(): UseThemePreferenceReturn {
+  const [preference, setPreferenceState] = useState<ThemePreference>('dark');
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>('dark');
+  const [isReady, setIsReady] = useState(false);
+
+  // Resolve once we know both preference and system theme
+  const resolvedTheme: ResolvedTheme = preference === 'system' ? systemTheme : preference;
+
+  // Initialize from storage + system
+  useEffect(() => {
+    const stored = readStoredPreference();
+    const system = getSystemTheme();
+    setSystemTheme(system);
+
+    const initial = stored ?? 'system';
+    setPreferenceState(initial);
+
+    const resolved = initial === 'system' ? system : initial;
+    applyThemeToDOM(resolved);
+    setIsReady(true);
+
+    log.info(`Theme initialized: preference=${initial}, resolved=${resolved}`);
+  }, []);
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handler = (e: MediaQueryListEvent) => {
+      const newSystem: ResolvedTheme = e.matches ? 'dark' : 'light';
+      setSystemTheme(newSystem);
+      log.info(`System theme changed to ${newSystem}`);
+    };
+
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  // Apply theme to DOM whenever resolved theme changes
+  useEffect(() => {
+    if (isReady) {
+      applyThemeToDOM(resolvedTheme);
+    }
+  }, [resolvedTheme, isReady]);
+
+  const setPreference = useCallback((pref: ThemePreference) => {
+    setPreferenceState(pref);
+    writeStoredPreference(pref);
+    const resolved = resolveTheme(pref);
+    applyThemeToDOM(resolved);
+    log.info(`Theme preference set to ${pref} (resolved: ${resolved})`);
+  }, []);
+
+  const toggle = useCallback(() => {
+    const next: ResolvedTheme = resolvedTheme === 'dark' ? 'light' : 'dark';
+    setPreference(next);
+  }, [resolvedTheme, setPreference]);
+
+  const tokens: ThemeTokens = useMemo(
+    () => (resolvedTheme === 'dark' ? darkTheme : lightTheme),
+    [resolvedTheme],
+  );
+
+  return {
+    preference,
+    resolvedTheme,
+    setPreference,
+    toggle,
+    isReady,
+    isDark: resolvedTheme === 'dark',
+    isLight: resolvedTheme === 'light',
+    tokens,
+  };
+}

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,0 +1,45 @@
+/**
+ * ============================================================================
+ * ThemeProvider - React context for theme preference
+ * ============================================================================
+ *
+ * Wraps useThemePreference in a context so any component can access
+ * theme state without prop-drilling.
+ *
+ * Usage:
+ *   import { useThemeContext } from '@/providers/ThemeProvider';
+ *   const { resolvedTheme, setPreference, toggle, tokens } = useThemeContext();
+ *
+ * Related: #195
+ */
+
+'use client';
+
+import React, { createContext, useContext } from 'react';
+import {
+  useThemePreference,
+  type UseThemePreferenceReturn,
+} from '../hooks/useThemePreference';
+
+const ThemeContext = createContext<UseThemePreferenceReturn | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const themeState = useThemePreference();
+
+  return (
+    <ThemeContext.Provider value={themeState}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+/**
+ * Access the theme context. Throws if used outside ThemeProvider.
+ */
+export function useThemeContext(): UseThemePreferenceReturn {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useThemeContext must be used within a <ThemeProvider>');
+  }
+  return ctx;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- Add useThemePreference hook with 3-way pref (light/dark/system) and localStorage persistence
- Add ThemeProvider context wrapping the hook
- Add FOUC prevention script in _document.tsx
- Set `darkMode: 'class'` in tailwind.config.js
- Backward-compatible useTheme re-export
- Add @isa/theme dependency

## Test plan
- [ ] Theme toggles between light/dark/system
- [ ] FOUC prevention works on page load
- [ ] System preference detection works
- [ ] Preference persists across sessions

Fixes #195
🤖 Generated with [Claude Code](https://claude.com/claude-code)