### PR TITLE
feat(core): artifact edit-to-version evolution loop (#256)

### DIFF
--- a/src/components/ui/chat/ArtifactPanel.tsx
+++ b/src/components/ui/chat/ArtifactPanel.tsx
@@ -29,10 +29,15 @@ const TAB_CONFIG: { id: ArtifactPanelTab; label: string }[] = [
   { id: 'edit', label: 'Edit' },
 ];
 
+interface ArtifactPanelProps {
+  /** Called when user submits an edit instruction — sends to Mate for evolution (#256) */
+  onEditArtifact?: (artifactId: string, instruction: string, currentContent: string) => void;
+}
+
 /**
  * ArtifactPanel — reads from useArtifactManager store
  */
-export const ArtifactPanel: React.FC = () => {
+export const ArtifactPanel: React.FC<ArtifactPanelProps> = ({ onEditArtifact }) => {
   const openArtifactId = useArtifactManager(s => s.openArtifactId);
   const panelLayout = useArtifactManager(s => s.panelLayout);
   const artifacts = useArtifactManager(s => s.artifacts);
@@ -59,10 +64,14 @@ export const ArtifactPanel: React.FC = () => {
   }, [activeVersion]);
 
   const handleEdit = useCallback(() => {
-    if (!editInstruction.trim() || !artifact) return;
-    // Create a new version with the edit instruction
-    // In practice, this would send to Mate and create version from response (#256)
-    addVersion(artifact.id, activeVersion?.content || '', editInstruction.trim());
+    if (!editInstruction.trim() || !artifact || !activeVersion) return;
+    if (onEditArtifact) {
+      // Send to Mate for evolution — new version created from response (#256)
+      onEditArtifact(artifact.id, editInstruction.trim(), activeVersion.content);
+    } else {
+      // Fallback: create local version (no backend)
+      addVersion(artifact.id, activeVersion.content, editInstruction.trim());
+    }
     setEditInstruction('');
   }, [editInstruction, artifact, activeVersion, addVersion]);
 

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -505,9 +505,11 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         onEditMessage={messageHandlers.handleEditMessage}
         onRegenerateMessage={messageHandlers.handleRegenerateMessage}
 
-        // Artifact Panel — store-driven (#249, #252)
+        // Artifact Panel — store-driven (#249, #252, #256)
         showArtifactPanel={artifactPanelLayout !== 'closed'}
-        artifactPanelContent={<ArtifactPanel />}
+        artifactPanelContent={
+          <ArtifactPanel onEditArtifact={messageHandlers.handleArtifactEdit} />
+        }
 
         // Sidebar state (injected from AppLayout via useSidebar)
         sidebarOpen={sidebarOpen}

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -210,6 +210,21 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
             useChatStore.getState().setIsTyping(false);
             useChatStore.getState().setExecutingPlan(false);
             logger.info(LogCategory.CHAT_FLOW, 'Message sending completed successfully');
+
+            // Artifact edit-to-version: if this was an artifact edit, create new version (#256)
+            if (typeof window !== 'undefined' && (window as any).__pendingArtifactEdit) {
+              const { artifactId, instruction } = (window as any).__pendingArtifactEdit;
+              delete (window as any).__pendingArtifactEdit;
+              // Get the last assistant message content as the new version
+              const messages = useMessageStore.getState().messages;
+              const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant');
+              if (lastAssistant && 'content' in lastAssistant && lastAssistant.content) {
+                import('../../stores/useArtifactManager').then(({ useArtifactManager }) => {
+                  useArtifactManager.getState().addVersion(artifactId, lastAssistant.content, instruction);
+                  log.info('Artifact version created from edit response', { artifactId, instruction });
+                });
+              }
+            }
           },
           onToolStart: (toolName: string, toolCallId?: string) => {
             if (isDelegationTool(toolName) && toolCallId) {
@@ -401,6 +416,49 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     handleSendMessage(userContent);
   };
 
+  /**
+   * Edit an artifact — sends structured follow-up to Mate, creates new version (#256)
+   *
+   * The core evolution loop:
+   * 1. User types instruction in artifact Edit tab
+   * 2. System sends: "[Artifact Edit] <instruction>\n\nOriginal content:\n```\n<content>\n```"
+   * 3. Mate responds with updated content
+   * 4. Response callback creates a new ArtifactVersion
+   */
+  const handleArtifactEdit = async (artifactId: string, instruction: string, currentContent: string) => {
+    const { useArtifactManager } = await import('../../stores/useArtifactManager');
+    const artifactManager = useArtifactManager.getState();
+
+    // Build structured edit prompt
+    const editPrompt = `[Artifact Edit Request]
+Instruction: ${instruction}
+
+Current artifact content:
+\`\`\`
+${currentContent}
+\`\`\`
+
+Please apply the requested changes and return ONLY the updated content. Do not include explanations — just the updated artifact.`;
+
+    // Send as a regular message — the response will be captured
+    // and used to create a new artifact version
+    const originalSendMessage = handleSendMessage;
+
+    // Store the artifact ID so the response callback can create a version
+    if (typeof window !== 'undefined') {
+      (window as any).__pendingArtifactEdit = {
+        artifactId,
+        instruction,
+      };
+    }
+
+    await originalSendMessage(editPrompt, {
+      artifact_edit: true,
+      artifact_id: artifactId,
+      edit_instruction: instruction,
+    });
+  };
+
   return {
     handleNewChat,
     handleSendMessage,
@@ -408,5 +466,6 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     handleMessageClick,
     handleEditMessage,
     handleRegenerateMessage,
+    handleArtifactEdit,
   };
 }


### PR DESCRIPTION
## Summary

Wire the core artifact evolution loop — user instructs changes, Mate applies them, new version created automatically.

### Flow
```
User types "make it responsive" in Edit tab
  → handleArtifactEdit sends structured prompt to Mate
    → Mate responds with updated code
      → onStreamComplete detects pending edit
        → useArtifactManager.addVersion(id, newContent, instruction)
          → Panel updates, version selector shows "v2 — make it responsive"
```

### Changes
- `messageHandlers.ts`: Add `handleArtifactEdit` handler + version creation in `onStreamComplete`
- `ArtifactPanel.tsx`: Add `onEditArtifact` prop, dispatch to handler instead of local version
- `ChatModule.tsx`: Wire `handleArtifactEdit` to panel

Fixes #256
🤖 Generated with [Claude Code](https://claude.com/claude-code)