### PR TITLE
fix(ui): conversation time grouping + build fixes (#238)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  transpilePackages: ['@isa/ui-web', '@isa/core', '@isa/theme', '@isa/transport'],
   // Produce a standalone build for Docker deployment
   output: 'standalone',
   env: {
@@ -16,6 +17,8 @@ const nextConfig = {
       fs: false,
       net: false,
       tls: false,
+      child_process: false,
+      dns: false,
     };
     return config;
   },

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -105,19 +105,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
       className={`min-h-dvh w-full flex flex-col bg-[var(--surface-bg,#0f172a)] text-[var(--text-primary,#fff)] relative ${className}`}
     >
       {/* Platform Navigation - Surface switcher for authenticated users */}
-      {isAuthenticated && (
-        <PlatformNav
-          activeSurface: "app",
+      {isAuthenticated && (() => {
+        const navProps = {
+          activeSurface: "app" as const,
           user: authUser ? { name: authUser.name, email: authUser.email } : null,
-          urls: {
-            app: surfaceUrls.app,
-            console: surfaceUrls.console,
-            docs: surfaceUrls.docs,
-            marketing: surfaceUrls.marketing,
-          },
+          urls: surfaceUrls,
           onLogout: logout,
-        })
-      )}
+        };
+        return <PlatformNav {...navProps} />;
+      })()}
       {/* Application Header - responsive on all viewports */}
       <div className="h-14 md:h-16 flex-shrink-0 p-1.5 md:p-2">
         <AppHeader

--- a/src/components/ui/session/SessionHistory.tsx
+++ b/src/components/ui/session/SessionHistory.tsx
@@ -73,6 +73,34 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
     });
   }, [sessions, searchQuery]);
 
+  // Group sessions by time period (#238)
+  const groupedSessions = useMemo(() => {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterday = new Date(today.getTime() - 86400000);
+    const prev7 = new Date(today.getTime() - 7 * 86400000);
+    const prev30 = new Date(today.getTime() - 30 * 86400000);
+
+    const groups: { label: string; sessions: typeof filteredSessions }[] = [
+      { label: 'Today', sessions: [] },
+      { label: 'Yesterday', sessions: [] },
+      { label: 'Previous 7 Days', sessions: [] },
+      { label: 'Previous 30 Days', sessions: [] },
+      { label: 'Older', sessions: [] },
+    ];
+
+    for (const s of filteredSessions) {
+      const d = new Date(s.timestamp || s.createdAt || 0);
+      if (d >= today) groups[0].sessions.push(s);
+      else if (d >= yesterday) groups[1].sessions.push(s);
+      else if (d >= prev7) groups[2].sessions.push(s);
+      else if (d >= prev30) groups[3].sessions.push(s);
+      else groups[4].sessions.push(s);
+    }
+
+    return groups.filter(g => g.sessions.length > 0);
+  }, [filteredSessions]);
+
   return (
     <div className={`session-history ${className} flex flex-col h-full`}>
       {/* Header */}
@@ -149,9 +177,15 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
             </div>
           </div>
         ) : (
-          filteredSessions.filter(session => session && typeof session === 'object' && session.id).map((session) => {
+          groupedSessions.map((group) => (
+            <div key={group.label}>
+              {/* Time group header (#238) */}
+              <div className="px-1 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-white/40 select-none">
+                {group.label}
+              </div>
+              {group.sessions.filter(session => session && typeof session === 'object' && session.id).map((session) => {
             const isActive = session.id === currentSessionId;
-            
+
             return (
               <div
                 key={session.id}
@@ -276,7 +310,9 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
                 </div>
               </div>
             );
-          })
+          })}
+            </div>
+          ))
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Group conversations by time: Today, Yesterday, Previous 7 Days, Previous 30 Days, Older
- Fix AppLayout PlatformNav JSX syntax error (persistent linter conflict)
- Fix webpack fallbacks for child_process/dns (SDK Node.js deps)
- Add transpilePackages for @isa SDK ESM packages

Verified working via Playwright — screenshot confirms "PREVIOUS 30 DAYS" header.

Fixes #238
🤖 Generated with [Claude Code](https://claude.com/claude-code)