### PR TITLE
feat(ui): build ArtifactPeekCard — compact inline artifact preview

### DIFF
--- a/src/components/ui/chat/ArtifactPeekCard.tsx
+++ b/src/components/ui/chat/ArtifactPeekCard.tsx
@@ -1,121 +1,353 @@
 /**
  * ArtifactPeekCard — Compact inline artifact preview (#251)
  *
- * Replaces both ArtifactMessageComponent and ArtifactComponent with a unified
- * peek card. Renders consistently across all content types.
+ * Unified peek card that replaces ArtifactMessageComponent in the chat
+ * message list. Accepts either an ArtifactMessage (from chat stream) or
+ * an ArtifactNode (from the manager store).
  *
- * Design: flat card, 1px border, 8px radius, type badge, version indicator,
- * hover actions (copy, expand). Click opens in artifact panel.
+ * - Compact card with thumbnail/preview, title, type badge, version badge
+ * - Click opens the artifact in the side panel via artifactManager.openArtifact
+ * - Hover reveals quick actions: copy, download, expand
+ * - Keyboard navigable (Tab, Enter/Space)
+ * - Consistent glass-dark theme across all widget/content types
  */
-import React, { useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
+import type { ArtifactMessage } from '../../../types/chatTypes';
 import type { ArtifactNode } from '../../../types/artifactTypes';
 import { getActiveVersion, getVersionCount } from '../../../types/artifactTypes';
 import { useArtifactManager } from '../../../stores/useArtifactManager';
+import { ContentRenderer, StatusRenderer } from '../../shared';
 
-const TYPE_ICONS: Record<string, string> = {
-  code: '\u{1F4BB}',        // laptop
-  text: '\u{1F4DD}',        // memo
-  image: '\u{1F5BC}',       // frame with picture
-  html: '\u{1F310}',        // globe
-  svg: '\u{1F3A8}',         // palette
-  data: '\u{1F4CA}',        // bar chart
-  chart: '\u{1F4C8}',       // chart increasing
-  form: '\u{1F4CB}',        // clipboard
-  dashboard: '\u{1F4CA}',   // bar chart
-  search_results: '\u{1F50D}', // magnifying glass
-  analysis: '\u{1F9EA}',    // test tube
-  a2ui_surface: '\u{2728}', // sparkles
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Widget-type to icon + accent colour mapping */
+const WIDGET_META: Record<string, { icon: string; color: string }> = {
+  dream:             { icon: '\uD83C\uDFA8', color: '#a78bfa' },
+  hunt:              { icon: '\uD83D\uDD0D', color: '#60a5fa' },
+  omni:              { icon: '\u26A1',       color: '#fbbf24' },
+  data_scientist:    { icon: '\uD83D\uDCCA', color: '#34d399' },
+  knowledge:         { icon: '\uD83E\uDDE0', color: '#f472b6' },
+  custom_automation: { icon: '\uD83E\uDD16', color: '#818cf8' },
+  digitalhub:        { icon: '\uD83D\uDCC2', color: '#fb923c' },
+  doc:               { icon: '\uD83D\uDCDD', color: '#94a3b8' },
 };
 
-interface ArtifactPeekCardProps {
-  artifact: ArtifactNode;
+const DEFAULT_WIDGET_META = { icon: '\uD83D\uDCCE', color: '#94a3b8' };
+
+/** Content-type to human-readable badge label */
+const TYPE_LABELS: Record<string, string> = {
+  image: 'Image',
+  text: 'Text',
+  data: 'Data',
+  analysis: 'Analysis',
+  knowledge: 'Knowledge',
+  search_results: 'Search',
+  code: 'Code',
+  html: 'HTML',
+  svg: 'SVG',
+  chart: 'Chart',
+  form: 'Form',
+  dashboard: 'Dashboard',
+  a2ui_surface: 'Surface',
+};
+
+// ---------------------------------------------------------------------------
+// Props — supports both ArtifactMessage and ArtifactNode inputs
+// ---------------------------------------------------------------------------
+
+export interface ArtifactPeekCardProps {
+  /** ArtifactMessage from the chat stream */
+  artifactMessage?: ArtifactMessage;
+  /** ArtifactNode from the manager store (used when rendered outside chat) */
+  artifact?: ArtifactNode;
+  /** Fallback open handler when the artifact is not in the manager store */
+  onFallbackOpen?: () => void;
   className?: string;
 }
 
-export const ArtifactPeekCard: React.FC<ArtifactPeekCardProps> = ({ artifact, className = '' }) => {
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const ArtifactPeekCard: React.FC<ArtifactPeekCardProps> = ({
+  artifactMessage,
+  artifact: artifactNodeProp,
+  onFallbackOpen,
+  className = '',
+}) => {
+  // --- Resolve data from whichever source was provided --------------------
   const openArtifact = useArtifactManager(s => s.openArtifact);
-  const activeVersion = getActiveVersion(artifact);
-  const versionCount = getVersionCount(artifact);
+  const managerArtifacts = useArtifactManager(s => s.artifacts);
 
-  const handleClick = useCallback(() => {
-    openArtifact(artifact.id, 'inspect');
-  }, [artifact.id, openArtifact]);
+  // Determine the managed artifact (from the store) for version info
+  const managedArtifact: ArtifactNode | undefined = artifactNodeProp
+    ?? (artifactMessage
+      ? Object.values(managerArtifacts).find(
+          a => a.sourceMessageId === artifactMessage.id || a.id === artifactMessage.artifact.id,
+        )
+      : undefined);
 
-  const handleCopy = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    await navigator.clipboard.writeText(activeVersion.content);
-  }, [activeVersion.content]);
+  // Normalised display values
+  const widgetType  = managedArtifact?.widgetType ?? artifactMessage?.artifact.widgetType ?? '';
+  const contentType = managedArtifact?.contentType ?? artifactMessage?.artifact.contentType ?? 'text';
+  const title       = managedArtifact?.title ?? artifactMessage?.artifact.widgetName ?? widgetType;
+  const content     = managedArtifact
+    ? getActiveVersion(managedArtifact).content
+    : artifactMessage?.artifact.content;
+  const versionNumber = managedArtifact
+    ? getVersionCount(managedArtifact)
+    : (artifactMessage?.artifact.version ?? 1);
+  const language    = managedArtifact ? getActiveVersion(managedArtifact).language : undefined;
+  const isLoading   = content === 'Loading...' || (artifactMessage?.isStreaming ?? false);
 
-  // Truncate content for preview
-  const preview = activeVersion.content.length > 200
-    ? activeVersion.content.slice(0, 200) + '...'
-    : activeVersion.content;
+  const meta      = WIDGET_META[widgetType] ?? DEFAULT_WIDGET_META;
+  const typeLabel = TYPE_LABELS[contentType] ?? contentType;
+
+  // --- Local state --------------------------------------------------------
+  const [hovered, setHovered] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // --- Handlers -----------------------------------------------------------
+
+  const handleOpen = useCallback(() => {
+    if (managedArtifact) {
+      openArtifact(managedArtifact.id, 'inspect');
+    } else {
+      onFallbackOpen?.();
+    }
+  }, [managedArtifact, openArtifact, onFallbackOpen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleOpen();
+      }
+    },
+    [handleOpen],
+  );
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!content || isLoading) return;
+      const text = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    },
+    [content, isLoading],
+  );
+
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!content || isLoading) return;
+      const text = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+      const blob = new Blob([text], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${title || 'artifact'}-v${versionNumber}.txt`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+    [content, isLoading, title, versionNumber],
+  );
+
+  // --- Render -------------------------------------------------------------
 
   return (
     <div
-      onClick={handleClick}
-      className={`group cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-[#1a1a1a] hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all duration-150 overflow-hidden max-w-md ${className}`}
       role="button"
       tabIndex={0}
-      onKeyDown={e => { if (e.key === 'Enter') handleClick(); }}
-      aria-label={`Artifact: ${artifact.title}`}
+      aria-label={`Open artifact: ${title} version ${versionNumber}`}
+      className={`group relative my-3 max-w-sm cursor-pointer select-none rounded-xl transition-all duration-200 ${className}`}
+      style={{
+        background: 'var(--glass-secondary, rgba(255,255,255,0.04))',
+        border: '1px solid var(--glass-border, rgba(255,255,255,0.08))',
+        boxShadow: hovered
+          ? '0 4px 24px rgba(0,0,0,0.25), 0 0 0 1px var(--glass-border, rgba(255,255,255,0.12))'
+          : 'none',
+      }}
+      onClick={handleOpen}
+      onKeyDown={handleKeyDown}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <span className="text-base">{TYPE_ICONS[artifact.contentType] || '\u{1F4CE}'}</span>
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-            {artifact.title}
+      {/* ---- Header ---- */}
+      <div className="flex items-center gap-2.5 px-3.5 py-2.5">
+        {/* Icon circle */}
+        <span
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-base"
+          style={{ background: `color-mix(in srgb, ${meta.color} 15%, transparent)` }}
+          aria-hidden
+        >
+          {meta.icon}
+        </span>
+
+        {/* Title + badges */}
+        <div className="min-w-0 flex-1">
+          <h4
+            className="truncate text-sm font-medium leading-tight"
+            style={{ color: 'var(--text-primary, #e2e8f0)' }}
+          >
+            {title}
+          </h4>
+          <div className="mt-0.5 flex items-center gap-1.5">
+            {/* Type badge */}
+            <span
+              className="rounded px-1.5 py-px font-medium uppercase tracking-wide"
+              style={{
+                background: 'var(--glass-primary, rgba(255,255,255,0.06))',
+                color: 'var(--text-secondary, #94a3b8)',
+                fontSize: '10px',
+              }}
+            >
+              {typeLabel}
+            </span>
+            {/* Version badge */}
+            <span
+              className="rounded px-1.5 py-px font-semibold"
+              style={{
+                background: `color-mix(in srgb, ${meta.color} 12%, transparent)`,
+                color: meta.color,
+                fontSize: '10px',
+              }}
+            >
+              v{versionNumber}
+            </span>
+            {/* Language badge (code artifacts) */}
+            {language && (
+              <span
+                className="rounded px-1.5 py-px font-medium"
+                style={{
+                  background: 'rgba(96,165,250,0.12)',
+                  color: '#60a5fa',
+                  fontSize: '10px',
+                }}
+              >
+                {language}
+              </span>
+            )}
           </div>
         </div>
-        {/* Version badge */}
-        {versionCount > 1 && (
-          <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 rounded">
-            v{activeVersion.number}
-          </span>
-        )}
-        {/* Language badge */}
-        {activeVersion.language && (
-          <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 rounded">
-            {activeVersion.language}
-          </span>
-        )}
+
+        {/* Expand chevron */}
+        <span
+          className="shrink-0 text-xs transition-transform duration-150 group-hover:translate-x-0.5"
+          style={{ color: hovered ? meta.color : 'var(--text-muted, #64748b)' }}
+          aria-hidden
+        >
+          &#x2197;
+        </span>
       </div>
 
-      {/* Content Preview */}
-      <div className="px-3 py-2 relative">
-        {artifact.contentType === 'image' ? (
-          <img
-            src={activeVersion.content}
-            alt={artifact.title}
-            className="w-full h-32 object-cover rounded"
-          />
-        ) : (
-          <pre className="text-xs font-mono text-gray-600 dark:text-gray-400 leading-relaxed whitespace-pre-wrap line-clamp-4 overflow-hidden">
-            {preview}
-          </pre>
+      {/* ---- Preview area (max-h-96 per spec) ---- */}
+      <div className="relative max-h-96 overflow-hidden rounded-b-xl px-3.5 pb-3">
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-6">
+            <StatusRenderer status="loading" message="Generating..." variant="inline" size="sm" />
+          </div>
         )}
 
-        {/* Hover overlay with actions */}
-        <div className="absolute inset-0 bg-white/80 dark:bg-[#1a1a1a]/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-          <button
-            onClick={handleCopy}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        {/* Image preview */}
+        {!isLoading && contentType === 'image' && content && (
+          <div
+            className="overflow-hidden rounded-lg"
+            style={{ border: '1px solid var(--glass-border, rgba(255,255,255,0.08))' }}
           >
-            Copy
-          </button>
-          <span className="px-3 py-1.5 text-xs font-medium rounded-md bg-[#111111] dark:bg-gray-100 text-white dark:text-[#111111]">
-            Open
-          </span>
-        </div>
+            <ContentRenderer
+              content={content}
+              type="image"
+              variant="widget"
+              size="sm"
+              features={{ imagePreview: true }}
+              className="max-h-48 w-full object-cover"
+            />
+          </div>
+        )}
+
+        {/* Text / data / code / search_results / analysis / knowledge preview */}
+        {!isLoading && contentType !== 'image' && content && (
+          <div
+            className="max-h-32 overflow-hidden rounded-lg px-3 py-2 text-xs"
+            style={{
+              background: 'var(--glass-primary, rgba(255,255,255,0.06))',
+              border: '1px solid var(--glass-border, rgba(255,255,255,0.06))',
+              color: 'var(--text-secondary, #94a3b8)',
+              maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+              WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+            }}
+          >
+            <ContentRenderer
+              content={content}
+              type={contentType === 'search_results' ? 'search_results' : 'markdown'}
+              variant="widget"
+              size="xs"
+              features={{ markdown: true, truncate: 200, wordBreak: true }}
+            />
+          </div>
+        )}
+
+        {/* Empty fallback */}
+        {!isLoading && !content && (
+          <div className="py-4 text-center text-xs" style={{ color: 'var(--text-muted, #64748b)' }}>
+            No content available
+          </div>
+        )}
       </div>
 
-      {/* Footer */}
-      {artifact.widgetType && (
-        <div className="px-3 py-1.5 border-t border-gray-100 dark:border-gray-800">
-          <span className="text-[11px] text-gray-400 capitalize">{artifact.widgetType}</span>
-        </div>
-      )}
+      {/* ---- Hover quick-action bar ---- */}
+      <div
+        className="absolute bottom-2 right-2 flex items-center gap-1 rounded-lg px-1.5 py-1 transition-opacity duration-150"
+        style={{
+          background: 'var(--glass-primary, rgba(15,15,20,0.85))',
+          border: '1px solid var(--glass-border, rgba(255,255,255,0.1))',
+          opacity: hovered ? 1 : 0,
+          pointerEvents: hovered ? 'auto' : 'none',
+        }}
+      >
+        {/* Copy */}
+        <button
+          type="button"
+          aria-label={copied ? 'Copied' : 'Copy content'}
+          className="rounded p-1 text-xs transition-colors hover:bg-white/10"
+          style={{ color: 'var(--text-muted, #64748b)' }}
+          onClick={handleCopy}
+        >
+          {copied ? '\u2705' : '\uD83D\uDCCB'}
+        </button>
+
+        {/* Download (non-image text content) */}
+        {content && contentType !== 'image' && !isLoading && (
+          <button
+            type="button"
+            aria-label="Download artifact"
+            className="rounded p-1 text-xs transition-colors hover:bg-white/10"
+            style={{ color: 'var(--text-muted, #64748b)' }}
+            onClick={handleDownload}
+          >
+            \u2B07\uFE0F
+          </button>
+        )}
+
+        {/* Open in panel */}
+        <button
+          type="button"
+          aria-label="Open in panel"
+          className="rounded p-1 text-xs transition-colors hover:bg-white/10"
+          style={{ color: meta.color }}
+          onClick={(e) => { e.stopPropagation(); handleOpen(); }}
+        >
+          \u2197\uFE0F
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -26,6 +26,7 @@ import { ChatMessage, ArtifactMessage, RegularMessage } from '../../../types/cha
 const log = createLogger('MessageList');
 import { ArtifactComponent } from './ArtifactComponent';
 import { ArtifactMessageComponent } from './ArtifactMessageComponent';
+import { ArtifactPeekCard } from './ArtifactPeekCard';
 import { ContentType } from '../../../types/appTypes';
 import { ContentRenderer, StatusRenderer, GlassMessageBubble } from '../../shared';
 import { ChatWelcome } from './ChatWelcome';
@@ -505,9 +506,9 @@ export const MessageList = memo<MessageListProps>(({
         const resultPreview = !isStreaming && artifactMessage.artifact.content && artifactMessage.artifact.content !== 'Loading...'
           ? (
             <div className="ml-12" style={{ width: 'calc(100% - 3rem)' }}>
-              <ArtifactMessageComponent
+              <ArtifactPeekCard
                 artifactMessage={artifactMessage}
-                onReopen={() => onMessageClick?.(artifactMessage)}
+                onFallbackOpen={() => onMessageClick?.(artifactMessage)}
               />
             </div>
           )
@@ -552,16 +553,11 @@ export const MessageList = memo<MessageListProps>(({
               </div>
             )}
             
-            {/* Use new ArtifactMessageComponent for new artifact messages */}
+            {/* Unified ArtifactPeekCard replaces ArtifactMessageComponent (#251) */}
             <div className="ml-12" style={{ width: 'calc(100% - 3rem)' }}>
-              <ArtifactMessageComponent
+              <ArtifactPeekCard
                 artifactMessage={artifactMessage}
-                onReopen={() => {
-                  // Handle artifact reopening - delegate to message click handler
-                  if (onMessageClick) {
-                    onMessageClick(artifactMessage);
-                  }
-                }}
+                onFallbackOpen={() => onMessageClick?.(artifactMessage)}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
Replace `ArtifactMessageComponent` rendering in MessageList with a unified `ArtifactPeekCard`:
- Compact card (max-h-96) with icon, title, type badge (Image/Text/Data/Code), version badge (v1, v2...)
- Glass-dark theme using `var(--glass-*)` CSS variables
- Click opens artifact in side panel via `artifactManager.openArtifact()`
- Hover reveals quick actions: copy content, download (text types), expand to panel
- Preview area: image thumbnail via `ContentRenderer`, text/code with fade-masked preview
- Accepts both `ArtifactMessage` (chat stream) and `ArtifactNode` (manager store) props
- Accessible: `role=button`, `tabIndex={0}`, `aria-label`, Enter/Space activation

## Test plan
- [ ] Artifact messages render as compact PeekCards in chat
- [ ] Click card → artifact opens in side panel
- [ ] Hover → quick actions visible (copy, download, expand)
- [ ] Image artifacts show thumbnail preview
- [ ] Code artifacts show syntax-highlighted snippet with fade
- [ ] Version badge shows correct version number
- [ ] Keyboard navigation works (Tab, Enter/Space)

Fixes #251
Part of Epic #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)