### PR TITLE
feat(ui): command palette, custom instructions, keyboard shortcuts (#193, #197, #198)

### DIFF
--- a/src/components/ui/chat/CommandPalette.tsx
+++ b/src/components/ui/chat/CommandPalette.tsx
@@ -1,0 +1,181 @@
+/**
+ * CommandPalette — Cmd+K search and navigation (#193)
+ *
+ * Design ref (docs/design/claude-ui-reference.md):
+ * - width: 560px, border-radius: 12px, centered at 20vh from top
+ * - Search input at top, results below with keyboard nav
+ * - Backdrop: rgba(0,0,0,0.5)
+ */
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { GATEWAY_ENDPOINTS } from '../../../config/gatewayConfig';
+
+interface SearchResult {
+  id: string;
+  title: string;
+  snippet?: string;
+  type: 'conversation' | 'action';
+  timestamp?: string;
+}
+
+const DEFAULT_ACTIONS: SearchResult[] = [
+  { id: 'new-chat', title: 'New Chat', type: 'action' },
+  { id: 'settings', title: 'Settings', type: 'action' },
+];
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectConversation?: (sessionId: string) => void;
+  onAction?: (actionId: string) => void;
+}
+
+export const CommandPalette: React.FC<CommandPaletteProps> = ({
+  open, onClose, onSelectConversation, onAction,
+}) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>(DEFAULT_ACTIONS);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setResults(DEFAULT_ACTIONS);
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  // Search conversations
+  const search = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults(DEFAULT_ACTIONS);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`${GATEWAY_ENDPOINTS.SESSIONS.SEARCH}?q=${encodeURIComponent(q)}&limit=10`);
+      if (res.ok) {
+        const data = await res.json();
+        const sessions = (data.results || data.sessions || []).map((s: any) => ({
+          id: s.session_id || s.id,
+          title: s.title || s.snippet || q,
+          snippet: s.snippet || s.preview,
+          type: 'conversation' as const,
+          timestamp: s.created_at || s.timestamp,
+        }));
+        setResults(sessions.length > 0 ? sessions : DEFAULT_ACTIONS);
+      }
+    } catch {
+      // Silently fail — show default actions
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Debounced search
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    setSelectedIndex(0);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(value), 300);
+  };
+
+  // Keyboard navigation
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && results[selectedIndex]) {
+      e.preventDefault();
+      const item = results[selectedIndex];
+      if (item.type === 'conversation') onSelectConversation?.(item.id);
+      else onAction?.(item.id);
+      onClose();
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-center pt-[20vh]" onKeyDown={handleKeyDown}>
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+
+      {/* Palette */}
+      <div className="relative w-[560px] max-h-[400px] bg-white dark:bg-gray-800 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+        {/* Search input */}
+        <div className="flex items-center border-b border-gray-200 dark:border-gray-700">
+          <svg className="w-5 h-5 text-gray-400 ml-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => handleQueryChange(e.target.value)}
+            placeholder="Search conversations..."
+            className="flex-1 px-4 py-4 text-base bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none"
+          />
+          {loading && (
+            <div className="w-4 h-4 mr-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+          )}
+        </div>
+
+        {/* Results */}
+        <div className="overflow-y-auto max-h-[320px]">
+          {results.map((item, i) => (
+            <button
+              key={item.id}
+              onClick={() => {
+                if (item.type === 'conversation') onSelectConversation?.(item.id);
+                else onAction?.(item.id);
+                onClose();
+              }}
+              className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors ${
+                i === selectedIndex
+                  ? 'bg-gray-100 dark:bg-white/10'
+                  : 'hover:bg-gray-50 dark:hover:bg-white/5'
+              }`}
+            >
+              {/* Icon */}
+              <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700 flex-shrink-0">
+                {item.type === 'conversation' ? (
+                  <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                )}
+              </div>
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{item.title}</div>
+                {item.snippet && (
+                  <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{item.snippet}</div>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* Footer hint */}
+        <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-2 flex items-center gap-4 text-xs text-gray-400">
+          <span><kbd className="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500">↑↓</kbd> navigate</span>
+          <span><kbd className="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500">↵</kbd> select</span>
+          <span><kbd className="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500">esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/settings/CustomInstructionsSettings.tsx
+++ b/src/components/ui/settings/CustomInstructionsSettings.tsx
@@ -1,0 +1,111 @@
+/**
+ * CustomInstructionsSettings — Profile-level custom instructions editor (#197)
+ *
+ * Connects to PUT/GET /api/v1/users/me/instructions (isA_user #260).
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { GATEWAY_ENDPOINTS } from '../../../config/gatewayConfig';
+
+const MAX_CHARS = 4000;
+
+export const CustomInstructionsSettings: React.FC = () => {
+  const [instructions, setInstructions] = useState('');
+  const [saved, setSaved] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  // Fetch current instructions
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch(`${GATEWAY_ENDPOINTS.ACCOUNTS.BASE}/../users/me/instructions`, {
+          credentials: 'include',
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const text = data.instructions || '';
+          setInstructions(text);
+          setSaved(text);
+        }
+      } catch {
+        // Silently fail
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await fetch(`${GATEWAY_ENDPOINTS.ACCOUNTS.BASE}/../users/me/instructions`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ instructions }),
+      });
+      if (res.ok) {
+        setSaved(instructions);
+        setMessage({ type: 'success', text: 'Custom instructions saved' });
+        setTimeout(() => setMessage(null), 3000);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setMessage({ type: 'error', text: err.detail || 'Failed to save' });
+      }
+    } catch {
+      setMessage({ type: 'error', text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  }, [instructions]);
+
+  const hasChanges = instructions !== saved;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Custom Instructions</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Tell Mate about yourself and how you'd like it to respond. These instructions apply to all conversations.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="h-32 rounded-xl border border-gray-200 dark:border-gray-700 animate-pulse bg-gray-50 dark:bg-gray-800" />
+      ) : (
+        <>
+          <textarea
+            value={instructions}
+            onChange={e => setInstructions(e.target.value.slice(0, MAX_CHARS))}
+            placeholder="e.g., I'm a software engineer working on a TypeScript monorepo. I prefer concise responses with code examples..."
+            className="w-full min-h-[160px] p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 resize-vertical focus:outline-none focus:ring-2 focus:ring-blue-500"
+            rows={6}
+          />
+
+          <div className="flex items-center justify-between">
+            <span className={`text-xs ${instructions.length >= MAX_CHARS ? 'text-red-500' : 'text-gray-400'}`}>
+              {instructions.length}/{MAX_CHARS}
+            </span>
+
+            <div className="flex items-center gap-3">
+              {message && (
+                <span className={`text-sm ${message.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                  {message.text}
+                </span>
+              )}
+              <button
+                onClick={handleSave}
+                disabled={!hasChanges || saving}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/settings/KeyboardShortcutsOverlay.tsx
+++ b/src/components/ui/settings/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,53 @@
+/**
+ * KeyboardShortcutsOverlay — Shows all available keyboard shortcuts (#198)
+ */
+import React from 'react';
+import { APP_SHORTCUTS, formatShortcut } from '../../../hooks/useKeyboardShortcuts';
+
+interface KeyboardShortcutsOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const KeyboardShortcutsOverlay: React.FC<KeyboardShortcutsOverlayProps> = ({ open, onClose }) => {
+  if (!open) return null;
+
+  // Group by category
+  const grouped = APP_SHORTCUTS.reduce<Record<string, typeof APP_SHORTCUTS>>((acc, s) => {
+    (acc[s.category] ??= []).push(s);
+    return acc;
+  }, {});
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-[400px] max-h-[60vh] overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Keyboard Shortcuts</h2>
+          <button onClick={onClose} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-6 py-4 space-y-6 overflow-y-auto">
+          {Object.entries(grouped).map(([category, shortcuts]) => (
+            <div key={category}>
+              <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{category}</h3>
+              <div className="space-y-2">
+                {shortcuts.map((s) => (
+                  <div key={s.key + (s.meta ? 'm' : '') + (s.shift ? 's' : '')} className="flex items-center justify-between">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{s.description}</span>
+                    <kbd className="px-2 py-1 text-xs font-mono bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded border border-gray-200 dark:border-gray-600">
+                      {formatShortcut(s)}
+                    </kbd>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/settings/SettingsModal.tsx
+++ b/src/components/ui/settings/SettingsModal.tsx
@@ -3,8 +3,9 @@
  */
 import React, { useState } from 'react';
 import { AppearanceSettings } from './AppearanceSettings';
+import { CustomInstructionsSettings } from './CustomInstructionsSettings';
 
-type SettingsTab = 'appearance' | 'general';
+type SettingsTab = 'general' | 'appearance';
 
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
@@ -61,11 +62,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) =
           </button>
 
           {activeTab === 'appearance' && <AppearanceSettings />}
-          {activeTab === 'general' && (
-            <div className="text-sm text-gray-500 dark:text-gray-400">
-              General settings coming soon.
-            </div>
-          )}
+          {activeTab === 'general' && <CustomInstructionsSettings />}
         </div>
       </div>
     </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,55 @@
+/**
+ * useKeyboardShortcuts — Global keyboard shortcut system (#198)
+ *
+ * Registers shortcuts: Cmd+K (search), Cmd+, (settings), Cmd+N (new chat), ? (help)
+ */
+import { useEffect, useCallback } from 'react';
+
+export interface ShortcutDef {
+  key: string;
+  meta?: boolean;
+  shift?: boolean;
+  description: string;
+  category: string;
+  action: () => void;
+}
+
+export function useKeyboardShortcuts(shortcuts: ShortcutDef[]) {
+  const handler = useCallback((e: KeyboardEvent) => {
+    // Don't fire in input/textarea unless it's a meta combo
+    const target = e.target as HTMLElement;
+    const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+    if (isInput && !e.metaKey && !e.ctrlKey) return;
+
+    for (const s of shortcuts) {
+      const metaMatch = s.meta ? (e.metaKey || e.ctrlKey) : (!e.metaKey && !e.ctrlKey);
+      const shiftMatch = s.shift ? e.shiftKey : !e.shiftKey;
+      if (e.key === s.key && metaMatch && shiftMatch) {
+        e.preventDefault();
+        s.action();
+        return;
+      }
+    }
+  }, [shortcuts]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [handler]);
+}
+
+/** All registered shortcuts for display in help overlay */
+export const APP_SHORTCUTS: Omit<ShortcutDef, 'action'>[] = [
+  { key: 'k', meta: true, description: 'Search conversations', category: 'Navigation' },
+  { key: ',', meta: true, description: 'Open settings', category: 'Navigation' },
+  { key: 'n', meta: true, description: 'New chat', category: 'Chat' },
+  { key: '?', description: 'Show keyboard shortcuts', category: 'Help' },
+];
+
+export function formatShortcut(s: Omit<ShortcutDef, 'action'>): string {
+  const parts: string[] = [];
+  if (s.meta) parts.push('⌘');
+  if (s.shift) parts.push('⇧');
+  parts.push(s.key.toUpperCase());
+  return parts.join('');
+}

--- a/src/modules/AppModule.tsx
+++ b/src/modules/AppModule.tsx
@@ -40,6 +40,10 @@ import { OrganizationModule } from './OrganizationModule';
 import { RightSidebarLayout } from '../components/ui/chat/RightSidebarLayout';
 import UserButtonContainer from '../components/ui/user/UserButtonContainer';
 import { UserPortal } from '../components/ui/user/UserPortal';
+import { CommandPalette } from '../components/ui/chat/CommandPalette';
+import { SettingsModal } from '../components/ui/settings/SettingsModal';
+import { KeyboardShortcutsOverlay } from '../components/ui/settings/KeyboardShortcutsOverlay';
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 
 // Business logic hooks
 import { useChat } from '../hooks/useChat';
@@ -75,6 +79,18 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
   
   // Widget selector state
   const [showWidgetSelector, setShowWidgetSelector] = useState(false);
+
+  // Command palette, settings, and shortcuts overlay state (#193, #197, #198)
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showShortcuts, setShowShortcuts] = useState(false);
+
+  // Register global keyboard shortcuts (#198)
+  useKeyboardShortcuts(useMemo(() => [
+    { key: 'k', meta: true, description: 'Search conversations', category: 'Navigation', action: () => setShowCommandPalette(true) },
+    { key: ',', meta: true, description: 'Open settings', category: 'Navigation', action: () => setShowSettings(true) },
+    { key: '?', description: 'Show keyboard shortcuts', category: 'Help', action: () => setShowShortcuts(true) },
+  ], []));
   
   // Right panel state
   const [showRightPanel, setShowRightPanel] = useState(false);
@@ -324,6 +340,17 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
         )
       })}
         </AppLayout>
+
+        {/* Global overlays (#193, #197, #198) */}
+        <CommandPalette
+          open={showCommandPalette}
+          onClose={() => setShowCommandPalette(false)}
+          onAction={(id) => {
+            if (id === 'settings') setShowSettings(true);
+          }}
+        />
+        <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} />
+        <KeyboardShortcutsOverlay open={showShortcuts} onClose={() => setShowShortcuts(false)} />
       </OrganizationModule>
     </ContextModule>
   );


### PR DESCRIPTION
## Summary
- **Command Palette (#193)**: Cmd+K search overlay, conversation search via API, keyboard nav
- **Custom Instructions (#197)**: Profile-level instructions editor in Settings, connects to API
- **Keyboard Shortcuts (#198)**: Global shortcut system (Cmd+K, Cmd+,, ?), help overlay

## Test plan
- [ ] Cmd+K opens command palette, search returns conversations
- [ ] Settings > General shows custom instructions editor
- [ ] Save/load custom instructions works
- [ ] ? key shows keyboard shortcuts overlay
- [ ] All overlays close on Escape and backdrop click

Fixes #193, #197, #198
🤖 Generated with [Claude Code](https://claude.com/claude-code)