### PR TITLE
feat(desktop): global hotkey spotlight + fix Electron embedding

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,11 +1,14 @@
 import {
   app,
   BrowserWindow,
+  globalShortcut,
+  ipcMain,
   Menu,
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
 import path from 'node:path';
+import { toggleSpotlight, hideSpotlight, resizeSpotlight } from './spotlight';
 
 // Handle Squirrel installer events on Windows
 if (require('electron-squirrel-startup')) app.quit();
@@ -26,19 +29,19 @@ if (!gotLock) {
 
 // ---------- Constants ----------
 const DEV_URL = 'http://localhost:4100';
-const IS_DEV = !app.isPackaged;
 const isMac = process.platform === 'darwin';
 
-// Vite injects these at build time via electron-forge plugin
-declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string | undefined;
+// Vite injects these at build time via electron-forge Vite plugin
+declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
+declare const MAIN_WINDOW_VITE_NAME: string | undefined;
+
+// ---------- Preload path ----------
+function getPreloadPath(): string {
+  return path.join(__dirname, 'preload.js');
+}
 
 // ---------- Window creation ----------
 function createWindow(): BrowserWindow {
-  const preloadPath =
-    typeof MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY === 'string'
-      ? MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY
-      : path.join(__dirname, 'preload.js');
-
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -49,26 +52,22 @@ function createWindow(): BrowserWindow {
     trafficLightPosition: isMac ? { x: 16, y: 16 } : undefined,
     backgroundColor: '#0a0a0a',
     webPreferences: {
-      preload: preloadPath,
+      preload: getPreloadPath(),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
     },
   });
 
-  // Load the app
-  if (IS_DEV) {
-    win.loadURL(DEV_URL);
+  // Load the app — use Vite dev server URL in dev, bundled files in prod
+  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
     win.webContents.openDevTools({ mode: 'detach' });
+  } else if (MAIN_WINDOW_VITE_NAME) {
+    win.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`));
   } else {
-    // In production, load from the bundled Next.js standalone output
-    // For now, fall back to the dev URL — production loading will be
-    // configured when the build pipeline is wired up.
-    const prodIndex = path.join(__dirname, '..', 'renderer', 'index.html');
-    win.loadFile(prodIndex).catch(() => {
-      // Fallback: if no local build exists, try the dev server
-      win.loadURL(DEV_URL);
-    });
+    // Fallback for development without forge
+    win.loadURL(DEV_URL);
   }
 
   // Open external links in the default browser
@@ -103,7 +102,15 @@ function buildMenu(): void {
       : []),
     {
       label: 'File',
-      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
+      submenu: [
+        {
+          label: 'Quick Chat',
+          accelerator: isMac ? 'CmdOrCtrl+Shift+Space' : 'Ctrl+Shift+Space',
+          click: () => toggleSpotlight(getPreloadPath()),
+        },
+        { type: 'separator' },
+        isMac ? { role: 'close' } : { role: 'quit' },
+      ],
     },
     {
       label: 'Edit',
@@ -159,15 +166,56 @@ function buildMenu(): void {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
+// ---------- IPC handlers ----------
+function setupIPC(): void {
+  ipcMain.handle('app:version', () => app.getVersion());
+  ipcMain.handle('app:platform', () => process.platform);
+
+  // Spotlight IPC
+  ipcMain.on('spotlight:hide', () => hideSpotlight());
+  ipcMain.on('spotlight:resize', (_e, height: number) => resizeSpotlight(height));
+  ipcMain.on('spotlight:open-main', (_e, route?: string) => {
+    hideSpotlight();
+    const mainWin = BrowserWindow.getAllWindows().find(
+      (w) => w.webContents.getURL().includes('localhost:4100') && !w.webContents.getURL().includes('/spotlight'),
+    );
+    if (mainWin) {
+      if (mainWin.isMinimized()) mainWin.restore();
+      mainWin.focus();
+      if (route) {
+        mainWin.webContents.executeJavaScript(`window.location.hash = '${route}'`);
+      }
+    }
+  });
+}
+
+// ---------- Global shortcut ----------
+function registerGlobalShortcut(): void {
+  const accelerator = isMac ? 'CommandOrControl+Shift+Space' : 'Ctrl+Shift+Space';
+  const registered = globalShortcut.register(accelerator, () => {
+    toggleSpotlight(getPreloadPath());
+  });
+
+  if (!registered) {
+    console.warn(`[isA Desktop] Failed to register global shortcut: ${accelerator}`);
+  }
+}
+
 // ---------- App lifecycle ----------
 app.whenReady().then(() => {
   buildMenu();
+  setupIPC();
+  registerGlobalShortcut();
   createWindow();
 
   app.on('activate', () => {
     // macOS: re-create window when dock icon is clicked
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });
 
 app.on('window-all-closed', () => {

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -14,7 +14,10 @@ contextBridge.exposeInMainWorld('isElectron', true);
 contextBridge.exposeInMainWorld('electronAPI', {
   /** Send a one-way message to the main process. */
   send: (channel: string, ...args: unknown[]) => {
-    const allowedChannels = ['app:ready', 'window:minimize', 'window:close'];
+    const allowedChannels = [
+      'app:ready', 'window:minimize', 'window:close',
+      'spotlight:hide', 'spotlight:resize', 'spotlight:open-main',
+    ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...args);
     }

--- a/desktop/src/spotlight.ts
+++ b/desktop/src/spotlight.ts
@@ -1,0 +1,104 @@
+import { BrowserWindow, screen } from 'electron';
+import path from 'node:path';
+
+let spotlightWindow: BrowserWindow | null = null;
+
+const DEV_URL = 'http://localhost:4100/spotlight';
+const IS_DEV = !require('electron').app.isPackaged;
+const isMac = process.platform === 'darwin';
+
+/**
+ * Create or toggle the spotlight window — a compact, floating Mate input
+ * that appears centered on the active screen.
+ */
+export function toggleSpotlight(preloadPath: string): void {
+  if (spotlightWindow && !spotlightWindow.isDestroyed()) {
+    if (spotlightWindow.isVisible()) {
+      spotlightWindow.hide();
+    } else {
+      showSpotlight();
+    }
+    return;
+  }
+
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const { width: screenW, height: screenH } = display.workAreaSize;
+  const { x: screenX, y: screenY } = display.workArea;
+  const winW = 680;
+  const winH = 72;
+
+  spotlightWindow = new BrowserWindow({
+    width: winW,
+    height: winH,
+    x: screenX + Math.round((screenW - winW) / 2),
+    y: screenY + Math.round(screenH * 0.25),
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    show: false,
+    hasShadow: true,
+    vibrancy: isMac ? 'under-window' : undefined,
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  if (IS_DEV) {
+    spotlightWindow.loadURL(DEV_URL);
+  } else {
+    const prodIndex = path.join(__dirname, '..', 'renderer', 'spotlight.html');
+    spotlightWindow.loadFile(prodIndex).catch(() => {
+      spotlightWindow?.loadURL(DEV_URL);
+    });
+  }
+
+  spotlightWindow.on('blur', () => {
+    spotlightWindow?.hide();
+  });
+
+  spotlightWindow.on('closed', () => {
+    spotlightWindow = null;
+  });
+
+  spotlightWindow.once('ready-to-show', () => {
+    showSpotlight();
+  });
+}
+
+function showSpotlight(): void {
+  if (!spotlightWindow || spotlightWindow.isDestroyed()) return;
+
+  // Re-center on the active display each time
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const { width: screenW } = display.workAreaSize;
+  const { x: screenX, y: screenY } = display.workArea;
+  const [winW] = spotlightWindow.getSize();
+  const screenH = display.workAreaSize.height;
+
+  spotlightWindow.setPosition(
+    screenX + Math.round((screenW - winW) / 2),
+    screenY + Math.round(screenH * 0.25),
+  );
+  spotlightWindow.show();
+  spotlightWindow.focus();
+}
+
+export function hideSpotlight(): void {
+  spotlightWindow?.hide();
+}
+
+export function resizeSpotlight(height: number): void {
+  if (!spotlightWindow || spotlightWindow.isDestroyed()) return;
+  const [w] = spotlightWindow.getSize();
+  spotlightWindow.setSize(w, Math.min(height, 520));
+}
+
+export function getSpotlightWindow(): BrowserWindow | null {
+  return spotlightWindow;
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -23,6 +23,14 @@ const themeInitScript = `
       d.style.colorScheme = 'light';
     }
   } catch(e) {}
+  // Detect Electron and set data attribute + titlebar CSS variable
+  try {
+    if (window.isElectron || window.electronAPI || navigator.userAgent.includes('Electron')) {
+      d.setAttribute('data-electron', 'true');
+      var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      d.style.setProperty('--electron-titlebar-height', isMac ? '38px' : '0px');
+    }
+  } catch(e2) {}
 })();
 `;
 

--- a/pages/spotlight.tsx
+++ b/pages/spotlight.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Spotlight page — loaded inside the Electron spotlight window.
+ * A minimal floating chat input for quick Mate interactions.
+ */
+export default function SpotlightPage() {
+  const [input, setInput] = useState('');
+  const [response, setResponse] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+
+  // Auto-focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Resize the spotlight window when response appears
+  useEffect(() => {
+    if (!electronAPI) return;
+    const height = response ? 280 : 72;
+    electronAPI.send('spotlight:resize', height);
+  }, [response, electronAPI]);
+
+  // Escape to hide
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        electronAPI?.send('spotlight:hide');
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [electronAPI]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || isLoading) return;
+
+    setIsLoading(true);
+    setResponse('');
+
+    try {
+      // Use the gateway endpoint directly for a quick response
+      const gatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:9080';
+      const res = await fetch(`${gatewayUrl}/api/v1/mate/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input.trim(), quick: true }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setResponse(data.response || data.content || 'No response');
+      } else {
+        setResponse('Could not reach Mate. Is the backend running?');
+      }
+    } catch {
+      setResponse('Could not connect. Make sure the isA_ backend is running.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [input, isLoading]);
+
+  const handleOpenMain = () => {
+    electronAPI?.send('spotlight:open-main');
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        background: 'transparent',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        WebkitAppRegion: 'no-drag' as any,
+      }}
+    >
+      {/* Input bar */}
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          background: 'rgba(20, 20, 24, 0.95)',
+          backdropFilter: 'blur(20px)',
+          borderRadius: 16,
+          border: '1px solid rgba(255, 255, 255, 0.08)',
+          padding: '12px 20px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
+        }}
+      >
+        <span style={{ fontSize: 18, opacity: 0.5 }}>✦</span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask Mate anything..."
+          style={{
+            flex: 1,
+            background: 'none',
+            border: 'none',
+            outline: 'none',
+            color: '#e4e4e7',
+            fontSize: 16,
+            fontWeight: 400,
+            letterSpacing: '-0.01em',
+          }}
+        />
+        {isLoading && (
+          <span style={{ fontSize: 12, color: '#71717a', animation: 'pulse 1.5s infinite' }}>
+            thinking...
+          </span>
+        )}
+      </form>
+
+      {/* Response area */}
+      {response && (
+        <div
+          style={{
+            background: 'rgba(20, 20, 24, 0.95)',
+            backdropFilter: 'blur(20px)',
+            borderRadius: 16,
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            padding: '16px 20px',
+            marginTop: 8,
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
+          }}
+        >
+          <p style={{
+            color: '#d4d4d8',
+            fontSize: 14,
+            lineHeight: 1.6,
+            margin: 0,
+            maxHeight: 140,
+            overflowY: 'auto',
+            whiteSpace: 'pre-wrap',
+          }}>
+            {response}
+          </p>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            marginTop: 12,
+            gap: 8,
+          }}>
+            <button
+              onClick={handleOpenMain}
+              style={{
+                background: 'rgba(255, 255, 255, 0.06)',
+                border: '1px solid rgba(255, 255, 255, 0.1)',
+                borderRadius: 8,
+                color: '#a1a1aa',
+                fontSize: 12,
+                padding: '6px 12px',
+                cursor: 'pointer',
+              }}
+            >
+              Open in isA_ →
+            </button>
+          </div>
+        </div>
+      )}
+
+      <style jsx global>{`
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html, body { background: transparent !important; overflow: hidden; }
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/utils/nativeApp.ts
+++ b/src/utils/nativeApp.ts
@@ -49,8 +49,12 @@ export const detectNativeApp = (): NativeAppInfo => {
   // Check for Capacitor
   const isCapacitor = typeof window !== 'undefined' && !!(window as any).Capacitor;
   
-  // Check for Electron
-  const isElectron = typeof window !== 'undefined' && !!(window as any).require;
+  // Check for Electron — detect via preload-injected flag (sandbox disables window.require)
+  const isElectron = typeof window !== 'undefined' && (
+    !!(window as any).isElectron ||
+    !!(window as any).electronAPI ||
+    userAgent.includes('Electron')
+  );
   
   // Check for PWA
   const isPWA = isStandalone || isInWebAppiOS || isInWebAppChrome;


### PR DESCRIPTION
## Summary

**Electron embedding fixes (#218):**
- Fix Vite variable names (`MAIN_WINDOW_VITE_DEV_SERVER_URL` instead of webpack convention)
- Fix Electron detection in `nativeApp.ts` — use preload-injected `window.isElectron` (sandbox:true disables `window.require`)
- Add `data-electron` attribute and `--electron-titlebar-height` CSS variable in `_document.tsx`

**Global hotkey spotlight (#219):**
- `Cmd+Shift+Space` (macOS) / `Ctrl+Shift+Space` (Win/Linux) summons a floating Mate chat input
- Frameless, transparent, always-on-top window centered on active display
- Auto-hides on blur, Escape dismisses
- `pages/spotlight.tsx` — minimal dark input bar, sends to Mate, shows response
- "Open in isA_" button focuses the main window
- Dynamic window resizing, IPC channels for spotlight control
- Menu bar "Quick Chat" item as secondary access

## Files Changed (6)
- `desktop/src/main.ts` — Vite vars fix, globalShortcut, IPC handlers, spotlight integration
- `desktop/src/spotlight.ts` — NEW: spotlight window management module
- `desktop/src/preload.ts` — Add spotlight IPC channels
- `src/utils/nativeApp.ts` — Fix Electron detection for sandbox mode
- `pages/_document.tsx` — Add Electron data attribute and CSS variable
- `pages/spotlight.tsx` — NEW: spotlight chat UI page

## Test plan
- [ ] `npm run desktop` opens Electron window loading isA_ web
- [ ] `Cmd+Shift+Space` summons floating spotlight input
- [ ] Type a message and press Enter → shows response
- [ ] Press Escape → spotlight hides
- [ ] Click outside spotlight → spotlight hides
- [ ] "Open in isA_" → focuses main window
- [ ] `window.isElectron` is `true` in renderer console
- [ ] `document.documentElement.dataset.electron` is `"true"`
- [ ] Multiple monitors: spotlight appears on active display

Fixes #218, Fixes #219
Part of Epic #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)