### PR TITLE
feat(desktop): clipboard, deep links, offline cache, and auto-updater

### DIFF
--- a/desktop/src/clipboard.ts
+++ b/desktop/src/clipboard.ts
@@ -1,0 +1,88 @@
+import { clipboard, BrowserWindow, nativeImage } from 'electron';
+
+let watchInterval: ReturnType<typeof setInterval> | null = null;
+let lastText = '';
+let lastImageHash = '';
+let enabled = false;
+
+export type ClipboardContentType = 'code' | 'url' | 'text' | 'image' | 'empty';
+
+interface ClipboardContent {
+  type: ClipboardContentType;
+  text?: string;
+  imageBase64?: string;
+}
+
+function detectContentType(text: string): ClipboardContentType {
+  if (!text.trim()) return 'empty';
+  // URL detection
+  if (/^https?:\/\/\S+$/i.test(text.trim())) return 'url';
+  // Code detection: has indentation + brackets/semicolons, or starts with import/function/const/class
+  if (/^(import |from |function |const |let |var |class |export |#include|def |async )/.test(text.trim())) return 'code';
+  if ((text.includes('{') && text.includes('}')) || (text.includes('(') && text.includes(');'))) return 'code';
+  return 'text';
+}
+
+function getImageHash(img: Electron.NativeImage): string {
+  if (img.isEmpty()) return '';
+  const buf = img.toPNG();
+  // Simple hash: first 32 bytes as hex
+  return buf.subarray(0, 32).toString('hex');
+}
+
+function checkClipboard(mainWindow: () => BrowserWindow | undefined): void {
+  // Check text
+  const text = clipboard.readText();
+  if (text && text !== lastText) {
+    lastText = text;
+    const type = detectContentType(text);
+    const win = mainWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('clipboard:changed', { type, text } as ClipboardContent);
+    }
+    return;
+  }
+
+  // Check image
+  const img = clipboard.readImage();
+  const hash = getImageHash(img);
+  if (hash && hash !== lastImageHash) {
+    lastImageHash = hash;
+    const win = mainWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('clipboard:changed', {
+        type: 'image',
+        imageBase64: img.toPNG().toString('base64'),
+      } as ClipboardContent);
+    }
+  }
+}
+
+export function startClipboardWatch(mainWindow: () => BrowserWindow | undefined): void {
+  if (watchInterval) return;
+  enabled = true;
+  // Initialize with current clipboard to avoid firing on existing content
+  lastText = clipboard.readText();
+  lastImageHash = getImageHash(clipboard.readImage());
+  watchInterval = setInterval(() => checkClipboard(mainWindow), 2000);
+}
+
+export function stopClipboardWatch(): void {
+  enabled = false;
+  if (watchInterval) {
+    clearInterval(watchInterval);
+    watchInterval = null;
+  }
+}
+
+export function isClipboardWatchEnabled(): boolean {
+  return enabled;
+}
+
+export function getClipboardContent(): ClipboardContent {
+  const text = clipboard.readText();
+  if (text) return { type: detectContentType(text), text };
+  const img = clipboard.readImage();
+  if (!img.isEmpty()) return { type: 'image', imageBase64: img.toPNG().toString('base64') };
+  return { type: 'empty' };
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -16,6 +16,9 @@ import { captureScreen, captureWindow, cleanupOldScreenshots } from './screensho
 import { initFilesystem, pickFolder, listFiles, readFile, searchFiles, addPermittedFolder, removePermittedFolder, getPermittedFolders } from './filesystem';
 import { getLocalModels, refreshLocalModels, startAutoDetect, stopAutoDetect } from './local-models';
 import { initMCPHost, addServer as mcpAddServer, removeServer as mcpRemoveServer, startServer as mcpStartServer, stopServer as mcpStopServer, restartServer as mcpRestartServer, getServerStatus, getServerLogs, listServers, shutdownAll as mcpShutdownAll } from './mcp-host';
+import { startClipboardWatch, stopClipboardWatch, getClipboardContent } from './clipboard';
+import { initOfflineCache, cacheConversation, getCachedConversations, getCachedConversation, clearOfflineCache, isOnline } from './offline-cache';
+import { initAutoUpdater, checkForUpdates, quitAndInstall, stopAutoUpdater } from './updater';
 
 // Handle Squirrel installer events on Windows
 if (require('electron-squirrel-startup')) app.quit();
@@ -25,12 +28,15 @@ const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
 } else {
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, argv) => {
     const win = BrowserWindow.getAllWindows()[0];
     if (win) {
       if (win.isMinimized()) win.restore();
       win.focus();
     }
+    // Deep link handling on Windows/Linux (protocol URL comes as argv)
+    const deepLink = argv.find((a) => a.startsWith('isaapp://'));
+    if (deepLink) handleDeepLink(deepLink);
   });
 }
 
@@ -237,6 +243,24 @@ function setupIPC(): void {
   ipcMain.handle('mcp:start-server', (_e, name: string) => mcpStartServer(name));
   ipcMain.handle('mcp:stop-server', (_e, name: string) => { mcpStopServer(name); });
   ipcMain.handle('mcp:restart-server', (_e, name: string) => { mcpRestartServer(name); });
+
+  // Clipboard IPC
+  ipcMain.on('clipboard:start-watch', () => startClipboardWatch(getMainWindow));
+  ipcMain.on('clipboard:stop-watch', () => stopClipboardWatch());
+  ipcMain.handle('clipboard:get-content', () => getClipboardContent());
+
+  // Offline cache IPC
+  ipcMain.handle('offline:is-online', () => isOnline());
+  ipcMain.handle('offline:cache-conversation', (_e, id: string, title: string, messages: any[]) => {
+    cacheConversation(id, title, messages);
+  });
+  ipcMain.handle('offline:get-conversations', () => getCachedConversations());
+  ipcMain.handle('offline:get-conversation', (_e, id: string) => getCachedConversation(id));
+  ipcMain.handle('offline:clear-cache', () => { clearOfflineCache(); });
+
+  // Auto-updater IPC
+  ipcMain.on('updater:check-now', () => checkForUpdates());
+  ipcMain.on('updater:quit-and-install', () => quitAndInstall());
 }
 
 // Helper to get the main (non-spotlight) window
@@ -265,15 +289,50 @@ function registerGlobalShortcut(): void {
   }
 }
 
+// ---------- Deep link handler ----------
+function handleDeepLink(url: string): void {
+  try {
+    // Parse isaapp://chat/session-123 → /app?session=session-123
+    const parsed = new URL(url);
+    const pathParts = parsed.pathname.replace(/^\/+/, '').split('/');
+    let route = '/app';
+
+    if (pathParts[0] === 'chat' && pathParts[1]) {
+      route = `/app?session=${pathParts[1]}`;
+    } else if (pathParts[0] === 'settings') {
+      route = '/app?view=settings';
+    }
+
+    const win = getMainWindow();
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
+      win.webContents.send('app:deep-link', route);
+    }
+  } catch (err) {
+    console.warn('[isA Desktop] Invalid deep link:', url, err);
+  }
+}
+
 // ---------- App lifecycle ----------
+app.setAsDefaultProtocolClient('isaapp');
+
+// macOS: deep link via open-url event
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleDeepLink(url);
+});
+
 app.whenReady().then(() => {
   buildMenu();
   setupIPC();
   registerGlobalShortcut();
   createTray(trayDeps());
   initFilesystem();
+  initOfflineCache();
   initMCPHost();
   startAutoDetect();
+  initAutoUpdater(getMainWindow);
   cleanupOldScreenshots();
   createWindow();
 
@@ -286,6 +345,7 @@ app.whenReady().then(() => {
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();
   stopAutoDetect();
+  stopAutoUpdater();
   mcpShutdownAll();
 });
 

--- a/desktop/src/offline-cache.ts
+++ b/desktop/src/offline-cache.ts
@@ -1,0 +1,104 @@
+import { app } from 'electron';
+import { net } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CACHE_FILE = 'offline-cache.json';
+const MAX_CONVERSATIONS = 50;
+
+interface CachedMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+}
+
+interface CachedConversation {
+  id: string;
+  title: string;
+  messages: CachedMessage[];
+  cachedAt: string;
+}
+
+let cache: CachedConversation[] = [];
+
+function getCachePath(): string {
+  return path.join(app.getPath('userData'), CACHE_FILE);
+}
+
+function loadCache(): void {
+  try {
+    const filePath = getCachePath();
+    if (fs.existsSync(filePath)) {
+      cache = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    }
+  } catch {
+    cache = [];
+  }
+}
+
+function saveCache(): void {
+  fs.writeFileSync(getCachePath(), JSON.stringify(cache, null, 2));
+}
+
+export function initOfflineCache(): void {
+  loadCache();
+}
+
+/**
+ * Cache a conversation for offline access.
+ * Keeps only the last MAX_CONVERSATIONS entries (LRU).
+ */
+export function cacheConversation(id: string, title: string, messages: CachedMessage[]): void {
+  // Remove existing entry if present
+  cache = cache.filter((c) => c.id !== id);
+
+  // Add to front (most recent)
+  cache.unshift({
+    id,
+    title,
+    messages,
+    cachedAt: new Date().toISOString(),
+  });
+
+  // Trim to max
+  if (cache.length > MAX_CONVERSATIONS) {
+    cache = cache.slice(0, MAX_CONVERSATIONS);
+  }
+
+  saveCache();
+}
+
+/**
+ * Get list of cached conversations (without full messages for speed).
+ */
+export function getCachedConversations(): Array<{ id: string; title: string; messageCount: number; cachedAt: string }> {
+  return cache.map((c) => ({
+    id: c.id,
+    title: c.title,
+    messageCount: c.messages.length,
+    cachedAt: c.cachedAt,
+  }));
+}
+
+/**
+ * Get a specific cached conversation with full messages.
+ */
+export function getCachedConversation(id: string): CachedConversation | null {
+  return cache.find((c) => c.id === id) ?? null;
+}
+
+/**
+ * Clear all cached conversations.
+ */
+export function clearOfflineCache(): void {
+  cache = [];
+  saveCache();
+}
+
+/**
+ * Check if the device is currently online.
+ */
+export function isOnline(): boolean {
+  return net.isOnline();
+}

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -19,6 +19,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'spotlight:hide', 'spotlight:resize', 'spotlight:open-main',
       'tray:update-status', 'tray:set-badge',
       'notification:show',
+      'clipboard:start-watch', 'clipboard:stop-watch',
+      'updater:check-now', 'updater:quit-and-install',
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...args);
@@ -37,6 +39,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'mcp:list-servers', 'mcp:get-status', 'mcp:get-logs',
       'mcp:add-server', 'mcp:remove-server',
       'mcp:start-server', 'mcp:stop-server', 'mcp:restart-server',
+      'clipboard:get-content',
+      'offline:is-online', 'offline:cache-conversation', 'offline:get-conversations',
+      'offline:get-conversation', 'offline:clear-cache',
     ];
     if (allowedChannels.includes(channel)) {
       return ipcRenderer.invoke(channel, ...args);
@@ -46,7 +51,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   /** Subscribe to messages from the main process. Returns an unsubscribe function. */
   on: (channel: string, callback: (...args: unknown[]) => void) => {
-    const allowedChannels = ['app:update-available', 'app:deep-link', 'notification:click'];
+    const allowedChannels = [
+      'app:update-available', 'app:deep-link', 'notification:click',
+      'clipboard:changed', 'updater:status',
+    ];
     if (allowedChannels.includes(channel)) {
       const listener = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>
         callback(...args);

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -1,0 +1,71 @@
+import { autoUpdater, BrowserWindow } from 'electron';
+
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+/**
+ * Initialize the auto-updater. Sends IPC events to the renderer
+ * for update status changes.
+ */
+export function initAutoUpdater(getMainWindow: () => BrowserWindow | undefined): void {
+  // autoUpdater only works with signed apps + a update server
+  // For development, this is a no-op. In production, configure
+  // the feed URL in forge.config.ts or via electron-updater.
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[isA Desktop] Auto-updater disabled in development');
+    return;
+  }
+
+  autoUpdater.on('checking-for-update', () => {
+    sendToRenderer(getMainWindow, 'updater:status', 'checking');
+  });
+
+  autoUpdater.on('update-available', () => {
+    sendToRenderer(getMainWindow, 'updater:status', 'available');
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    sendToRenderer(getMainWindow, 'updater:status', 'up-to-date');
+  });
+
+  autoUpdater.on('update-downloaded', () => {
+    sendToRenderer(getMainWindow, 'updater:status', 'downloaded');
+  });
+
+  autoUpdater.on('error', (err) => {
+    sendToRenderer(getMainWindow, 'updater:status', 'error');
+    console.error('[isA Desktop] Auto-updater error:', err);
+  });
+
+  // Check on launch
+  checkForUpdates();
+
+  // Periodic check
+  checkInterval = setInterval(checkForUpdates, CHECK_INTERVAL_MS);
+}
+
+export function checkForUpdates(): void {
+  try {
+    autoUpdater.checkForUpdates();
+  } catch (err) {
+    console.warn('[isA Desktop] Update check failed:', err);
+  }
+}
+
+export function quitAndInstall(): void {
+  autoUpdater.quitAndInstall();
+}
+
+export function stopAutoUpdater(): void {
+  if (checkInterval) {
+    clearInterval(checkInterval);
+    checkInterval = null;
+  }
+}
+
+function sendToRenderer(getMainWindow: () => BrowserWindow | undefined, channel: string, ...args: unknown[]): void {
+  const win = getMainWindow();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(channel, ...args);
+  }
+}

--- a/src/hooks/useAutoUpdater.ts
+++ b/src/hooks/useAutoUpdater.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloaded' | 'up-to-date' | 'error';
+
+/**
+ * Bridge hook for Electron auto-updater.
+ * Tracks update status and provides manual check/install triggers.
+ */
+export function useAutoUpdater() {
+  const [status, setStatus] = useState<UpdateStatus>('idle');
+
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    const unsub = electronAPI.on('updater:status', (newStatus: UpdateStatus) => {
+      setStatus(newStatus);
+    });
+
+    return unsub;
+  }, []);
+
+  const checkForUpdates = useCallback(() => {
+    if (!isElectron || !electronAPI) return;
+    electronAPI.send('updater:check-now');
+  }, []);
+
+  const quitAndInstall = useCallback(() => {
+    if (!isElectron || !electronAPI) return;
+    electronAPI.send('updater:quit-and-install');
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    status,
+    checkForUpdates,
+    quitAndInstall,
+    hasUpdate: status === 'available' || status === 'downloaded',
+  };
+}

--- a/src/hooks/useClipboardIntelligence.ts
+++ b/src/hooks/useClipboardIntelligence.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+type ClipboardContentType = 'code' | 'url' | 'text' | 'image' | 'empty';
+
+interface ClipboardEvent {
+  type: ClipboardContentType;
+  text?: string;
+  imageBase64?: string;
+}
+
+/**
+ * Bridge hook for clipboard intelligence.
+ * Watches clipboard changes and provides context-aware content type detection.
+ * Off by default for privacy — call `enable()` to start watching.
+ */
+export function useClipboardIntelligence() {
+  const [lastClipboard, setLastClipboard] = useState<ClipboardEvent | null>(null);
+  const [watching, setWatching] = useState(false);
+
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    const unsub = electronAPI.on('clipboard:changed', (event: ClipboardEvent) => {
+      setLastClipboard(event);
+    });
+
+    return unsub;
+  }, []);
+
+  const enable = useCallback(() => {
+    if (!isElectron || !electronAPI) return;
+    electronAPI.send('clipboard:start-watch');
+    setWatching(true);
+  }, []);
+
+  const disable = useCallback(() => {
+    if (!isElectron || !electronAPI) return;
+    electronAPI.send('clipboard:stop-watch');
+    setWatching(false);
+    setLastClipboard(null);
+  }, []);
+
+  const getContent = useCallback(async (): Promise<ClipboardEvent | null> => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('clipboard:get-content');
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    watching,
+    lastClipboard,
+    enable,
+    disable,
+    getContent,
+  };
+}

--- a/src/hooks/useDeepLinks.ts
+++ b/src/hooks/useDeepLinks.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+/**
+ * Bridge hook for deep link navigation (isaapp:// protocol).
+ * Listens for deep-link events from the main process and navigates accordingly.
+ */
+export function useDeepLinks() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    const unsub = electronAPI.on('app:deep-link', (route: string) => {
+      if (route) router.push(route);
+    });
+
+    return unsub;
+  }, [router]);
+}

--- a/src/hooks/useOfflineCache.ts
+++ b/src/hooks/useOfflineCache.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+
+interface CachedConversationSummary {
+  id: string;
+  title: string;
+  messageCount: number;
+  cachedAt: string;
+}
+
+/**
+ * Bridge hook for offline conversation cache.
+ * Caches conversations locally so they're available without network.
+ */
+export function useOfflineCache() {
+  const [isOffline, setIsOffline] = useState(false);
+  const [cachedConversations, setCachedConversations] = useState<CachedConversationSummary[]>([]);
+
+  // Check online status
+  useEffect(() => {
+    if (!isElectron || !electronAPI) return;
+
+    const check = async () => {
+      const online = await electronAPI.invoke('offline:is-online');
+      setIsOffline(!online);
+    };
+    check();
+    const interval = setInterval(check, 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const refreshCache = useCallback(async () => {
+    if (!isElectron || !electronAPI) return;
+    const list = await electronAPI.invoke('offline:get-conversations');
+    setCachedConversations(list ?? []);
+  }, []);
+
+  useEffect(() => { refreshCache(); }, [refreshCache]);
+
+  const cacheConversation = useCallback(async (id: string, title: string, messages: any[]) => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('offline:cache-conversation', id, title, messages);
+    refreshCache();
+  }, [refreshCache]);
+
+  const getCachedConversation = useCallback(async (id: string) => {
+    if (!isElectron || !electronAPI) return null;
+    return electronAPI.invoke('offline:get-conversation', id);
+  }, []);
+
+  const clearCache = useCallback(async () => {
+    if (!isElectron || !electronAPI) return;
+    await electronAPI.invoke('offline:clear-cache');
+    setCachedConversations([]);
+  }, []);
+
+  return {
+    isAvailable: isElectron,
+    isOffline,
+    cachedConversations,
+    cacheConversation,
+    getCachedConversation,
+    clearCache,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 — Ambient Companion features for the desktop app.

### Clipboard Intelligence (#227)
- `desktop/src/clipboard.ts` — polls clipboard every 2s, detects content type (code/URL/text/image), fires `clipboard:changed` IPC event
- Off by default for privacy — user opts in via settings
- `src/hooks/useClipboardIntelligence.ts` — bridge hook with enable/disable

### Deep Links (#228)
- `isaapp://` protocol registered via `app.setAsDefaultProtocolClient`
- macOS: `open-url` event handler; Windows/Linux: `second-instance` argv parsing
- Routes: `isaapp://chat/<session-id>` → navigate to chat, `isaapp://settings` → open settings
- `src/hooks/useDeepLinks.ts` — bridge hook for navigation events

### Offline Cache (#229)
- `desktop/src/offline-cache.ts` — JSON file cache (last 50 conversations, LRU eviction)
- `net.isOnline()` for connectivity detection
- `src/hooks/useOfflineCache.ts` — bridge hook with online status polling (10s interval)

### Auto-Updater (#232)
- `desktop/src/updater.ts` — Electron autoUpdater, checks on launch + every 6 hours
- Status events: checking → available → downloaded (or up-to-date/error)
- `src/hooks/useAutoUpdater.ts` — bridge hook with status state + manual check/install

### Deferred
- **#230 Calendar widget** — blocked by CalendarService backend
- **#231 Cross-channel continuity** — already wired in web app via SSE, desktop inherits

## Files (9 changed)
| Type | Files |
|------|-------|
| Desktop modules | `clipboard.ts`, `offline-cache.ts`, `updater.ts` (NEW) |
| Desktop infra | `main.ts` (deep link protocol, Phase 3 IPC, lifecycle), `preload.ts` (10 new channels) |
| Bridge hooks | `useClipboardIntelligence.ts`, `useDeepLinks.ts`, `useOfflineCache.ts`, `useAutoUpdater.ts` (NEW) |

## Test plan
- [ ] `electronAPI.send('clipboard:start-watch')` → starts watching clipboard
- [ ] Copy text → `clipboard:changed` event fires with correct type
- [ ] `electronAPI.send('clipboard:stop-watch')` → stops watching
- [ ] Open `isaapp://chat/test-session` in browser → isA_ Desktop activates and navigates
- [ ] `electronAPI.invoke('offline:is-online')` → returns boolean
- [ ] `electronAPI.invoke('offline:cache-conversation', 'id', 'title', [...])` → caches
- [ ] `electronAPI.invoke('offline:get-conversations')` → returns cached list
- [ ] Auto-updater logs "disabled in development" in dev mode
- [ ] `electronAPI.send('updater:check-now')` → triggers update check

Fixes #227, Fixes #228, Fixes #229, Fixes #232
Part of Epic #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)