### PR TITLE
fix(ui): wire all callback gaps — editing, regen, model, memory

### DIFF
--- a/src/components/ui/chat/ChatContentLayout.tsx
+++ b/src/components/ui/chat/ChatContentLayout.tsx
@@ -34,6 +34,8 @@ export interface ChatContentLayoutProps {
   isTyping?: boolean;        // Accept typing state as prop
   onSendMessage?: (message: string) => void;
   currentTasks?: any[];      // Accept current tasks for status display
+  onEditMessage?: (editedContent: string, originalMessageId: string) => void;
+  onRegenerateMessage?: (userContent: string, assistantMessageId: string) => void;
 }
 
 /**
@@ -55,7 +57,9 @@ export const ChatContentLayout: React.FC<ChatContentLayoutProps> = ({
   isLoading = false,
   isTyping = false,
   onSendMessage,
-  currentTasks = []
+  currentTasks = [],
+  onEditMessage,
+  onRegenerateMessage,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   
@@ -101,6 +105,8 @@ export const ChatContentLayout: React.FC<ChatContentLayoutProps> = ({
         isLoading={isLoading}
         isTyping={isTyping}
         onSendMessage={onSendMessage}
+        onEditMessage={onEditMessage}
+        onRegenerateMessage={onRegenerateMessage}
       />
 
       {/* Auto-scroll anchor */}

--- a/src/components/ui/chat/ChatLayout.tsx
+++ b/src/components/ui/chat/ChatLayout.tsx
@@ -96,6 +96,10 @@ export interface ChatLayoutProps {
   onSendMessage?: (content: string, metadata?: Record<string, any>) => Promise<void>;
   onSendMultimodal?: (content: string, files: File[], metadata?: Record<string, any>) => Promise<void>;
   onMessageClick?: (message: any) => void;
+  /** Edit a user message and re-send (wiring gap fix) */
+  onEditMessage?: (editedContent: string, originalMessageId: string) => void;
+  /** Regenerate an assistant response (wiring gap fix) */
+  onRegenerateMessage?: (userContent: string, assistantMessageId: string) => void;
   
   // 🆕 Widget System Integration
   showWidgetSelector?: boolean;
@@ -169,7 +173,9 @@ export const ChatLayout = memo<ChatLayoutProps>(({
   onSendMessage,
   onSendMultimodal,
   onMessageClick,
-  
+  onEditMessage,
+  onRegenerateMessage,
+
   // Widget System Integration
   showWidgetSelector = false,
   onCloseWidgetSelector,
@@ -331,6 +337,8 @@ export const ChatLayout = memo<ChatLayoutProps>(({
                 isTyping={isTyping}
                 currentTasks={currentTasks}
                 onMessageClick={onMessageClick}
+                onEditMessage={onEditMessage}
+                onRegenerateMessage={onRegenerateMessage}
                 {...conversationProps}
               />
             </div>

--- a/src/components/ui/settings/MemoryManager.tsx
+++ b/src/components/ui/settings/MemoryManager.tsx
@@ -32,8 +32,21 @@ export const MemoryManager: React.FC = () => {
   const [editContent, setEditContent] = useState('');
 
   useEffect(() => {
-    // Fetch memories from API (placeholder — will connect to #386 when ready)
-    setLoading(false);
+    // Fetch memories from Mate API (isA_OS #386)
+    (async () => {
+      try {
+        const mateUrl = process.env.NEXT_PUBLIC_MATE_URL || 'http://localhost:18789';
+        const res = await fetch(`${mateUrl}/api/v1/memories`, { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setMemories(Array.isArray(data) ? data : data.memories || []);
+        }
+      } catch {
+        // Memory API not available — show empty state
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
   const filtered = memories.filter(m =>

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -497,6 +497,8 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         onSendMultimodal={messageHandlers.handleSendMultimodal}
         onMessageClick={messageHandlers.handleMessageClick}
         onNewChat={messageHandlers.handleNewChat}
+        onEditMessage={messageHandlers.handleEditMessage}
+        onRegenerateMessage={messageHandlers.handleRegenerateMessage}
 
         // Sidebar state (injected from AppLayout via useSidebar)
         sidebarOpen={sidebarOpen}

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -183,9 +183,15 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
         const { getChatBackend } = await import('../../config/runtimeEnv');
         const useMate = getChatBackend() === 'mate';
+
+        // Include selected model in the request (wiring gap fix — #194)
+        const selectedModel = typeof window !== 'undefined' ? localStorage.getItem('isa_selected_model') : null;
+        const matePayload: Record<string, any> = { session_id: enrichedMetadata.session_id };
+        if (selectedModel) matePayload.model = selectedModel;
+
         const sendFn = useMate
-          ? chatService.sendMessageViaMate.bind(chatService, content, { session_id: enrichedMetadata.session_id }, token)
-          : chatService.sendMessage.bind(chatService, content, enrichedMetadata, token);
+          ? chatService.sendMessageViaMate.bind(chatService, content, matePayload, token)
+          : chatService.sendMessage.bind(chatService, content, { ...enrichedMetadata, ...(selectedModel ? { model: selectedModel } : {}) }, token);
 
         await sendFn({
           onStreamStart: (messageId: string, status?: string) => {
@@ -368,10 +374,39 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     }
   };
 
+  /**
+   * Edit a user message — removes messages from that point and re-sends (wiring gap fix)
+   */
+  const handleEditMessage = (editedContent: string, originalMessageId: string) => {
+    const { messages } = useMessageStore.getState();
+    const idx = messages.findIndex(m => m.id === originalMessageId);
+    if (idx < 0) return;
+
+    // Remove the edited message and everything after it
+    const { removeMessage } = useChatStore.getState();
+    for (let i = messages.length - 1; i >= idx; i--) {
+      removeMessage(messages[i].id);
+    }
+
+    // Re-send with edited content
+    handleSendMessage(editedContent);
+  };
+
+  /**
+   * Regenerate an assistant response — removes it and re-sends the prior user message (wiring gap fix)
+   */
+  const handleRegenerateMessage = (userContent: string, assistantMessageId: string) => {
+    const { removeMessage } = useChatStore.getState();
+    removeMessage(assistantMessageId);
+    handleSendMessage(userContent);
+  };
+
   return {
     handleNewChat,
     handleSendMessage,
     handleSendMultimodal,
     handleMessageClick,
+    handleEditMessage,
+    handleRegenerateMessage,
   };
 }


### PR DESCRIPTION
## Summary — Audit Remediation

Fixes 4 wiring gaps found during honest audit:

1. **Message editing callbacks** — `onEditMessage` now wired through ChatModule → ChatLayout → ChatContentLayout → MessageList. Handler in messageHandlers removes messages from edit point and re-sends.

2. **Regeneration callbacks** — `onRegenerateMessage` wired through same chain. Handler removes assistant message and re-sends prior user message.

3. **Model selection sent to backend** — Selected model ID from localStorage now included in Mate chat payload (`model` field). Previously selection was persisted locally but never sent.

4. **Memory manager API** — Now fetches from Mate `/api/v1/memories` endpoint on mount instead of showing empty placeholder.

## Remaining gaps (require browser QA)
- Conversation sharing dialog: component exists, needs a trigger button in session context menu
- Starred conversations: hook exists, needs star toggle UI in session list
- Code sandbox / file creation: components exist, need artifact renderer integration
- Research mode: component exists, needs Mate research event triggers

These remaining items are UI integration tasks best done with the dev server running.

## Test plan
- [ ] Edit a user message → textarea opens, submitting re-sends
- [ ] Click regenerate on assistant message → response regenerated
- [ ] Select a model → verify network request includes model field
- [ ] Open Settings > Memory → verify API fetch attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)