### PR TITLE
feat(ui): calendar sync, alerts, task events, and desktop calendar widget

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -261,6 +261,22 @@ function setupIPC(): void {
   // Auto-updater IPC
   ipcMain.on('updater:check-now', () => checkForUpdates());
   ipcMain.on('updater:quit-and-install', () => quitAndInstall());
+
+  // Calendar IPC (#230)
+  ipcMain.handle('calendar:get-today', async () => {
+    const win = getMainWindow();
+    if (!win) return [];
+    return win.webContents.executeJavaScript(
+      `fetch((window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/calendar/events?start=' + new Date(new Date().setHours(0,0,0,0)).toISOString() + '&end=' + new Date(new Date().setHours(23,59,59,999)).toISOString(), { credentials: 'include' }).then(r => r.json()).catch(() => [])`
+    );
+  });
+  ipcMain.handle('calendar:get-tasks', async () => {
+    const win = getMainWindow();
+    if (!win) return [];
+    return win.webContents.executeJavaScript(
+      `fetch((window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/tasks?status=pending&limit=10', { credentials: 'include' }).then(r => r.json()).catch(() => [])`
+    );
+  });
 }
 
 // Helper to get the main (non-spotlight) window

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -41,6 +41,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'mcp:start-server', 'mcp:stop-server', 'mcp:restart-server',
       'clipboard:get-content',
       'offline:is-online', 'offline:cache-conversation', 'offline:get-conversations',
+      'calendar:get-today', 'calendar:get-tasks',
       'offline:get-conversation', 'offline:clear-cache',
     ];
     if (allowedChannels.includes(channel)) {

--- a/src/api/adapters/CalendarAdapter.ts
+++ b/src/api/adapters/CalendarAdapter.ts
@@ -1,0 +1,70 @@
+/**
+ * CalendarAdapter — bridges CalendarService backend to the frontend via gateway.
+ */
+const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:9080';
+const BASE = `${GATEWAY}/api/v1/calendar`;
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  description?: string;
+  startTime: string;
+  endTime: string;
+  allDay?: boolean;
+  provider?: string;
+  reminders?: number[];
+  metadata?: Record<string, any>;
+}
+
+export interface CalendarProvider {
+  id: string;
+  name: string;
+  type: 'google' | 'outlook' | 'apple' | 'local';
+  connected: boolean;
+  lastSynced?: string;
+}
+
+async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Calendar API error: ${res.status}`);
+  return res.json();
+}
+
+export async function getEvents(start: string, end: string): Promise<CalendarEvent[]> {
+  return apiFetch(`/events?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+}
+
+export async function getTodayEvents(): Promise<CalendarEvent[]> {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).toISOString();
+  return getEvents(start, end);
+}
+
+export async function createEvent(event: Omit<CalendarEvent, 'id'>): Promise<CalendarEvent> {
+  return apiFetch('/events', { method: 'POST', body: JSON.stringify(event) });
+}
+
+export async function deleteEvent(id: string): Promise<void> {
+  await apiFetch(`/events/${id}`, { method: 'DELETE' });
+}
+
+export async function getProviders(): Promise<CalendarProvider[]> {
+  return apiFetch('/providers');
+}
+
+export async function connectProvider(type: CalendarProvider['type']): Promise<{ authUrl: string }> {
+  return apiFetch(`/providers/${type}/connect`, { method: 'POST' });
+}
+
+export async function disconnectProvider(type: CalendarProvider['type']): Promise<void> {
+  await apiFetch(`/providers/${type}/disconnect`, { method: 'POST' });
+}
+
+export async function syncProvider(type: CalendarProvider['type']): Promise<void> {
+  await apiFetch(`/providers/${type}/sync`, { method: 'POST' });
+}

--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -274,6 +274,24 @@ case 'memory_recall': {
       break;
     }
 
+    case 'task_created': {
+      results.push({
+        type: 'custom_event' as AGUIEventType,
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        metadata: {
+          custom_type: 'task_created',
+          task_id: event.task_id || event.id,
+          title: event.title || event.content || 'New task',
+          description: event.description,
+          due_at: event.due_at,
+          custom_data: event.metadata,
+        },
+      });
+      break;
+    }
+
     case 'autonomous_result': {
       // Background autonomous action result from Mate (scheduled tasks, triggers, etc.)
       // Mapped to a custom AGUI event that the autonomousEventService will handle.

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -470,6 +470,20 @@ export class ChatService {
         break;
       }
 
+      case 'task_created': {
+        const { useTaskStore } = require('../stores/useTaskStore');
+        useTaskStore.getState().addTask({
+          id: event.metadata?.task_id || `task-${Date.now()}`,
+          title: event.metadata?.title || 'New task',
+          description: event.metadata?.description,
+          status: 'pending',
+          dueAt: event.metadata?.due_at,
+          createdAt: new Date().toISOString(),
+        });
+        log.info('Task created from conversation', { taskId: event.metadata?.task_id });
+        break;
+      }
+
       case 'autonomous_result': {
         // Background autonomous event received via the active chat stream.
         // Dispatch directly to the chat store so it appears in the timeline.

--- a/src/components/ui/calendar/CalendarSyncSettings.tsx
+++ b/src/components/ui/calendar/CalendarSyncSettings.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { useCalendarStore } from '../../../stores/useCalendarStore';
+import * as CalendarAdapter from '../../../api/adapters/CalendarAdapter';
+import type { CalendarProvider } from '../../../api/adapters/CalendarAdapter';
+
+const PROVIDERS: Array<{ type: CalendarProvider['type']; label: string; icon: string }> = [
+  { type: 'google', label: 'Google Calendar', icon: '📅' },
+  { type: 'outlook', label: 'Outlook Calendar', icon: '📧' },
+  { type: 'apple', label: 'Apple Calendar', icon: '🍎' },
+];
+
+export const CalendarSyncSettings: React.FC = () => {
+  const { providers, fetchProviders } = useCalendarStore();
+  const [syncing, setSyncing] = useState<string | null>(null);
+
+  useEffect(() => { fetchProviders(); }, [fetchProviders]);
+
+  const handleConnect = async (type: CalendarProvider['type']) => {
+    const { authUrl } = await CalendarAdapter.connectProvider(type);
+    window.open(authUrl, '_blank', 'width=500,height=600');
+  };
+
+  const handleDisconnect = async (type: CalendarProvider['type']) => {
+    await CalendarAdapter.disconnectProvider(type);
+    fetchProviders();
+  };
+
+  const handleSync = async (type: CalendarProvider['type']) => {
+    setSyncing(type);
+    try { await CalendarAdapter.syncProvider(type); fetchProviders(); } finally { setSyncing(null); }
+  };
+
+  const getProvider = (type: string) => providers.find((p) => p.type === type);
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-[var(--text-primary)] mb-3">Calendar Sync</h3>
+      <p className="text-xs text-[var(--text-tertiary)] mb-4">Connect your calendars so Mate can see your schedule and send reminders.</p>
+      {PROVIDERS.map(({ type, label, icon }) => {
+        const connected = getProvider(type);
+        return (
+          <div key={type} className="flex items-center justify-between p-3 rounded-lg border border-[var(--glass-border)]">
+            <div className="flex items-center gap-3">
+              <span className="text-lg">{icon}</span>
+              <div>
+                <p className="text-sm font-medium text-[var(--text-primary)]">{label}</p>
+                {connected?.connected && <p className="text-xs text-[var(--text-tertiary)]">Last synced: {connected.lastSynced ? new Date(connected.lastSynced).toLocaleString() : 'Never'}</p>}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {connected?.connected ? (
+                <>
+                  <button onClick={() => handleSync(type)} disabled={syncing === type} className="px-3 py-1 text-xs rounded-md bg-[var(--glass-bg)] border border-[var(--glass-border)] text-[var(--text-secondary)]">{syncing === type ? 'Syncing...' : 'Sync'}</button>
+                  <button onClick={() => handleDisconnect(type)} className="px-3 py-1 text-xs rounded-md text-red-400 hover:text-red-300">Disconnect</button>
+                </>
+              ) : (
+                <button onClick={() => handleConnect(type)} className="px-3 py-1 text-xs rounded-md bg-[var(--accent-primary)] text-white hover:opacity-90">Connect</button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/ui/settings/SettingsModal.tsx
+++ b/src/components/ui/settings/SettingsModal.tsx
@@ -8,8 +8,9 @@ import { ProjectSettings } from './ProjectSettings';
 import { MemoryManager } from './MemoryManager';
 import { SkillBuilder } from './SkillBuilder';
 import { ConnectorMarketplace } from './ConnectorMarketplace';
+import { CalendarSyncSettings } from '../calendar/CalendarSyncSettings';
 
-type SettingsTab = 'general' | 'appearance' | 'project' | 'memory' | 'skills' | 'integrations';
+type SettingsTab = 'general' | 'appearance' | 'project' | 'memory' | 'skills' | 'calendar' | 'integrations';
 
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
@@ -17,6 +18,7 @@ const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'project', label: 'Project' },
   { id: 'memory', label: 'Memory' },
   { id: 'skills', label: 'Skills' },
+  { id: 'calendar', label: 'Calendar' },
   { id: 'integrations', label: 'Integrations' },
 ];
 
@@ -74,6 +76,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) =
           {activeTab === 'project' && <ProjectSettings />}
           {activeTab === 'memory' && <MemoryManager />}
           {activeTab === 'skills' && <SkillBuilder />}
+          {activeTab === 'calendar' && <CalendarSyncSettings />}
           {activeTab === 'integrations' && <ConnectorMarketplace />}
         </div>
       </div>

--- a/src/modules/AlertModule.tsx
+++ b/src/modules/AlertModule.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from 'react';
+import { useCalendarStore } from '../stores/useCalendarStore';
+import { useTaskStore } from '../stores/useTaskStore';
+
+const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
+const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
+
+function sendAlert(title: string, body: string, route?: string): void {
+  if (isElectron && electronAPI) {
+    electronAPI.send('notification:show', title, body, route);
+  } else if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+    new Notification(title, { body });
+  }
+}
+
+export const AlertModule: React.FC = () => {
+  const todayEvents = useCalendarStore((s) => s.todayEvents);
+  const fetchTodayEvents = useCalendarStore((s) => s.fetchTodayEvents);
+  const firedReminders = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    fetchTodayEvents();
+    const interval = setInterval(fetchTodayEvents, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchTodayEvents]);
+
+  useEffect(() => {
+    const check = () => {
+      const now = Date.now();
+      for (const event of todayEvents) {
+        const start = new Date(event.startTime).getTime();
+        const minutesUntil = (start - now) / 60000;
+        const reminders = event.reminders ?? [15];
+        for (const mins of reminders) {
+          const key = `${event.id}-${mins}`;
+          if (minutesUntil <= mins && minutesUntil > mins - 1 && !firedReminders.current.has(key)) {
+            firedReminders.current.add(key);
+            sendAlert(`${event.title} in ${Math.round(minutesUntil)} min`, event.description || 'Event starting soon', '/app?view=calendar');
+          }
+        }
+      }
+    };
+    check();
+    const interval = setInterval(check, 60_000);
+    return () => clearInterval(interval);
+  }, [todayEvents]);
+
+  useEffect(() => {
+    const unsub = useTaskStore.subscribe((state, prev) => {
+      const prevIds = new Set((prev as any).tasks?.filter((t: any) => t.status === 'completed').map((t: any) => t.id) ?? []);
+      for (const task of state.tasks ?? []) {
+        if (task.status === 'completed' && !prevIds.has(task.id)) {
+          sendAlert('Task completed', task.title || task.id, '/app');
+        }
+      }
+    });
+    return unsub;
+  }, []);
+
+  return null;
+};

--- a/src/modules/AppModule.tsx
+++ b/src/modules/AppModule.tsx
@@ -37,6 +37,7 @@ import { SessionModule } from './SessionModule';
 import { UserModule } from './UserModule';
 import { ContextModule } from './ContextModule';
 import { OrganizationModule } from './OrganizationModule';
+import { AlertModule } from './AlertModule';
 import { RightSidebarLayout } from '../components/ui/chat/RightSidebarLayout';
 import UserButtonContainer from '../components/ui/user/UserButtonContainer';
 import { UserPortal } from '../components/ui/user/UserPortal';
@@ -281,6 +282,7 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
   return (
     <ContextModule>
       <OrganizationModule>
+        <AlertModule />
         {/* 🆕 Session Artifact Tester - Development Only */}
         
         <AppLayout {...props}>

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import type { CalendarEvent, CalendarProvider } from '../api/adapters/CalendarAdapter';
+import * as CalendarAdapter from '../api/adapters/CalendarAdapter';
+
+interface CalendarState {
+  events: CalendarEvent[];
+  todayEvents: CalendarEvent[];
+  providers: CalendarProvider[];
+  isLoading: boolean;
+  error: string | null;
+  fetchTodayEvents: () => Promise<void>;
+  fetchEvents: (start: string, end: string) => Promise<void>;
+  fetchProviders: () => Promise<void>;
+  addEvent: (event: Omit<CalendarEvent, 'id'>) => Promise<CalendarEvent>;
+  removeEvent: (id: string) => Promise<void>;
+}
+
+export const useCalendarStore = create<CalendarState>((set) => ({
+  events: [],
+  todayEvents: [],
+  providers: [],
+  isLoading: false,
+  error: null,
+  fetchTodayEvents: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const todayEvents = await CalendarAdapter.getTodayEvents();
+      set({ todayEvents, isLoading: false });
+    } catch (err: any) {
+      set({ error: err.message, isLoading: false });
+    }
+  },
+  fetchEvents: async (start, end) => {
+    set({ isLoading: true, error: null });
+    try {
+      const events = await CalendarAdapter.getEvents(start, end);
+      set({ events, isLoading: false });
+    } catch (err: any) {
+      set({ error: err.message, isLoading: false });
+    }
+  },
+  fetchProviders: async () => {
+    try {
+      const providers = await CalendarAdapter.getProviders();
+      set({ providers });
+    } catch (err: any) {
+      set({ error: err.message });
+    }
+  },
+  addEvent: async (event) => {
+    const created = await CalendarAdapter.createEvent(event);
+    set((s) => ({ todayEvents: [...s.todayEvents, created], events: [...s.events, created] }));
+    return created;
+  },
+  removeEvent: async (id) => {
+    await CalendarAdapter.deleteEvent(id);
+    set((s) => ({
+      todayEvents: s.todayEvents.filter((e) => e.id !== id),
+      events: s.events.filter((e) => e.id !== id),
+    }));
+  },
+}));


### PR DESCRIPTION
## Summary
Full calendar integration — 5 stories.

- **AlertModule (#162)**: Unified alerts for calendar reminders + task completions
- **CalendarSyncSettings (#163)**: Provider management in Settings → Calendar tab
- **Task events (#164)**: task_created SSE handling in MateEventAdapter + chatService
- **Calendar reminders (#165)**: Polls events every 60s, fires notification 15min before
- **Desktop calendar (#230)**: calendar:get-today, calendar:get-tasks IPC handlers

Fixes #162, Fixes #163, Fixes #164, Fixes #165, Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)