### PR TITLE
fix(core): wire ArtifactPeekCard → ArtifactPanel via auto-registration

### DIFF
--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -184,6 +184,28 @@ export const useChatStore = create<ChatStore>()(
         }
       }
 
+      // Auto-register artifact messages in ArtifactManager store (wires peek card → panel)
+      if (message.type === 'artifact' && !message.isStreaming) {
+        import('../stores/useArtifactManager').then(({ useArtifactManager }) => {
+          const am = useArtifactManager.getState();
+          const art = (message as any).artifact;
+          if (art && art.content && art.content !== 'Loading...') {
+            // Only register if not already in the store
+            const existing = Object.values(am.artifacts).find(a => a.sourceMessageId === message.id);
+            if (!existing) {
+              am.createArtifact({
+                title: art.widgetName || art.widgetType || 'Artifact',
+                content: typeof art.content === 'string' ? art.content : JSON.stringify(art.content, null, 2),
+                contentType: art.contentType || 'text',
+                widgetType: art.widgetType,
+                sessionId: (message as any).sessionId,
+                sourceMessageId: message.id,
+              });
+            }
+          }
+        });
+      }
+
       logger.info(LogCategory.CHAT_FLOW, 'Message added/updated in chat store and session', {
         messageId: message.id,
         role: message.role,


### PR DESCRIPTION
## Summary

The missing link: when artifacts arrive in chat, auto-register them in `useArtifactManager` so clicking the PeekCard opens the new panel.

### Before
```
ArtifactMessage → chat store → PeekCard → click → onFallbackOpen (no panel)
```

### After
```
ArtifactMessage → chat store → auto-register in ArtifactManager
  → PeekCard finds managedArtifact → click → openArtifact(id, 'inspect')
    → ArtifactPanel opens with version selector, Preview/Code/Edit tabs
```

### Change
`useChatStore.addMessage()`: when message is type `artifact` and not streaming, calls `useArtifactManager.createArtifact()` with title, content, contentType, widgetType, sourceMessageId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)