### PR TITLE
feat(desktop): filesystem, local models, screenshots, and MCP hosting

### DIFF
--- a/desktop/src/filesystem.ts
+++ b/desktop/src/filesystem.ts
@@ -1,0 +1,147 @@
+import { dialog, app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PERMITTED_FILE = 'permitted-folders.json';
+let permittedFolders: Set<string> = new Set();
+
+// Load permitted folders from disk
+function loadPermitted(): void {
+  const filePath = path.join(app.getPath('userData'), PERMITTED_FILE);
+  try {
+    if (fs.existsSync(filePath)) {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      permittedFolders = new Set(Array.isArray(data) ? data : []);
+    }
+  } catch {
+    permittedFolders = new Set();
+  }
+}
+
+function savePermitted(): void {
+  const filePath = path.join(app.getPath('userData'), PERMITTED_FILE);
+  fs.writeFileSync(filePath, JSON.stringify([...permittedFolders], null, 2));
+}
+
+function isPermitted(targetPath: string): boolean {
+  const resolved = path.resolve(targetPath);
+  for (const folder of permittedFolders) {
+    if (resolved.startsWith(path.resolve(folder))) return true;
+  }
+  return false;
+}
+
+function isBinary(filePath: string): boolean {
+  try {
+    const buf = Buffer.alloc(512);
+    const fd = fs.openSync(filePath, 'r');
+    const bytesRead = fs.readSync(fd, buf, 0, 512, 0);
+    fs.closeSync(fd);
+    for (let i = 0; i < bytesRead; i++) {
+      if (buf[i] === 0) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+const MAX_SIZE = 100 * 1024 * 1024; // 100MB
+const WARN_SIZE = 10 * 1024 * 1024; // 10MB
+
+// ---------- Public API ----------
+
+export function initFilesystem(): void {
+  loadPermitted();
+}
+
+export async function pickFolder(): Promise<string | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory'],
+    title: 'Grant isA_ access to this folder',
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  const folder = result.filePaths[0];
+  addPermittedFolder(folder);
+  return folder;
+}
+
+export function addPermittedFolder(folder: string): void {
+  permittedFolders.add(path.resolve(folder));
+  savePermitted();
+}
+
+export function removePermittedFolder(folder: string): void {
+  permittedFolders.delete(path.resolve(folder));
+  savePermitted();
+}
+
+export function getPermittedFolders(): string[] {
+  return [...permittedFolders];
+}
+
+export function listFiles(folderPath: string, pattern?: string): string[] {
+  if (!isPermitted(folderPath)) throw new Error('Folder not permitted');
+
+  const results: string[] = [];
+  const regex = pattern ? new RegExp(pattern.replace(/\*/g, '.*'), 'i') : null;
+
+  function walk(dir: string) {
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (!regex || regex.test(entry.name)) {
+          results.push(fullPath);
+        }
+        if (results.length >= 1000) return; // Cap results
+      }
+    } catch { /* skip inaccessible dirs */ }
+  }
+
+  walk(folderPath);
+  return results;
+}
+
+export function readFile(filePath: string): { content: string; size: number; warning?: string } {
+  if (!isPermitted(filePath)) throw new Error('File not in a permitted folder');
+
+  const stat = fs.statSync(filePath);
+  if (stat.size > MAX_SIZE) throw new Error(`File too large (${(stat.size / 1024 / 1024).toFixed(1)}MB > 100MB limit)`);
+  if (isBinary(filePath)) throw new Error('Binary file — cannot read as text');
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return {
+    content,
+    size: stat.size,
+    warning: stat.size > WARN_SIZE ? `Large file (${(stat.size / 1024 / 1024).toFixed(1)}MB)` : undefined,
+  };
+}
+
+export function searchFiles(folderPath: string, query: string): Array<{ file: string; line: number; text: string }> {
+  if (!isPermitted(folderPath)) throw new Error('Folder not permitted');
+
+  const files = listFiles(folderPath);
+  const results: Array<{ file: string; line: number; text: string }> = [];
+  const lowerQuery = query.toLowerCase();
+
+  for (const file of files) {
+    try {
+      const stat = fs.statSync(file);
+      if (stat.size > WARN_SIZE || isBinary(file)) continue;
+
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].toLowerCase().includes(lowerQuery)) {
+          results.push({ file, line: i + 1, text: lines[i].trim().substring(0, 200) });
+          if (results.length >= 200) return results;
+        }
+      }
+    } catch { /* skip unreadable files */ }
+  }
+
+  return results;
+}

--- a/desktop/src/local-models.ts
+++ b/desktop/src/local-models.ts
@@ -1,0 +1,100 @@
+import http from 'node:http';
+
+export interface LocalModel {
+  id: string;
+  name: string;
+  provider: 'ollama' | 'lmstudio';
+  endpoint: string;
+}
+
+let cachedModels: LocalModel[] = [];
+let detectInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Detect Ollama models on localhost:11434.
+ */
+async function detectOllama(): Promise<LocalModel[]> {
+  try {
+    const data = await httpGet('http://localhost:11434/api/tags');
+    const parsed = JSON.parse(data);
+    if (!parsed.models || !Array.isArray(parsed.models)) return [];
+    return parsed.models.map((m: any) => ({
+      id: `ollama:${m.name}`,
+      name: m.name,
+      provider: 'ollama' as const,
+      endpoint: 'http://localhost:11434',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Detect LM Studio models on localhost:1234.
+ */
+async function detectLMStudio(): Promise<LocalModel[]> {
+  try {
+    const data = await httpGet('http://localhost:1234/v1/models');
+    const parsed = JSON.parse(data);
+    if (!parsed.data || !Array.isArray(parsed.data)) return [];
+    return parsed.data.map((m: any) => ({
+      id: `lmstudio:${m.id}`,
+      name: m.id,
+      provider: 'lmstudio' as const,
+      endpoint: 'http://localhost:1234',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get all detected local models (cached).
+ */
+export function getLocalModels(): LocalModel[] {
+  return cachedModels;
+}
+
+/**
+ * Re-detect local models from all providers.
+ */
+export async function refreshLocalModels(): Promise<LocalModel[]> {
+  const [ollama, lmstudio] = await Promise.all([detectOllama(), detectLMStudio()]);
+  cachedModels = [...ollama, ...lmstudio];
+  return cachedModels;
+}
+
+/**
+ * Start periodic detection (every 60 seconds).
+ */
+export function startAutoDetect(): void {
+  refreshLocalModels(); // Initial detection
+  if (detectInterval) return;
+  detectInterval = setInterval(refreshLocalModels, 60_000);
+}
+
+/**
+ * Stop periodic detection.
+ */
+export function stopAutoDetect(): void {
+  if (detectInterval) {
+    clearInterval(detectInterval);
+    detectInterval = null;
+  }
+}
+
+// Simple HTTP GET helper (no external deps)
+function httpGet(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: 3000 }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
+  });
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -12,6 +12,10 @@ import { toggleSpotlight, hideSpotlight, resizeSpotlight } from './spotlight';
 import { createTray, updateTrayStatus, setDockBadge } from './tray';
 import { showNotification } from './notifications';
 import { saveToken, loadToken, clearToken } from './keychain';
+import { captureScreen, captureWindow, cleanupOldScreenshots } from './screenshot';
+import { initFilesystem, pickFolder, listFiles, readFile, searchFiles, addPermittedFolder, removePermittedFolder, getPermittedFolders } from './filesystem';
+import { getLocalModels, refreshLocalModels, startAutoDetect, stopAutoDetect } from './local-models';
+import { initMCPHost, addServer as mcpAddServer, removeServer as mcpRemoveServer, startServer as mcpStartServer, stopServer as mcpStopServer, restartServer as mcpRestartServer, getServerStatus, getServerLogs, listServers, shutdownAll as mcpShutdownAll } from './mcp-host';
 
 // Handle Squirrel installer events on Windows
 if (require('electron-squirrel-startup')) app.quit();
@@ -206,6 +210,33 @@ function setupIPC(): void {
   ipcMain.handle('auth:save-token', (_e, token: string) => saveToken(token));
   ipcMain.handle('auth:load-token', () => loadToken());
   ipcMain.handle('auth:clear-token', () => clearToken());
+
+  // Screenshot IPC
+  ipcMain.handle('screenshot:capture-screen', () => captureScreen());
+  ipcMain.handle('screenshot:capture-window', () => captureWindow());
+
+  // Filesystem IPC
+  ipcMain.handle('fs:pick-folder', () => pickFolder());
+  ipcMain.handle('fs:list-files', (_e, folder: string, pattern?: string) => listFiles(folder, pattern));
+  ipcMain.handle('fs:read-file', (_e, filePath: string) => readFile(filePath));
+  ipcMain.handle('fs:search-files', (_e, folder: string, query: string) => searchFiles(folder, query));
+  ipcMain.handle('fs:add-permitted', (_e, folder: string) => { addPermittedFolder(folder); });
+  ipcMain.handle('fs:remove-permitted', (_e, folder: string) => { removePermittedFolder(folder); });
+  ipcMain.handle('fs:get-permitted', () => getPermittedFolders());
+
+  // Local models IPC
+  ipcMain.handle('models:get-local', () => getLocalModels());
+  ipcMain.handle('models:detect', () => refreshLocalModels());
+
+  // MCP host IPC
+  ipcMain.handle('mcp:list-servers', () => listServers());
+  ipcMain.handle('mcp:get-status', () => getServerStatus());
+  ipcMain.handle('mcp:get-logs', (_e, name: string) => getServerLogs(name));
+  ipcMain.handle('mcp:add-server', (_e, config: any) => { mcpAddServer(config); });
+  ipcMain.handle('mcp:remove-server', (_e, name: string) => { mcpRemoveServer(name); });
+  ipcMain.handle('mcp:start-server', (_e, name: string) => mcpStartServer(name));
+  ipcMain.handle('mcp:stop-server', (_e, name: string) => { mcpStopServer(name); });
+  ipcMain.handle('mcp:restart-server', (_e, name: string) => { mcpRestartServer(name); });
 }
 
 // Helper to get the main (non-spotlight) window
@@ -240,6 +271,10 @@ app.whenReady().then(() => {
   setupIPC();
   registerGlobalShortcut();
   createTray(trayDeps());
+  initFilesystem();
+  initMCPHost();
+  startAutoDetect();
+  cleanupOldScreenshots();
   createWindow();
 
   app.on('activate', () => {
@@ -250,6 +285,8 @@ app.whenReady().then(() => {
 
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();
+  stopAutoDetect();
+  mcpShutdownAll();
 });
 
 app.on('window-all-closed', () => {

--- a/desktop/src/mcp-host.ts
+++ b/desktop/src/mcp-host.ts
@@ -1,0 +1,197 @@
+import { app } from 'electron';
+import { spawn, ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONFIG_FILE = 'mcp-servers.json';
+const MAX_LOG_LINES = 100;
+const MAX_RESTARTS = 3;
+const RESTART_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface MCPServerConfig {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  enabled: boolean;
+}
+
+interface ServerState {
+  config: MCPServerConfig;
+  process: ChildProcess | null;
+  status: 'running' | 'stopped' | 'crashed';
+  logs: string[];
+  restartTimestamps: number[];
+}
+
+const servers = new Map<string, ServerState>();
+
+// ---------- Config persistence ----------
+
+function getConfigPath(): string {
+  return path.join(app.getPath('userData'), CONFIG_FILE);
+}
+
+function loadConfigs(): MCPServerConfig[] {
+  try {
+    const filePath = getConfigPath();
+    if (fs.existsSync(filePath)) {
+      return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    }
+  } catch { /* ignore */ }
+  return [];
+}
+
+function saveConfigs(): void {
+  const configs = [...servers.values()].map((s) => s.config);
+  fs.writeFileSync(getConfigPath(), JSON.stringify(configs, null, 2));
+}
+
+// ---------- Public API ----------
+
+export function initMCPHost(): void {
+  const configs = loadConfigs();
+  for (const config of configs) {
+    servers.set(config.name, {
+      config,
+      process: null,
+      status: 'stopped',
+      logs: [],
+      restartTimestamps: [],
+    });
+    if (config.enabled) {
+      startServer(config.name);
+    }
+  }
+}
+
+export function addServer(config: MCPServerConfig): void {
+  servers.set(config.name, {
+    config,
+    process: null,
+    status: 'stopped',
+    logs: [],
+    restartTimestamps: [],
+  });
+  saveConfigs();
+  if (config.enabled) startServer(config.name);
+}
+
+export function removeServer(name: string): void {
+  stopServer(name);
+  servers.delete(name);
+  saveConfigs();
+}
+
+export function startServer(name: string): boolean {
+  const state = servers.get(name);
+  if (!state) return false;
+  if (state.process) return true; // Already running
+
+  try {
+    const child = spawn(state.config.command, state.config.args, {
+      env: { ...process.env, ...state.config.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    state.process = child;
+    state.status = 'running';
+
+    child.stdout?.on('data', (data: Buffer) => {
+      appendLog(state, `[stdout] ${data.toString().trim()}`);
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      appendLog(state, `[stderr] ${data.toString().trim()}`);
+    });
+
+    child.on('exit', (code) => {
+      state.process = null;
+      appendLog(state, `[exit] Process exited with code ${code}`);
+
+      if (code !== 0 && state.config.enabled) {
+        // Auto-restart with rate limiting
+        const now = Date.now();
+        state.restartTimestamps = state.restartTimestamps.filter(
+          (t) => now - t < RESTART_WINDOW_MS,
+        );
+
+        if (state.restartTimestamps.length < MAX_RESTARTS) {
+          state.restartTimestamps.push(now);
+          appendLog(state, '[auto-restart] Restarting...');
+          setTimeout(() => startServer(name), 2000);
+        } else {
+          state.status = 'crashed';
+          appendLog(state, '[crashed] Max restarts exceeded');
+        }
+      } else {
+        state.status = 'stopped';
+      }
+    });
+
+    return true;
+  } catch (err) {
+    state.status = 'crashed';
+    appendLog(state, `[error] Failed to start: ${err}`);
+    return false;
+  }
+}
+
+export function stopServer(name: string): void {
+  const state = servers.get(name);
+  if (!state?.process) return;
+
+  state.config.enabled = false;
+  const child = state.process;
+
+  child.kill('SIGTERM');
+  const forceKill = setTimeout(() => {
+    if (!child.killed) child.kill('SIGKILL');
+  }, 5000);
+
+  child.on('exit', () => clearTimeout(forceKill));
+}
+
+export function restartServer(name: string): void {
+  stopServer(name);
+  const state = servers.get(name);
+  if (state) {
+    state.config.enabled = true;
+    setTimeout(() => startServer(name), 1000);
+  }
+}
+
+export function getServerStatus(): Array<{ name: string; status: string; enabled: boolean }> {
+  return [...servers.entries()].map(([name, state]) => ({
+    name,
+    status: state.status,
+    enabled: state.config.enabled,
+  }));
+}
+
+export function getServerLogs(name: string): string[] {
+  return servers.get(name)?.logs ?? [];
+}
+
+export function listServers(): MCPServerConfig[] {
+  return [...servers.values()].map((s) => s.config);
+}
+
+/**
+ * Graceful shutdown all servers. Call on app quit.
+ */
+export function shutdownAll(): void {
+  for (const [name] of servers) {
+    stopServer(name);
+  }
+}
+
+// ---------- Internal ----------
+
+function appendLog(state: ServerState, line: string): void {
+  const timestamped = `[${new Date().toISOString()}] ${line}`;
+  state.logs.push(timestamped);
+  if (state.logs.length > MAX_LOG_LINES) {
+    state.logs.shift();
+  }
+}

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -30,6 +30,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const allowedChannels = [
       'app:version', 'app:platform',
       'auth:save-token', 'auth:load-token', 'auth:clear-token',
+      'screenshot:capture-screen', 'screenshot:capture-window',
+      'fs:pick-folder', 'fs:list-files', 'fs:read-file', 'fs:search-files',
+      'fs:add-permitted', 'fs:remove-permitted', 'fs:get-permitted',
+      'models:get-local', 'models:detect',
+      'mcp:list-servers', 'mcp:get-status', 'mcp:get-logs',
+      'mcp:add-server', 'mcp:remove-server',
+      'mcp:start-server', 'mcp:stop-server', 'mcp:restart-server',
     ];
     if (allowedChannels.includes(channel)) {
       return ipcRenderer.invoke(channel, ...args);

--- a/desktop/src/screenshot.ts
+++ b/desktop/src/screenshot.ts
@@ -1,0 +1,77 @@
+import { desktopCapturer, BrowserWindow, app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCREENSHOT_DIR = 'isa-screenshots';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getScreenshotDir(): string {
+  const dir = path.join(app.getPath('temp'), SCREENSHOT_DIR);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+/**
+ * Capture the entire active screen. Returns base64 PNG and file path.
+ */
+export async function captureScreen(): Promise<{ path: string; base64: string }> {
+  const sources = await desktopCapturer.getSources({
+    types: ['screen'],
+    thumbnailSize: { width: 1920, height: 1080 },
+  });
+
+  const source = sources[0];
+  if (!source) throw new Error('No screen source available');
+
+  const png = source.thumbnail.toPNG();
+  const filename = `screen-${Date.now()}.png`;
+  const filePath = path.join(getScreenshotDir(), filename);
+  fs.writeFileSync(filePath, png);
+
+  return {
+    path: filePath,
+    base64: png.toString('base64'),
+  };
+}
+
+/**
+ * Capture the current Electron window contents. Returns base64 PNG and file path.
+ */
+export async function captureWindow(win?: BrowserWindow): Promise<{ path: string; base64: string }> {
+  const targetWin = win || BrowserWindow.getFocusedWindow();
+  if (!targetWin) throw new Error('No focused window to capture');
+
+  const image = await targetWin.webContents.capturePage();
+  const png = image.toPNG();
+  const filename = `window-${Date.now()}.png`;
+  const filePath = path.join(getScreenshotDir(), filename);
+  fs.writeFileSync(filePath, png);
+
+  return {
+    path: filePath,
+    base64: png.toString('base64'),
+  };
+}
+
+/**
+ * Delete screenshots older than 24 hours. Call on app startup.
+ */
+export function cleanupOldScreenshots(): void {
+  const dir = path.join(app.getPath('temp'), SCREENSHOT_DIR);
+  if (!fs.existsSync(dir)) return;
+
+  const now = Date.now();
+  try {
+    for (const file of fs.readdirSync(dir)) {
+      const filePath = path.join(dir, file);
+      const stat = fs.statSync(filePath);
+      if (now - stat.mtimeMs > MAX_AGE_MS) {
+        fs.unlinkSync(filePath);
+      }
+    }
+  } catch (err) {
+    console.warn('[isA Desktop] Screenshot cleanup error:', err);
+  }
+}

--- a/src/hooks/useDesktopFilesystem.ts
+++ b/src/hooks/useDesktopFilesystem.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+/**
+ * Bridge hook for desktop filesystem access.
+ * All operations are sandboxed — only permitted folders are accessible.
+ * No-ops when not running in Electron.
+ */
+export function useDesktopFilesystem() {
+  const pickFolder = useCallback(async (): Promise<string | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('fs:pick-folder');
+  }, []);
+
+  const getPermittedFolders = useCallback(async (): Promise<string[]> => {
+    if (!isElectron || !electronAPI) return [];
+    return electronAPI.invoke('fs:get-permitted');
+  }, []);
+
+  const removePermittedFolder = useCallback(async (folder: string): Promise<void> => {
+    if (!isElectron || !electronAPI) return;
+    return electronAPI.invoke('fs:remove-permitted', folder);
+  }, []);
+
+  const listFiles = useCallback(async (folder: string, pattern?: string): Promise<string[]> => {
+    if (!isElectron || !electronAPI) return [];
+    return electronAPI.invoke('fs:list-files', folder, pattern);
+  }, []);
+
+  const readFile = useCallback(async (filePath: string): Promise<{ content: string; size: number; warning?: string } | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('fs:read-file', filePath);
+  }, []);
+
+  const searchFiles = useCallback(async (folder: string, query: string): Promise<Array<{ file: string; line: number; text: string }>> => {
+    if (!isElectron || !electronAPI) return [];
+    return electronAPI.invoke('fs:search-files', folder, query);
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    pickFolder,
+    getPermittedFolders,
+    removePermittedFolder,
+    listFiles,
+    readFile,
+    searchFiles,
+  };
+}

--- a/src/hooks/useLocalMCPServers.ts
+++ b/src/hooks/useLocalMCPServers.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+interface MCPServerConfig {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  enabled: boolean;
+}
+
+interface MCPServerStatus {
+  name: string;
+  status: 'running' | 'stopped' | 'crashed';
+  enabled: boolean;
+}
+
+/**
+ * Bridge hook for local MCP server management.
+ * Only active in Electron — returns empty state in browser.
+ */
+export function useLocalMCPServers() {
+  const [servers, setServers] = useState<MCPServerStatus[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!isElectron || !electronAPI) return;
+    const status = await electronAPI.invoke('mcp:get-status');
+    setServers(status ?? []);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const addServer = useCallback(async (config: MCPServerConfig) => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('mcp:add-server', config);
+    refresh();
+  }, [refresh]);
+
+  const removeServer = useCallback(async (name: string) => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('mcp:remove-server', name);
+    refresh();
+  }, [refresh]);
+
+  const startServer = useCallback(async (name: string) => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('mcp:start-server', name);
+    refresh();
+  }, [refresh]);
+
+  const stopServer = useCallback(async (name: string) => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('mcp:stop-server', name);
+    refresh();
+  }, [refresh]);
+
+  const getLogs = useCallback(async (name: string): Promise<string[]> => {
+    if (!isElectron || !electronAPI) return [];
+    return electronAPI.invoke('mcp:get-logs', name);
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    servers,
+    addServer,
+    removeServer,
+    startServer,
+    stopServer,
+    getLogs,
+    refresh,
+  };
+}

--- a/src/hooks/useLocalModels.ts
+++ b/src/hooks/useLocalModels.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+interface LocalModel {
+  id: string;
+  name: string;
+  provider: 'ollama' | 'lmstudio';
+  endpoint: string;
+}
+
+/**
+ * Bridge hook for local model detection (Ollama, LM Studio).
+ * Only active in Electron — returns empty state in browser.
+ */
+export function useLocalModels() {
+  const [localModels, setLocalModels] = useState<LocalModel[]>([]);
+  const [isDetecting, setIsDetecting] = useState(false);
+
+  const refreshModels = useCallback(async () => {
+    if (!isElectron || !electronAPI) return;
+    setIsDetecting(true);
+    try {
+      const models = await electronAPI.invoke('models:detect');
+      setLocalModels(models ?? []);
+    } catch {
+      setLocalModels([]);
+    } finally {
+      setIsDetecting(false);
+    }
+  }, []);
+
+  // Initial detection on mount
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+    electronAPI.invoke('models:get-local').then((models: LocalModel[]) => {
+      setLocalModels(models ?? []);
+    });
+  }, []);
+
+  return {
+    localModels,
+    isLocalAvailable: isElectron && localModels.length > 0,
+    isDetecting,
+    refreshModels,
+  };
+}

--- a/src/hooks/useScreenCapture.ts
+++ b/src/hooks/useScreenCapture.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+interface CaptureResult {
+  path: string;
+  base64: string;
+}
+
+/**
+ * Bridge hook for desktop screenshot capture.
+ * Only available in Electron — returns no-ops in browser.
+ */
+export function useScreenCapture() {
+  const captureScreen = useCallback(async (): Promise<CaptureResult | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('screenshot:capture-screen');
+  }, []);
+
+  const captureWindow = useCallback(async (): Promise<CaptureResult | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('screenshot:capture-window');
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    captureScreen,
+    captureWindow,
+  };
+}


### PR DESCRIPTION
## Summary

The remaining Phase 2 desktop features — the local capabilities that differentiate isA_ Desktop from Claude Desktop.

### Local Filesystem Access (#221)
- `desktop/src/filesystem.ts` — sandboxed folder permissions, file listing/reading/searching
- Permission enforcement: all ops verify path is under a permitted folder
- Binary file detection, 100MB size guard, 1000 file result cap
- Permitted folders persisted to `userData/permitted-folders.json`

### Local Model Routing (#222)
- `desktop/src/local-models.ts` — auto-detect Ollama (`:11434`) and LM Studio (`:1234`)
- Periodic refresh every 60s, returns unified `LocalModel[]` with provider + endpoint
- Uses native `http` module (no external deps)

### Screenshot Capture (#223)
- `desktop/src/screenshot.ts` — full screen via `desktopCapturer`, window via `capturePage()`
- Saves to temp dir, auto-cleanup of screenshots older than 24h on app start

### Local MCP Server Hosting (#226)
- `desktop/src/mcp-host.ts` — spawn MCP servers as child processes via stdio
- Auto-restart on crash (max 3 per 5 min, then marks as crashed)
- Log ring buffer (last 100 lines per server), config persistence
- Graceful shutdown: SIGTERM → SIGKILL after 5s on app quit

### Bridge Hooks (4 new)
- `useDesktopFilesystem` — pick folder, list/read/search files
- `useLocalModels` — model detection state + refresh
- `useScreenCapture` — capture screen/window
- `useLocalMCPServers` — full CRUD for MCP server management

## Files (10 changed)
| Type | Files |
|------|-------|
| Desktop modules | `filesystem.ts`, `local-models.ts`, `screenshot.ts`, `mcp-host.ts` (NEW) |
| Desktop infra | `main.ts` (imports + 19 IPC handlers + lifecycle), `preload.ts` (15 new channels) |
| Bridge hooks | `useDesktopFilesystem.ts`, `useLocalModels.ts`, `useScreenCapture.ts`, `useLocalMCPServers.ts` (NEW) |

## Test plan
- [ ] `electronAPI.invoke('fs:pick-folder')` → opens folder picker dialog
- [ ] `electronAPI.invoke('fs:list-files', '/some/permitted/folder')` → returns file list
- [ ] `electronAPI.invoke('fs:read-file', '/permitted/file.txt')` → returns content
- [ ] `electronAPI.invoke('models:detect')` → detects Ollama/LM Studio if running
- [ ] `electronAPI.invoke('screenshot:capture-screen')` → returns base64 PNG
- [ ] `electronAPI.invoke('screenshot:capture-window')` → returns base64 PNG of app
- [ ] `electronAPI.invoke('mcp:add-server', { name: 'test', command: 'echo', args: ['hello'], enabled: true })` → spawns process
- [ ] `electronAPI.invoke('mcp:get-status')` → returns server statuses
- [ ] `electronAPI.invoke('mcp:get-logs', 'test')` → returns recent output
- [ ] App quit → all MCP servers receive SIGTERM

Fixes #221, Fixes #222, Fixes #223, Fixes #226
Part of Epic #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)