### PR TITLE
feat(desktop): system tray, native notifications, and keychain auth

### DIFF
--- a/desktop/src/keychain.ts
+++ b/desktop/src/keychain.ts
@@ -1,0 +1,67 @@
+import { safeStorage, app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TOKEN_FILE = 'auth.enc';
+
+function getTokenPath(): string {
+  return path.join(app.getPath('userData'), TOKEN_FILE);
+}
+
+/**
+ * Save a refresh token encrypted via the OS keychain (safeStorage).
+ * On macOS uses Keychain, on Windows uses DPAPI, on Linux uses Secret Service.
+ */
+export function saveToken(token: string): boolean {
+  if (!safeStorage.isEncryptionAvailable()) {
+    console.warn('[isA Desktop] safeStorage not available — token not persisted');
+    return false;
+  }
+
+  try {
+    const encrypted = safeStorage.encryptString(token);
+    fs.writeFileSync(getTokenPath(), encrypted);
+    return true;
+  } catch (err) {
+    console.error('[isA Desktop] Failed to save token:', err);
+    return false;
+  }
+}
+
+/**
+ * Load the stored refresh token. Returns null if not available.
+ */
+export function loadToken(): string | null {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return null;
+  }
+
+  const tokenPath = getTokenPath();
+  if (!fs.existsSync(tokenPath)) {
+    return null;
+  }
+
+  try {
+    const encrypted = fs.readFileSync(tokenPath);
+    return safeStorage.decryptString(encrypted);
+  } catch (err) {
+    console.error('[isA Desktop] Failed to load token:', err);
+    return null;
+  }
+}
+
+/**
+ * Clear the stored token (logout).
+ */
+export function clearToken(): boolean {
+  const tokenPath = getTokenPath();
+  try {
+    if (fs.existsSync(tokenPath)) {
+      fs.unlinkSync(tokenPath);
+    }
+    return true;
+  } catch (err) {
+    console.error('[isA Desktop] Failed to clear token:', err);
+    return false;
+  }
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -9,6 +9,9 @@ import {
 } from 'electron';
 import path from 'node:path';
 import { toggleSpotlight, hideSpotlight, resizeSpotlight } from './spotlight';
+import { createTray, updateTrayStatus, setDockBadge } from './tray';
+import { showNotification } from './notifications';
+import { saveToken, loadToken, clearToken } from './keychain';
 
 // Handle Squirrel installer events on Windows
 if (require('electron-squirrel-startup')) app.quit();
@@ -176,17 +179,47 @@ function setupIPC(): void {
   ipcMain.on('spotlight:resize', (_e, height: number) => resizeSpotlight(height));
   ipcMain.on('spotlight:open-main', (_e, route?: string) => {
     hideSpotlight();
-    const mainWin = BrowserWindow.getAllWindows().find(
-      (w) => w.webContents.getURL().includes('localhost:4100') && !w.webContents.getURL().includes('/spotlight'),
-    );
-    if (mainWin) {
-      if (mainWin.isMinimized()) mainWin.restore();
-      mainWin.focus();
+    const win = getMainWindow();
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
       if (route) {
-        mainWin.webContents.executeJavaScript(`window.location.hash = '${route}'`);
+        win.webContents.executeJavaScript(`window.location.hash = '${route}'`);
       }
     }
   });
+
+  // Tray IPC
+  ipcMain.on('tray:update-status', (_e, status: 'online' | 'offline' | 'busy') => {
+    updateTrayStatus(status, trayDeps());
+  });
+  ipcMain.on('tray:set-badge', (_e, count: number) => {
+    setDockBadge(count);
+  });
+
+  // Notification IPC
+  ipcMain.on('notification:show', (_e, title: string, body: string, route?: string) => {
+    showNotification({ title, body, route }, getMainWindow);
+  });
+
+  // Auth keychain IPC
+  ipcMain.handle('auth:save-token', (_e, token: string) => saveToken(token));
+  ipcMain.handle('auth:load-token', () => loadToken());
+  ipcMain.handle('auth:clear-token', () => clearToken());
+}
+
+// Helper to get the main (non-spotlight) window
+function getMainWindow(): BrowserWindow | undefined {
+  return BrowserWindow.getAllWindows().find(
+    (w) => !w.isDestroyed() && w.webContents.getURL().includes('localhost:4100') && !w.webContents.getURL().includes('/spotlight'),
+  );
+}
+
+function trayDeps() {
+  return {
+    toggleSpotlight: () => toggleSpotlight(getPreloadPath()),
+    getMainWindow,
+  };
 }
 
 // ---------- Global shortcut ----------
@@ -206,6 +239,7 @@ app.whenReady().then(() => {
   buildMenu();
   setupIPC();
   registerGlobalShortcut();
+  createTray(trayDeps());
   createWindow();
 
   app.on('activate', () => {

--- a/desktop/src/notifications.ts
+++ b/desktop/src/notifications.ts
@@ -1,0 +1,83 @@
+import { Notification, BrowserWindow } from 'electron';
+
+interface NotificationOptions {
+  title: string;
+  body: string;
+  route?: string; // Navigate to this route on click
+}
+
+// Rate limiting: max 3 notifications in 10 seconds
+const recentTimestamps: number[] = [];
+const MAX_PER_WINDOW = 3;
+const WINDOW_MS = 10_000;
+let batchedCount = 0;
+let batchTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Show a native OS notification. Rate-limited to prevent flooding.
+ */
+export function showNotification(
+  opts: NotificationOptions,
+  getMainWindow: () => BrowserWindow | undefined,
+): void {
+  const now = Date.now();
+
+  // Prune old timestamps
+  while (recentTimestamps.length > 0 && now - recentTimestamps[0] > WINDOW_MS) {
+    recentTimestamps.shift();
+  }
+
+  // Rate limit check
+  if (recentTimestamps.length >= MAX_PER_WINDOW) {
+    batchedCount++;
+    scheduleBatchSummary(getMainWindow);
+    return;
+  }
+
+  recentTimestamps.push(now);
+  sendNotification(opts, getMainWindow);
+}
+
+function sendNotification(
+  opts: NotificationOptions,
+  getMainWindow: () => BrowserWindow | undefined,
+): void {
+  if (!Notification.isSupported()) return;
+
+  const notification = new Notification({
+    title: opts.title,
+    body: opts.body,
+    silent: false,
+  });
+
+  notification.on('click', () => {
+    const win = getMainWindow();
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
+      if (opts.route) {
+        win.webContents.send('notification:click', opts.route);
+      }
+    }
+  });
+
+  notification.show();
+}
+
+function scheduleBatchSummary(getMainWindow: () => BrowserWindow | undefined): void {
+  if (batchTimer) return;
+
+  batchTimer = setTimeout(() => {
+    if (batchedCount > 0) {
+      sendNotification(
+        {
+          title: 'isA_',
+          body: `${batchedCount} more notification${batchedCount > 1 ? 's' : ''} while you were away`,
+        },
+        getMainWindow,
+      );
+      batchedCount = 0;
+    }
+    batchTimer = null;
+  }, WINDOW_MS);
+}

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -17,6 +17,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const allowedChannels = [
       'app:ready', 'window:minimize', 'window:close',
       'spotlight:hide', 'spotlight:resize', 'spotlight:open-main',
+      'tray:update-status', 'tray:set-badge',
+      'notification:show',
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...args);
@@ -25,7 +27,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   /** Send a message and wait for a response from the main process. */
   invoke: (channel: string, ...args: unknown[]) => {
-    const allowedChannels = ['app:version', 'app:platform'];
+    const allowedChannels = [
+      'app:version', 'app:platform',
+      'auth:save-token', 'auth:load-token', 'auth:clear-token',
+    ];
     if (allowedChannels.includes(channel)) {
       return ipcRenderer.invoke(channel, ...args);
     }
@@ -34,7 +39,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   /** Subscribe to messages from the main process. Returns an unsubscribe function. */
   on: (channel: string, callback: (...args: unknown[]) => void) => {
-    const allowedChannels = ['app:update-available', 'app:deep-link'];
+    const allowedChannels = ['app:update-available', 'app:deep-link', 'notification:click'];
     if (allowedChannels.includes(channel)) {
       const listener = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>
         callback(...args);

--- a/desktop/src/tray.ts
+++ b/desktop/src/tray.ts
@@ -1,0 +1,135 @@
+import { Tray, Menu, nativeImage, app, BrowserWindow } from 'electron';
+
+let tray: Tray | null = null;
+let currentStatus: 'online' | 'offline' | 'busy' = 'online';
+
+interface TrayDeps {
+  toggleSpotlight: () => void;
+  getMainWindow: () => BrowserWindow | undefined;
+}
+
+/**
+ * Create the system tray icon with context menu.
+ * On macOS this appears in the menu bar; on Windows/Linux in the system tray.
+ */
+export function createTray(deps: TrayDeps): Tray {
+  const icon = createTrayIcon('online');
+  tray = new Tray(icon);
+  tray.setToolTip('isA_ — Your AGI Companion');
+
+  rebuildMenu(deps);
+  return tray;
+}
+
+/**
+ * Update the tray status and rebuild the menu.
+ */
+export function updateTrayStatus(status: 'online' | 'offline' | 'busy', deps: TrayDeps): void {
+  currentStatus = status;
+  if (!tray) return;
+  tray.setImage(createTrayIcon(status));
+  rebuildMenu(deps);
+}
+
+/**
+ * Set the macOS dock badge count. Pass 0 or '' to clear.
+ */
+export function setDockBadge(count: number): void {
+  if (process.platform !== 'darwin') return;
+  app.dock?.setBadge(count > 0 ? String(count) : '');
+}
+
+// ---------- Internal ----------
+
+function rebuildMenu(deps: TrayDeps): void {
+  if (!tray) return;
+
+  const isMac = process.platform === 'darwin';
+  const statusLabel = {
+    online: '● Online',
+    offline: '○ Offline',
+    busy: '◐ Busy',
+  }[currentStatus];
+
+  const menu = Menu.buildFromTemplate([
+    {
+      label: 'New Chat',
+      accelerator: isMac ? 'CmdOrCtrl+N' : 'Ctrl+N',
+      click: () => {
+        const win = deps.getMainWindow();
+        if (win) {
+          if (win.isMinimized()) win.restore();
+          win.focus();
+        }
+      },
+    },
+    {
+      label: 'Quick Chat',
+      accelerator: isMac ? 'CmdOrCtrl+Shift+Space' : 'Ctrl+Shift+Space',
+      click: () => deps.toggleSpotlight(),
+    },
+    { type: 'separator' },
+    {
+      label: `Status: ${statusLabel}`,
+      enabled: false,
+    },
+    { type: 'separator' },
+    {
+      label: 'Settings',
+      click: () => {
+        const win = deps.getMainWindow();
+        if (win) {
+          if (win.isMinimized()) win.restore();
+          win.focus();
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit isA_',
+      accelerator: isMac ? 'CmdOrCtrl+Q' : 'Ctrl+Q',
+      click: () => app.quit(),
+    },
+  ]);
+
+  tray.setContextMenu(menu);
+}
+
+/**
+ * Create a 16x16 template icon for the tray.
+ * Uses a simple circle indicator — template images are auto-themed on macOS.
+ */
+function createTrayIcon(status: 'online' | 'offline' | 'busy'): Electron.NativeImage {
+  // 16x16 PNG with a simple "iA" glyph rendered as a template image.
+  // In production, replace with a proper icon from desktop/icons/
+  const size = 16;
+  const canvas = Buffer.alloc(size * size * 4, 0); // RGBA
+
+  // Draw a filled circle for the status dot
+  const cx = 8, cy = 8, r = 6;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - cx, dy = y - cy;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const idx = (y * size + x) * 4;
+
+      if (dist <= r) {
+        const alpha = status === 'offline' ? 80 : status === 'busy' ? 180 : 255;
+        // Template images on macOS use alpha channel only
+        canvas[idx] = 0;     // R
+        canvas[idx + 1] = 0; // G
+        canvas[idx + 2] = 0; // B
+        canvas[idx + 3] = alpha;
+      } else if (dist <= r + 1) {
+        // Anti-aliased edge
+        const edge = Math.max(0, 1 - (dist - r));
+        const alpha = Math.round(edge * (status === 'offline' ? 80 : 255));
+        canvas[idx + 3] = alpha;
+      }
+    }
+  }
+
+  const img = nativeImage.createFromBuffer(canvas, { width: size, height: size });
+  img.setTemplateImage(true);
+  return img;
+}

--- a/src/hooks/useDesktopAuth.ts
+++ b/src/hooks/useDesktopAuth.ts
@@ -1,0 +1,47 @@
+import { useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+/**
+ * Bridge hook for desktop auth via OS keychain.
+ * In Electron: persists refresh token in the OS keychain (Keychain/DPAPI/Secret Service).
+ * In browser: no-ops (auth handled by HttpOnly cookies).
+ */
+export function useDesktopAuth() {
+  const saveToken = useCallback(async (token: string): Promise<boolean> => {
+    if (!isElectron || !electronAPI) return false;
+    return electronAPI.invoke('auth:save-token', token);
+  }, []);
+
+  const loadToken = useCallback(async (): Promise<string | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('auth:load-token');
+  }, []);
+
+  const clearToken = useCallback(async (): Promise<boolean> => {
+    if (!isElectron || !electronAPI) return false;
+    return electronAPI.invoke('auth:clear-token');
+  }, []);
+
+  return { isElectron, saveToken, loadToken, clearToken };
+}
+
+/**
+ * Restore session from keychain on app startup.
+ * Call this once in the app root — it will attempt to load a stored
+ * refresh token and restore the auth session.
+ */
+export function useDesktopSessionRestore(
+  onTokenLoaded: (token: string) => void,
+) {
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    electronAPI.invoke('auth:load-token').then((token: string | null) => {
+      if (token) {
+        onTokenLoaded(token);
+      }
+    });
+  }, [onTokenLoaded]);
+}

--- a/src/hooks/useDesktopNotifications.ts
+++ b/src/hooks/useDesktopNotifications.ts
@@ -1,0 +1,41 @@
+import { useEffect, useCallback } from 'react';
+import { useRouter } from 'next/router';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+/**
+ * Bridge hook for desktop notifications.
+ * In Electron: routes to native OS notifications via IPC.
+ * In browser: falls through to the browser Notification API.
+ */
+export function useDesktopNotifications() {
+  const router = useRouter();
+
+  // Listen for notification clicks from main process
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    const unsub = electronAPI.on('notification:click', (route: string) => {
+      if (route) router.push(route);
+    });
+
+    return unsub;
+  }, [router]);
+
+  const sendNotification = useCallback((title: string, body: string, route?: string) => {
+    if (isElectron && electronAPI) {
+      electronAPI.send('notification:show', title, body, route);
+    } else if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+      const n = new Notification(title, { body });
+      if (route) {
+        n.onclick = () => {
+          window.focus();
+          router.push(route);
+        };
+      }
+    }
+  }, [router]);
+
+  return { sendNotification };
+}


### PR DESCRIPTION
## Summary

Phase 2 desktop features — three stories in one PR since they all extend the same Electron infrastructure (main.ts, preload.ts).

### System Tray (#220)
- `desktop/src/tray.ts` — menu bar icon with context menu (New Chat, Quick Chat, Status, Settings, Quit)
- Status indicator: online/offline/busy with template icon
- macOS dock badge count support
- IPC: `tray:update-status`, `tray:set-badge`

### Native Notifications (#224)
- `desktop/src/notifications.ts` — Electron Notification API wrapper
- Rate limiting: max 3 per 10 seconds, batches overflow into a summary notification
- Click-to-navigate: clicking a notification focuses the main window and routes to the source
- `src/hooks/useDesktopNotifications.ts` — bridge hook (Electron → native, browser → Notification API fallback)

### Secure Auth (#225)
- `desktop/src/keychain.ts` — uses Electron `safeStorage` (Keychain on macOS, DPAPI on Windows, Secret Service on Linux)
- Encrypted token stored in `userData/auth.enc`
- IPC: `auth:save-token`, `auth:load-token`, `auth:clear-token`
- `src/hooks/useDesktopAuth.ts` — bridge hook + `useDesktopSessionRestore` for startup token restore

## Files (7 changed)
- `desktop/src/tray.ts` — NEW
- `desktop/src/notifications.ts` — NEW
- `desktop/src/keychain.ts` — NEW
- `desktop/src/main.ts` — imports + IPC handlers + tray init
- `desktop/src/preload.ts` — added 7 new IPC channels
- `src/hooks/useDesktopNotifications.ts` — NEW
- `src/hooks/useDesktopAuth.ts` — NEW

## Test plan
- [ ] `npm run desktop` → tray icon appears in menu bar
- [ ] Right-click tray → context menu shows all items
- [ ] "New Chat" → focuses main window
- [ ] "Quick Chat" → opens spotlight
- [ ] `electronAPI.send('tray:update-status', 'busy')` → status label updates
- [ ] `electronAPI.send('notification:show', 'Test', 'Hello')` → OS notification appears
- [ ] Click notification → main window focuses
- [ ] `await electronAPI.invoke('auth:save-token', 'test123')` → returns true
- [ ] `await electronAPI.invoke('auth:load-token')` → returns 'test123'
- [ ] `await electronAPI.invoke('auth:clear-token')` → returns true, token gone

Fixes #220, Fixes #224, Fixes #225
Part of Epic #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)