### PR TITLE
feat(core): unified artifact system — versioned ArtifactNode model (#249, #250, #251, #252)

### DIFF
--- a/src/components/ui/chat/ArtifactPanel.tsx
+++ b/src/components/ui/chat/ArtifactPanel.tsx
@@ -1,20 +1,18 @@
 /**
- * ArtifactPanel — Claude-style side panel for viewing artifacts (#239)
+ * ArtifactPanel — Unified artifact side panel with versioning (#239, #252)
  *
- * Opens when user clicks an artifact in the chat. Shows:
- * - Header with title, close, copy, download actions
- * - Tab bar: Preview / Code / Edit
- * - Content area with appropriate rendering
- *
- * Design ref (docs/design/claude-ui-reference.md):
- * - Side panel slides in from right, chat area shrinks (50/50 or 40/60)
- * - Border-left divider, smooth transition
- * - Tabs with bottom border active indicator
+ * Now powered by ArtifactNode model with version chain.
+ * Shows: header with version selector, tabs (Preview/Code/Edit),
+ * content area with A2UI rendering support.
  */
 import React, { useState, useCallback } from 'react';
+import type { ArtifactNode } from '../../../types/artifactTypes';
+import { getActiveVersion, getVersionCount } from '../../../types/artifactTypes';
+import { useArtifactManager } from '../../../stores/useArtifactManager';
 
 export type ArtifactPanelTab = 'preview' | 'code' | 'edit';
 
+/** @deprecated Use ArtifactNode instead */
 export interface ArtifactPanelData {
   id: string;
   title: string;
@@ -25,40 +23,50 @@ export interface ArtifactPanelData {
   downloadUrl?: string;
 }
 
-interface ArtifactPanelProps {
-  open: boolean;
-  artifact: ArtifactPanelData | null;
-  onClose: () => void;
-  onRequestEdit?: (instruction: string) => void;
-}
-
 const TAB_CONFIG: { id: ArtifactPanelTab; label: string }[] = [
   { id: 'preview', label: 'Preview' },
   { id: 'code', label: 'Code' },
   { id: 'edit', label: 'Edit' },
 ];
 
-export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
-  open, artifact, onClose, onRequestEdit,
-}) => {
+/**
+ * ArtifactPanel — reads from useArtifactManager store
+ */
+export const ArtifactPanel: React.FC = () => {
+  const openArtifactId = useArtifactManager(s => s.openArtifactId);
+  const panelLayout = useArtifactManager(s => s.panelLayout);
+  const artifacts = useArtifactManager(s => s.artifacts);
+  const { closePanel, setActiveVersion, addVersion } = useArtifactManager(s => ({
+    closePanel: s.closePanel,
+    setActiveVersion: s.setActiveVersion,
+    addVersion: s.addVersion,
+  }));
+
+  const artifact = openArtifactId ? artifacts[openArtifactId] : null;
+
   const [activeTab, setActiveTab] = useState<ArtifactPanelTab>('preview');
   const [editInstruction, setEditInstruction] = useState('');
   const [copied, setCopied] = useState(false);
 
+  const activeVersion = artifact ? getActiveVersion(artifact) : null;
+  const versionCount = artifact ? getVersionCount(artifact) : 0;
+
   const handleCopy = useCallback(async () => {
-    if (!artifact) return;
-    await navigator.clipboard.writeText(artifact.content);
+    if (!activeVersion) return;
+    await navigator.clipboard.writeText(activeVersion.content);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  }, [artifact]);
+  }, [activeVersion]);
 
   const handleEdit = useCallback(() => {
-    if (!editInstruction.trim() || !onRequestEdit) return;
-    onRequestEdit(editInstruction.trim());
+    if (!editInstruction.trim() || !artifact) return;
+    // Create a new version with the edit instruction
+    // In practice, this would send to Mate and create version from response (#256)
+    addVersion(artifact.id, activeVersion?.content || '', editInstruction.trim());
     setEditInstruction('');
-  }, [editInstruction, onRequestEdit]);
+  }, [editInstruction, artifact, activeVersion, addVersion]);
 
-  if (!open || !artifact) return null;
+  if (panelLayout === 'closed' || !artifact || !activeVersion) return null;
 
   return (
     <div className="flex flex-col h-full bg-white dark:bg-[#1a1a1a] border-l border-gray-200 dark:border-gray-700/50">
@@ -66,15 +74,33 @@ export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700/50">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-            {artifact.title || artifact.filename || 'Artifact'}
+            {artifact.title}
           </span>
-          {artifact.language && (
-            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded">
-              {artifact.language}
+          {activeVersion.language && (
+            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 rounded">
+              {activeVersion.language}
             </span>
           )}
         </div>
         <div className="flex items-center gap-1">
+          {/* Version selector (#252) */}
+          {versionCount > 1 && (
+            <select
+              value={artifact.activeVersionIndex}
+              onChange={e => setActiveVersion(artifact.id, Number(e.target.value))}
+              className="px-2 py-1 text-xs rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none"
+              aria-label="Select version"
+            >
+              {artifact.versions.map((v, i) => (
+                <option key={v.versionId} value={i}>
+                  v{v.number}{v.instruction ? ` — ${v.instruction.slice(0, 30)}` : ''}
+                </option>
+              ))}
+            </select>
+          )}
+          {versionCount === 1 && (
+            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-400 rounded">v1</span>
+          )}
           {/* Copy */}
           <button
             onClick={handleCopy}
@@ -82,37 +108,20 @@ export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
             title={copied ? 'Copied!' : 'Copy'}
           >
             {copied ? (
-              <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
+              <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
             ) : (
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-              </svg>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
             )}
           </button>
           {/* Download */}
           {artifact.downloadUrl && (
-            <a
-              href={artifact.downloadUrl}
-              download={artifact.filename}
-              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-              title="Download"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
+            <a href={artifact.downloadUrl} download={artifact.filename} className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="Download">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
             </a>
           )}
           {/* Close */}
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            title="Close"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+          <button onClick={closePanel} className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="Close">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>
       </div>
@@ -138,16 +147,13 @@ export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
       <div className="flex-1 overflow-auto">
         {activeTab === 'preview' && (
           <div className="p-4">
-            {artifact.type === 'image' ? (
-              <img src={artifact.content} alt={artifact.title} className="max-w-full rounded-lg" />
-            ) : artifact.type === 'html' || artifact.type === 'svg' ? (
-              <div
-                className="bg-white rounded-lg border border-gray-200 dark:border-gray-700 p-4 min-h-[200px]"
-                dangerouslySetInnerHTML={{ __html: artifact.content }}
-              />
+            {artifact.contentType === 'image' ? (
+              <img src={activeVersion.content} alt={artifact.title} className="max-w-full rounded-lg" />
+            ) : artifact.contentType === 'html' || artifact.contentType === 'svg' ? (
+              <div className="bg-white rounded-lg border border-gray-200 dark:border-gray-700 p-4 min-h-[200px]" dangerouslySetInnerHTML={{ __html: activeVersion.content }} />
             ) : (
               <div className="prose dark:prose-invert max-w-none text-[15px] leading-[1.6]">
-                <pre className="whitespace-pre-wrap">{artifact.content}</pre>
+                <pre className="whitespace-pre-wrap">{activeVersion.content}</pre>
               </div>
             )}
           </div>
@@ -155,15 +161,21 @@ export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
 
         {activeTab === 'code' && (
           <pre className="p-4 text-[13px] font-mono leading-relaxed text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-[#111111] min-h-full overflow-x-auto">
-            <code>{artifact.content}</code>
+            <code>{activeVersion.content}</code>
           </pre>
         )}
 
         {activeTab === 'edit' && (
           <div className="flex flex-col h-full">
             <pre className="flex-1 p-4 text-[13px] font-mono leading-relaxed text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-[#111111] overflow-auto">
-              <code>{artifact.content}</code>
+              <code>{activeVersion.content}</code>
             </pre>
+            {/* Version instruction (what created this version) */}
+            {activeVersion.instruction && (
+              <div className="px-4 py-2 border-t border-gray-100 dark:border-gray-800 text-xs text-gray-400">
+                Created by: "{activeVersion.instruction}"
+              </div>
+            )}
             <div className="p-3 border-t border-gray-200 dark:border-gray-700/50">
               <div className="flex gap-2">
                 <input

--- a/src/components/ui/chat/ArtifactPeekCard.tsx
+++ b/src/components/ui/chat/ArtifactPeekCard.tsx
@@ -1,0 +1,121 @@
+/**
+ * ArtifactPeekCard — Compact inline artifact preview (#251)
+ *
+ * Replaces both ArtifactMessageComponent and ArtifactComponent with a unified
+ * peek card. Renders consistently across all content types.
+ *
+ * Design: flat card, 1px border, 8px radius, type badge, version indicator,
+ * hover actions (copy, expand). Click opens in artifact panel.
+ */
+import React, { useCallback } from 'react';
+import type { ArtifactNode } from '../../../types/artifactTypes';
+import { getActiveVersion, getVersionCount } from '../../../types/artifactTypes';
+import { useArtifactManager } from '../../../stores/useArtifactManager';
+
+const TYPE_ICONS: Record<string, string> = {
+  code: '\u{1F4BB}',        // laptop
+  text: '\u{1F4DD}',        // memo
+  image: '\u{1F5BC}',       // frame with picture
+  html: '\u{1F310}',        // globe
+  svg: '\u{1F3A8}',         // palette
+  data: '\u{1F4CA}',        // bar chart
+  chart: '\u{1F4C8}',       // chart increasing
+  form: '\u{1F4CB}',        // clipboard
+  dashboard: '\u{1F4CA}',   // bar chart
+  search_results: '\u{1F50D}', // magnifying glass
+  analysis: '\u{1F9EA}',    // test tube
+  a2ui_surface: '\u{2728}', // sparkles
+};
+
+interface ArtifactPeekCardProps {
+  artifact: ArtifactNode;
+  className?: string;
+}
+
+export const ArtifactPeekCard: React.FC<ArtifactPeekCardProps> = ({ artifact, className = '' }) => {
+  const openArtifact = useArtifactManager(s => s.openArtifact);
+  const activeVersion = getActiveVersion(artifact);
+  const versionCount = getVersionCount(artifact);
+
+  const handleClick = useCallback(() => {
+    openArtifact(artifact.id, 'inspect');
+  }, [artifact.id, openArtifact]);
+
+  const handleCopy = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await navigator.clipboard.writeText(activeVersion.content);
+  }, [activeVersion.content]);
+
+  // Truncate content for preview
+  const preview = activeVersion.content.length > 200
+    ? activeVersion.content.slice(0, 200) + '...'
+    : activeVersion.content;
+
+  return (
+    <div
+      onClick={handleClick}
+      className={`group cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-[#1a1a1a] hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all duration-150 overflow-hidden max-w-md ${className}`}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => { if (e.key === 'Enter') handleClick(); }}
+      aria-label={`Artifact: ${artifact.title}`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+        <span className="text-base">{TYPE_ICONS[artifact.contentType] || '\u{1F4CE}'}</span>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            {artifact.title}
+          </div>
+        </div>
+        {/* Version badge */}
+        {versionCount > 1 && (
+          <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 rounded">
+            v{activeVersion.number}
+          </span>
+        )}
+        {/* Language badge */}
+        {activeVersion.language && (
+          <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 rounded">
+            {activeVersion.language}
+          </span>
+        )}
+      </div>
+
+      {/* Content Preview */}
+      <div className="px-3 py-2 relative">
+        {artifact.contentType === 'image' ? (
+          <img
+            src={activeVersion.content}
+            alt={artifact.title}
+            className="w-full h-32 object-cover rounded"
+          />
+        ) : (
+          <pre className="text-xs font-mono text-gray-600 dark:text-gray-400 leading-relaxed whitespace-pre-wrap line-clamp-4 overflow-hidden">
+            {preview}
+          </pre>
+        )}
+
+        {/* Hover overlay with actions */}
+        <div className="absolute inset-0 bg-white/80 dark:bg-[#1a1a1a]/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+          <button
+            onClick={handleCopy}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          >
+            Copy
+          </button>
+          <span className="px-3 py-1.5 text-xs font-medium rounded-md bg-[#111111] dark:bg-gray-100 text-white dark:text-[#111111]">
+            Open
+          </span>
+        </div>
+      </div>
+
+      {/* Footer */}
+      {artifact.widgetType && (
+        <div className="px-3 py-1.5 border-t border-gray-100 dark:border-gray-800">
+          <span className="text-[11px] text-gray-400 capitalize">{artifact.widgetType}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -73,7 +73,7 @@ import {
 // 🆕 Mobile-first responsive layout
 import { ResponsiveChatLayout } from '../components/ui/adaptive/ResponsiveChatLayout';
 import { ArtifactPanel } from '../components/ui/chat/ArtifactPanel';
-import { useArtifactPanel } from '../hooks/useArtifactPanel';
+import { useArtifactManager, usePanelLayout } from '../stores/useArtifactManager';
 import { useDeviceType } from '../hooks/useDeviceType';
 import { useNativeApp } from '../hooks/useNativeApp';
 
@@ -107,8 +107,8 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
   // Module state for upgrade modal
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
-  // Artifact panel state (#239)
-  const artifactPanel = useArtifactPanel();
+  // Artifact panel — store-driven (#249, #252)
+  const artifactPanelLayout = usePanelLayout();
 
   // Extract widget selector, panel state, and sidebar state from props (managed by parent)
   const {
@@ -505,15 +505,9 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         onEditMessage={messageHandlers.handleEditMessage}
         onRegenerateMessage={messageHandlers.handleRegenerateMessage}
 
-        // Artifact Panel (#239)
-        showArtifactPanel={artifactPanel.isOpen}
-        artifactPanelContent={
-          <ArtifactPanel
-            open={artifactPanel.isOpen}
-            artifact={artifactPanel.artifact}
-            onClose={artifactPanel.closeArtifact}
-          />
-        }
+        // Artifact Panel — store-driven (#249, #252)
+        showArtifactPanel={artifactPanelLayout !== 'closed'}
+        artifactPanelContent={<ArtifactPanel />}
 
         // Sidebar state (injected from AppLayout via useSidebar)
         sidebarOpen={sidebarOpen}

--- a/src/stores/useArtifactManager.ts
+++ b/src/stores/useArtifactManager.ts
@@ -1,0 +1,167 @@
+/**
+ * useArtifactManager — Central artifact state management (#250)
+ *
+ * Replaces useArtifactStore with version-aware, A2UI-native artifact management.
+ * All artifacts flow through this store — widgets create, panel displays, chat previews.
+ */
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import type {
+  ArtifactNode,
+  ArtifactContentType,
+} from '../types/artifactTypes';
+import {
+  createArtifactNode,
+  addArtifactVersion,
+  getActiveVersion,
+} from '../types/artifactTypes';
+
+interface ArtifactManagerState {
+  /** All artifacts indexed by ID */
+  artifacts: Record<string, ArtifactNode>;
+  /** Currently open artifact ID (shown in panel) */
+  openArtifactId: string | null;
+  /** Panel layout mode */
+  panelLayout: 'closed' | 'inspect' | 'canvas';
+}
+
+interface ArtifactManagerActions {
+  /** Create a new artifact and return its ID */
+  createArtifact: (params: {
+    title: string;
+    content: string;
+    contentType: ArtifactContentType;
+    language?: string;
+    widgetType?: string;
+    filename?: string;
+    sessionId?: string;
+    sourceMessageId?: string;
+  }) => string;
+
+  /** Add a new version to an existing artifact */
+  addVersion: (artifactId: string, content: string, instruction: string) => void;
+
+  /** Set the active version index */
+  setActiveVersion: (artifactId: string, versionIndex: number) => void;
+
+  /** Fork an artifact (creates a copy with parentId link) */
+  forkArtifact: (artifactId: string) => string | null;
+
+  /** Open an artifact in the panel */
+  openArtifact: (artifactId: string, layout?: 'inspect' | 'canvas') => void;
+
+  /** Close the artifact panel */
+  closePanel: () => void;
+
+  /** Remove an artifact */
+  removeArtifact: (artifactId: string) => void;
+
+  /** Get an artifact by ID */
+  getArtifact: (artifactId: string) => ArtifactNode | undefined;
+
+  /** Get all artifacts for a session */
+  getSessionArtifacts: (sessionId: string) => ArtifactNode[];
+}
+
+type ArtifactManagerStore = ArtifactManagerState & ArtifactManagerActions;
+
+export const useArtifactManager = create<ArtifactManagerStore>()(
+  subscribeWithSelector((set, get) => ({
+    artifacts: {},
+    openArtifactId: null,
+    panelLayout: 'closed',
+
+    createArtifact: (params) => {
+      const node = createArtifactNode(params);
+      set(state => ({
+        artifacts: { ...state.artifacts, [node.id]: node },
+      }));
+      return node.id;
+    },
+
+    addVersion: (artifactId, content, instruction) => {
+      set(state => {
+        const artifact = state.artifacts[artifactId];
+        if (!artifact) return state;
+        const updated = addArtifactVersion(artifact, content, instruction);
+        return {
+          artifacts: { ...state.artifacts, [artifactId]: updated },
+        };
+      });
+    },
+
+    setActiveVersion: (artifactId, versionIndex) => {
+      set(state => {
+        const artifact = state.artifacts[artifactId];
+        if (!artifact || versionIndex < 0 || versionIndex >= artifact.versions.length) return state;
+        return {
+          artifacts: {
+            ...state.artifacts,
+            [artifactId]: { ...artifact, activeVersionIndex: versionIndex },
+          },
+        };
+      });
+    },
+
+    forkArtifact: (artifactId) => {
+      const artifact = get().artifacts[artifactId];
+      if (!artifact) return null;
+      const activeVersion = getActiveVersion(artifact);
+      const forked = createArtifactNode({
+        title: `${artifact.title} (fork)`,
+        content: activeVersion.content,
+        contentType: artifact.contentType,
+        language: activeVersion.language,
+        widgetType: artifact.widgetType,
+        sessionId: artifact.sessionId,
+      });
+      const forkedWithParent = { ...forked, parentId: artifactId };
+      set(state => ({
+        artifacts: { ...state.artifacts, [forkedWithParent.id]: forkedWithParent },
+      }));
+      return forkedWithParent.id;
+    },
+
+    openArtifact: (artifactId, layout = 'inspect') => {
+      set({ openArtifactId: artifactId, panelLayout: layout });
+    },
+
+    closePanel: () => {
+      set({ openArtifactId: null, panelLayout: 'closed' });
+    },
+
+    removeArtifact: (artifactId) => {
+      set(state => {
+        const { [artifactId]: _, ...rest } = state.artifacts;
+        return {
+          artifacts: rest,
+          openArtifactId: state.openArtifactId === artifactId ? null : state.openArtifactId,
+          panelLayout: state.openArtifactId === artifactId ? 'closed' : state.panelLayout,
+        };
+      });
+    },
+
+    getArtifact: (artifactId) => get().artifacts[artifactId],
+
+    getSessionArtifacts: (sessionId) =>
+      Object.values(get().artifacts).filter(a => a.sessionId === sessionId),
+  }))
+);
+
+// Selectors
+export const useOpenArtifact = () => {
+  const id = useArtifactManager(s => s.openArtifactId);
+  const artifacts = useArtifactManager(s => s.artifacts);
+  return id ? artifacts[id] : null;
+};
+
+export const usePanelLayout = () => useArtifactManager(s => s.panelLayout);
+export const useArtifactActions = () => useArtifactManager(s => ({
+  createArtifact: s.createArtifact,
+  addVersion: s.addVersion,
+  setActiveVersion: s.setActiveVersion,
+  forkArtifact: s.forkArtifact,
+  openArtifact: s.openArtifact,
+  closePanel: s.closePanel,
+  removeArtifact: s.removeArtifact,
+}));

--- a/src/types/artifactTypes.ts
+++ b/src/types/artifactTypes.ts
@@ -1,0 +1,191 @@
+/**
+ * Unified Artifact Type System (#250)
+ *
+ * Artifacts are A2UI surfaces with lifecycle management.
+ * Every rich interaction an agent generates is an artifact that can be
+ * viewed (peek), inspected (panel), interacted with (canvas),
+ * versioned, and evolved.
+ */
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+export type ArtifactContentType =
+  | 'code'
+  | 'text'
+  | 'image'
+  | 'html'
+  | 'svg'
+  | 'data'
+  | 'chart'
+  | 'form'
+  | 'dashboard'
+  | 'search_results'
+  | 'analysis'
+  | 'a2ui_surface';
+
+export type ArtifactLayout = 'peek' | 'inspect' | 'canvas';
+
+export type ArtifactTransformType =
+  | 'edit'
+  | 'fork'
+  | 'export'
+  | 'annotate'
+  | 'merge';
+
+// ============================================================================
+// ArtifactVersion — immutable snapshot of artifact content
+// ============================================================================
+
+export interface ArtifactVersion {
+  /** Unique version ID */
+  versionId: string;
+  /** Version number (1, 2, 3...) */
+  number: number;
+  /** Content at this version */
+  content: string;
+  /** Content type */
+  contentType: ArtifactContentType;
+  /** Language hint for code artifacts */
+  language?: string;
+  /** A2UI surface state (JSON) — if this artifact is a dynamic A2UI surface */
+  a2uiState?: Record<string, unknown>;
+  /** The instruction that created this version (empty for v1) */
+  instruction?: string;
+  /** Who created this version */
+  createdBy: 'user' | 'agent';
+  /** ISO timestamp */
+  createdAt: string;
+}
+
+// ============================================================================
+// ArtifactNode — the artifact entity with version chain
+// ============================================================================
+
+export interface ArtifactNode {
+  /** Unique artifact ID */
+  id: string;
+  /** Display title */
+  title: string;
+  /** Primary content type */
+  contentType: ArtifactContentType;
+  /** Source widget type (dream, hunt, omni, etc.) — null for pure agent artifacts */
+  widgetType?: string;
+  /** Filename hint */
+  filename?: string;
+  /** All versions (ordered, v1 first) */
+  versions: ArtifactVersion[];
+  /** Currently active version index */
+  activeVersionIndex: number;
+  /** Parent artifact ID (if forked) */
+  parentId?: string;
+  /** Session ID this artifact belongs to */
+  sessionId?: string;
+  /** Message ID that created this artifact */
+  sourceMessageId?: string;
+  /** ISO timestamp of creation */
+  createdAt: string;
+  /** ISO timestamp of last update */
+  updatedAt: string;
+  /** Download URL (if exportable) */
+  downloadUrl?: string;
+  /** Metadata */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// ArtifactTransform — an operation on an artifact
+// ============================================================================
+
+export interface ArtifactTransform {
+  type: ArtifactTransformType;
+  artifactId: string;
+  fromVersionId: string;
+  toVersionId?: string;
+  instruction?: string;
+  timestamp: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Get the active version of an artifact */
+export function getActiveVersion(artifact: ArtifactNode): ArtifactVersion {
+  return artifact.versions[artifact.activeVersionIndex] || artifact.versions[0];
+}
+
+/** Get the latest version of an artifact */
+export function getLatestVersion(artifact: ArtifactNode): ArtifactVersion {
+  return artifact.versions[artifact.versions.length - 1];
+}
+
+/** Get version count */
+export function getVersionCount(artifact: ArtifactNode): number {
+  return artifact.versions.length;
+}
+
+/** Create a new artifact with initial content */
+export function createArtifactNode(params: {
+  title: string;
+  content: string;
+  contentType: ArtifactContentType;
+  language?: string;
+  widgetType?: string;
+  filename?: string;
+  sessionId?: string;
+  sourceMessageId?: string;
+  a2uiState?: Record<string, unknown>;
+}): ArtifactNode {
+  const now = new Date().toISOString();
+  const versionId = `v_${Date.now().toString(36)}`;
+  return {
+    id: `art_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`,
+    title: params.title,
+    contentType: params.contentType,
+    widgetType: params.widgetType,
+    filename: params.filename,
+    versions: [{
+      versionId,
+      number: 1,
+      content: params.content,
+      contentType: params.contentType,
+      language: params.language,
+      a2uiState: params.a2uiState,
+      createdBy: 'agent',
+      createdAt: now,
+    }],
+    activeVersionIndex: 0,
+    sessionId: params.sessionId,
+    sourceMessageId: params.sourceMessageId,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** Add a new version to an artifact */
+export function addArtifactVersion(
+  artifact: ArtifactNode,
+  content: string,
+  instruction: string,
+  createdBy: 'user' | 'agent' = 'agent',
+): ArtifactNode {
+  const now = new Date().toISOString();
+  const newVersion: ArtifactVersion = {
+    versionId: `v_${Date.now().toString(36)}`,
+    number: artifact.versions.length + 1,
+    content,
+    contentType: artifact.contentType,
+    language: artifact.versions[0]?.language,
+    instruction,
+    createdBy,
+    createdAt: now,
+  };
+  return {
+    ...artifact,
+    versions: [...artifact.versions, newVersion],
+    activeVersionIndex: artifact.versions.length, // point to new version
+    updatedAt: now,
+  };
+}


### PR DESCRIPTION
## Summary

Foundation for A2UI-native artifact system. Artifacts are now versionable, composable entities with progressive disclosure (peek → inspect → canvas).

### New Files
- **`src/types/artifactTypes.ts`** — ArtifactNode, ArtifactVersion, ArtifactTransform types + helpers
- **`src/stores/useArtifactManager.ts`** — Central store: CRUD + versioning + panel state
- **`src/components/ui/chat/ArtifactPeekCard.tsx`** — Compact inline preview card

### Updated Files
- **ArtifactPanel** — Now store-driven with version selector dropdown
- **ChatModule** — Uses `usePanelLayout` from store instead of prop-based panel

### Architecture
```
ArtifactNode (versioned entity)
  → ArtifactPeekCard (inline in chat — click to open)
    → ArtifactPanel (side panel — version selector, Preview/Code/Edit tabs)
      → [Future] ArtifactCanvas (full-screen with metadata sidebar)
```

Old ArtifactMessageComponent and ArtifactComponent still exist for backward compat.
New code should use ArtifactPeekCard + useArtifactManager.

Fixes #250, #251, #252
🤖 Generated with [Claude Code](https://claude.com/claude-code)