### PR TITLE
feat(ui): scaffold Electron desktop app with electron-forge + Vite

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+out/
+.vite/
+dist/
+*.js.map

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,57 @@
+# isA_ Desktop
+
+Electron wrapper for the isA_ web application.
+
+## Prerequisites
+
+- Node.js >= 18
+- npm >= 9
+- The isA_ Next.js app (parent directory)
+
+## Development
+
+The desktop app loads the Next.js dev server, so you need both running:
+
+```bash
+# Terminal 1 — Start the Next.js app
+cd ..
+npm run dev          # starts on http://localhost:4100
+
+# Terminal 2 — Start Electron
+cd desktop
+npm install
+npm start            # opens the Electron window pointing at :4100
+```
+
+Or from the repo root:
+
+```bash
+npm run dev           # terminal 1
+npm run desktop       # terminal 2
+```
+
+## Building Distributables
+
+```bash
+# Package for the current platform (no installer)
+npm run package
+
+# Build platform installers (.dmg, .exe, .deb, etc.)
+npm run make
+```
+
+Build output goes to `desktop/out/`.
+
+## Architecture
+
+- **`src/main.ts`** — Electron main process. Creates the BrowserWindow, sets up menus, handles single-instance lock.
+- **`src/preload.ts`** — Preload script. Exposes `window.isElectron` and `window.electronAPI` via contextBridge.
+- **`forge.config.ts`** — Electron Forge configuration for packaging and making installers.
+- **`vite.main.config.ts`** / **`vite.preload.config.ts`** — Vite configs for bundling main and preload scripts.
+
+## How It Works
+
+- **Dev mode**: Loads `http://localhost:4100` (the Next.js dev server).
+- **Production mode**: Loads from the bundled Next.js standalone build (to be configured in a follow-up).
+
+The Next.js app detects it is running inside Electron via `window.isElectron` (set by the preload script) and the existing `src/utils/nativeApp.ts` detection logic.

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -1,0 +1,64 @@
+import type { ForgeConfig } from '@electron-forge/shared-types';
+import { MakerSquirrel } from '@electron-forge/maker-squirrel';
+import { MakerZIP } from '@electron-forge/maker-zip';
+import { MakerDMG } from '@electron-forge/maker-dmg';
+import { MakerDeb } from '@electron-forge/maker-deb';
+import { MakerRpm } from '@electron-forge/maker-rpm';
+import { VitePlugin } from '@electron-forge/plugin-vite';
+
+const config: ForgeConfig = {
+  packagerConfig: {
+    name: 'isA',
+    executableName: 'isa',
+    icon: './icons/icon', // .icns/.ico resolved per platform
+    appBundleId: 'com.isa.desktop',
+    asar: true,
+  },
+  rebuildConfig: {},
+  makers: [
+    new MakerSquirrel({
+      name: 'isa',
+      setupIcon: './icons/icon.ico',
+    }),
+    new MakerZIP({}, ['darwin']),
+    new MakerDMG({
+      format: 'ULFO',
+      name: 'isA',
+    }),
+    new MakerDeb({
+      options: {
+        name: 'isa',
+        productName: 'isA',
+        maintainer: 'isA Team',
+        homepage: 'https://github.com/xenoISA/isA_',
+      },
+    }),
+    new MakerRpm({
+      options: {
+        name: 'isa',
+        productName: 'isA',
+        homepage: 'https://github.com/xenoISA/isA_',
+      },
+    }),
+  ],
+  plugins: [
+    new VitePlugin({
+      // Main process Vite config
+      build: [
+        {
+          entry: 'src/main.ts',
+          config: 'vite.main.config.ts',
+          target: 'main',
+        },
+        {
+          entry: 'src/preload.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
+      ],
+      renderer: [],
+    }),
+  ],
+};
+
+export default config;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "isa-desktop",
+  "version": "0.1.0",
+  "description": "isA_ Desktop — Electron wrapper for the isA_ web app",
+  "main": ".vite/build/main.js",
+  "private": true,
+  "scripts": {
+    "start": "electron-forge start",
+    "package": "electron-forge package",
+    "make": "electron-forge make",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@electron-forge/cli": "^7.6.0",
+    "@electron-forge/maker-dmg": "^7.6.0",
+    "@electron-forge/maker-squirrel": "^7.6.0",
+    "@electron-forge/maker-zip": "^7.6.0",
+    "@electron-forge/maker-deb": "^7.6.0",
+    "@electron-forge/maker-rpm": "^7.6.0",
+    "@electron-forge/plugin-vite": "^7.6.0",
+    "electron": "^33.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "electron-squirrel-startup": "^1.0.1"
+  }
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,0 +1,175 @@
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  shell,
+  type MenuItemConstructorOptions,
+} from 'electron';
+import path from 'node:path';
+
+// Handle Squirrel installer events on Windows
+if (require('electron-squirrel-startup')) app.quit();
+
+// ---------- Single instance lock ----------
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
+    }
+  });
+}
+
+// ---------- Constants ----------
+const DEV_URL = 'http://localhost:4100';
+const IS_DEV = !app.isPackaged;
+const isMac = process.platform === 'darwin';
+
+// Vite injects these at build time via electron-forge plugin
+declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string | undefined;
+
+// ---------- Window creation ----------
+function createWindow(): BrowserWindow {
+  const preloadPath =
+    typeof MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY === 'string'
+      ? MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY
+      : path.join(__dirname, 'preload.js');
+
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    frame: true,
+    titleBarStyle: isMac ? 'hiddenInset' : 'default',
+    trafficLightPosition: isMac ? { x: 16, y: 16 } : undefined,
+    backgroundColor: '#0a0a0a',
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  // Load the app
+  if (IS_DEV) {
+    win.loadURL(DEV_URL);
+    win.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    // In production, load from the bundled Next.js standalone output
+    // For now, fall back to the dev URL — production loading will be
+    // configured when the build pipeline is wired up.
+    const prodIndex = path.join(__dirname, '..', 'renderer', 'index.html');
+    win.loadFile(prodIndex).catch(() => {
+      // Fallback: if no local build exists, try the dev server
+      win.loadURL(DEV_URL);
+    });
+  }
+
+  // Open external links in the default browser
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http')) shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  return win;
+}
+
+// ---------- Menu ----------
+function buildMenu(): void {
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' as const },
+              { type: 'separator' as const },
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const },
+              { role: 'hideOthers' as const },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+              { role: 'quit' as const },
+            ],
+          },
+        ]
+      : []),
+    {
+      label: 'File',
+      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac
+          ? [
+              { type: 'separator' as const },
+              { role: 'front' as const },
+            ]
+          : [{ role: 'close' as const }]),
+      ],
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'isA Documentation',
+          click: () =>
+            shell.openExternal('https://github.com/xenoISA/isA_'),
+        },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+// ---------- App lifecycle ----------
+app.whenReady().then(() => {
+  buildMenu();
+  createWindow();
+
+  app.on('activate', () => {
+    // macOS: re-create window when dock icon is clicked
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (!isMac) app.quit();
+});

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -1,0 +1,43 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+/**
+ * Preload script — runs in an isolated context before the renderer.
+ *
+ * Exposes a safe `window.electronAPI` bridge and sets `window.isElectron`
+ * so the Next.js app can detect it is running inside Electron.
+ */
+
+// Flag the environment
+contextBridge.exposeInMainWorld('isElectron', true);
+
+// Safe IPC bridge — only expose specific channels
+contextBridge.exposeInMainWorld('electronAPI', {
+  /** Send a one-way message to the main process. */
+  send: (channel: string, ...args: unknown[]) => {
+    const allowedChannels = ['app:ready', 'window:minimize', 'window:close'];
+    if (allowedChannels.includes(channel)) {
+      ipcRenderer.send(channel, ...args);
+    }
+  },
+
+  /** Send a message and wait for a response from the main process. */
+  invoke: (channel: string, ...args: unknown[]) => {
+    const allowedChannels = ['app:version', 'app:platform'];
+    if (allowedChannels.includes(channel)) {
+      return ipcRenderer.invoke(channel, ...args);
+    }
+    return Promise.reject(new Error(`Channel "${channel}" is not allowed`));
+  },
+
+  /** Subscribe to messages from the main process. Returns an unsubscribe function. */
+  on: (channel: string, callback: (...args: unknown[]) => void) => {
+    const allowedChannels = ['app:update-available', 'app:deep-link'];
+    if (allowedChannels.includes(channel)) {
+      const listener = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>
+        callback(...args);
+      ipcRenderer.on(channel, listener);
+      return () => ipcRenderer.removeListener(channel, listener);
+    }
+    return () => {};
+  },
+});

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/desktop/vite.main.config.ts
+++ b/desktop/vite.main.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['electron'],
+    },
+  },
+});

--- a/desktop/vite.preload.config.ts
+++ b/desktop/vite.preload.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['electron'],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "desktop": "cd desktop && npm start"
   },
   "dependencies": {
     "@isa/core": "^0.1.0",


### PR DESCRIPTION
## Summary
- Add `desktop/` directory with Electron + electron-forge + Vite scaffold
- Main process: BrowserWindow (1200x800), single-instance lock, macOS traffic light positioning, native menu bar (File/Edit/View/Window/Help)
- Preload script: exposes `window.isElectron` and `window.electronAPI` with safe IPC channels via contextBridge
- Security: contextIsolation + sandbox enabled, nodeIntegration disabled
- Forge config with makers for macOS (.dmg/.zip), Windows (Squirrel), Linux (.deb/.rpm)
- Root `npm run desktop` script for quick launch
- Dev mode loads localhost:4100; production loads bundled files with fallback

## Files Added (10)
```
desktop/
├── .gitignore
├── README.md
├── forge.config.ts          # Platform makers config
├── package.json             # Electron + Forge dependencies
├── tsconfig.json
├── vite.main.config.ts      # Main process Vite build
├── vite.preload.config.ts   # Preload Vite build
└── src/
    ├── main.ts              # Electron main process
    └── preload.ts           # Context bridge + IPC
```

## Test plan
- [ ] `cd desktop && npm install` succeeds
- [ ] Start Next.js (`npm run dev`), then `npm run desktop` opens Electron window loading localhost:4100
- [ ] `window.isElectron` is `true` in renderer console
- [ ] `window.electronAPI` exposes send/invoke/on methods
- [ ] Menu bar items work (File, Edit, View, Window, Help)
- [ ] Single instance lock prevents duplicate windows
- [ ] macOS: traffic light buttons positioned at (16, 16)
- [ ] External links open in default browser, not in Electron

Fixes #217
Part of Epic #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)