### PR TITLE
fix(data): SDK-aligned TaskAdapter and NotificationAdapter with backend sync

### DIFF
--- a/src/api/adapters/NotificationAdapter.ts
+++ b/src/api/adapters/NotificationAdapter.ts
@@ -1,0 +1,107 @@
+/**
+ * NotificationAdapter — SDK-aligned adapter for notification backend.
+ * Matches @isa/core notification contracts while maintaining backward compatibility.
+ */
+
+const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:9080';
+const BASE = `${GATEWAY}/api/v1/notifications`;
+
+// SDK-aligned types (matches @isa/core/services/notification/contracts.ts)
+export interface Notification {
+  id: string;
+  type: 'info' | 'success' | 'warning' | 'error' | 'task' | 'calendar' | 'channel';
+  priority: 'low' | 'normal' | 'high' | 'urgent';
+  title: string;
+  body: string;
+  read: boolean;
+  dismissed: boolean;
+  route?: string;
+  metadata?: Record<string, any>;
+  createdAt: string;
+  readAt?: string;
+}
+
+export interface NotificationSendRequest {
+  type: Notification['type'];
+  priority?: Notification['priority'];
+  title: string;
+  body: string;
+  route?: string;
+  metadata?: Record<string, any>;
+  targetUserId?: string;
+}
+
+export interface NotificationPreferences {
+  enabled: boolean;
+  channels: {
+    push: boolean;
+    email: boolean;
+    inApp: boolean;
+  };
+  quietHours?: {
+    enabled: boolean;
+    start: string; // HH:mm
+    end: string;
+  };
+}
+
+async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Notification API error: ${res.status}`);
+  return res.json();
+}
+
+// ---------- CRUD ----------
+
+export async function getNotifications(params?: { unreadOnly?: boolean; limit?: number }): Promise<Notification[]> {
+  const query = new URLSearchParams();
+  if (params?.unreadOnly) query.set('unread_only', 'true');
+  if (params?.limit) query.set('limit', String(params.limit));
+  const qs = query.toString();
+  return apiFetch(`${qs ? `?${qs}` : ''}`);
+}
+
+export async function getUnreadCount(): Promise<number> {
+  const data = await apiFetch<{ count: number }>('/unread-count');
+  return data.count;
+}
+
+export async function markAsRead(id: string): Promise<void> {
+  await apiFetch(`/${id}/read`, { method: 'POST' });
+}
+
+export async function markAllAsRead(): Promise<void> {
+  await apiFetch('/read-all', { method: 'POST' });
+}
+
+export async function dismiss(id: string): Promise<void> {
+  await apiFetch(`/${id}/dismiss`, { method: 'POST' });
+}
+
+export async function send(request: NotificationSendRequest): Promise<Notification> {
+  return apiFetch('', { method: 'POST', body: JSON.stringify(request) });
+}
+
+// ---------- Push ----------
+
+export async function subscribePush(subscription: PushSubscriptionJSON): Promise<void> {
+  await apiFetch('/push/subscribe', { method: 'POST', body: JSON.stringify(subscription) });
+}
+
+export async function unsubscribePush(): Promise<void> {
+  await apiFetch('/push/unsubscribe', { method: 'POST' });
+}
+
+// ---------- Preferences ----------
+
+export async function getPreferences(): Promise<NotificationPreferences> {
+  return apiFetch('/preferences');
+}
+
+export async function updatePreferences(prefs: Partial<NotificationPreferences>): Promise<NotificationPreferences> {
+  return apiFetch('/preferences', { method: 'PATCH', body: JSON.stringify(prefs) });
+}

--- a/src/api/adapters/TaskAdapter.ts
+++ b/src/api/adapters/TaskAdapter.ts
@@ -1,0 +1,78 @@
+/**
+ * TaskAdapter — SDK-aligned adapter for task backend.
+ * Wraps gateway API calls to /api/v1/tasks/*.
+ */
+
+const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:9080';
+const BASE = `${GATEWAY}/api/v1/tasks`;
+
+export interface BackendTask {
+  id: string;
+  title: string;
+  description?: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
+  priority?: 'low' | 'normal' | 'high' | 'urgent';
+  dueAt?: string;
+  completedAt?: string;
+  createdAt: string;
+  updatedAt?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface TaskCreatePayload {
+  title: string;
+  description?: string;
+  priority?: BackendTask['priority'];
+  dueAt?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface TaskUpdatePayload {
+  title?: string;
+  description?: string;
+  status?: BackendTask['status'];
+  priority?: BackendTask['priority'];
+  dueAt?: string;
+  metadata?: Record<string, any>;
+}
+
+async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Task API error: ${res.status}`);
+  return res.json();
+}
+
+export async function getTasks(params?: { status?: string; limit?: number }): Promise<BackendTask[]> {
+  const query = new URLSearchParams();
+  if (params?.status) query.set('status', params.status);
+  if (params?.limit) query.set('limit', String(params.limit));
+  const qs = query.toString();
+  return apiFetch(`${qs ? `?${qs}` : ''}`);
+}
+
+export async function getTask(id: string): Promise<BackendTask> {
+  return apiFetch(`/${id}`);
+}
+
+export async function createTask(payload: TaskCreatePayload): Promise<BackendTask> {
+  return apiFetch('', { method: 'POST', body: JSON.stringify(payload) });
+}
+
+export async function updateTask(id: string, payload: TaskUpdatePayload): Promise<BackendTask> {
+  return apiFetch(`/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  await apiFetch(`/${id}`, { method: 'DELETE' });
+}
+
+export async function completeTask(id: string): Promise<BackendTask> {
+  return apiFetch(`/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'completed', completedAt: new Date().toISOString() }),
+  });
+}

--- a/src/api/notificationService.ts
+++ b/src/api/notificationService.ts
@@ -30,6 +30,10 @@ import { BaseApiService } from './BaseApiService';
 import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { logger, LogCategory, createLogger } from '../utils/logger';
 
+// Re-export the SDK-aligned adapter for new consumers (#161)
+export * as NotificationAdapter from './adapters/NotificationAdapter';
+export type { NotificationSendRequest, NotificationPreferences as SDKNotificationPreferences } from './adapters/NotificationAdapter';
+
 import type {
   Notification,
   NotificationListResponse,

--- a/src/components/ui/settings/AppearanceSettings.tsx
+++ b/src/components/ui/settings/AppearanceSettings.tsx
@@ -23,7 +23,9 @@ const fontOptions: { value: ChatFont; label: string }[] = [
 ];
 
 export const AppearanceSettings: React.FC = () => {
-  const { preference, setTheme } = useThemeContext();
+  const themeCtx = useThemeContext();
+  const preference = themeCtx.preference;
+  const setTheme = themeCtx.setPreference ?? (themeCtx as any).setTheme;
   const { font, setFont, sendBehavior, setSendBehavior } = useAppearanceSettings();
 
   return (

--- a/src/stores/useTaskStore.ts
+++ b/src/stores/useTaskStore.ts
@@ -16,24 +16,29 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { 
-  TaskItem, 
-  TaskStatus, 
-  TaskAction, 
-  TaskProgress, 
-  TaskResult, 
-  TaskType, 
+import {
+  TaskItem,
+  TaskStatus,
+  TaskAction,
+  TaskProgress,
+  TaskResult,
+  TaskType,
   TaskPriority,
   TaskManagerState,
   TaskActionEvent
 } from '../types/taskTypes';
 import { logger, LogCategory } from '../utils/logger';
+import * as TaskAdapter from '../api/adapters/TaskAdapter';
 
 // ================================================================================
 // 任务管理Actions接口
 // ================================================================================
 
 interface TaskActions {
+  // Backend sync
+  syncTasks: () => Promise<void>;
+  addTask: (task: { id: string; title: string; description?: string; status: string; dueAt?: string; createdAt: string }) => void;
+
   // 任务创建和管理
   createTask: (title: string, type: TaskType, metadata?: Record<string, any>) => string;
   updateTask: (taskId: string, updates: Partial<TaskItem>) => void;
@@ -93,7 +98,70 @@ export const useTaskStore = create<TaskStore>()(
     failedTasksCount: 0,
     showTaskPanel: false,
     selectedTaskId: undefined,
-    
+
+    // ================================================================================
+    // Backend sync (#160)
+    // ================================================================================
+
+    syncTasks: async () => {
+      try {
+        const backendTasks = await TaskAdapter.getTasks();
+        const mapped: TaskItem[] = backendTasks.map((bt) => ({
+          id: bt.id,
+          title: bt.title,
+          type: 'background' as TaskType,
+          status: (bt.status === 'in_progress' ? 'running' : bt.status) as TaskStatus,
+          priority: (bt.priority || 'normal') as TaskPriority,
+          progress: { currentStep: 0, totalSteps: 1, percentage: bt.status === 'completed' ? 100 : 0 },
+          createdAt: bt.createdAt,
+          updatedAt: bt.updatedAt || bt.createdAt,
+          completedAt: bt.completedAt,
+          canPause: false,
+          canResume: false,
+          canCancel: bt.status === 'pending' || bt.status === 'in_progress',
+          canRetry: bt.status === 'failed',
+          metadata: { ...bt.metadata, description: bt.description, dueAt: bt.dueAt, synced: true },
+        }));
+        set({
+          tasks: mapped,
+          totalTasks: mapped.length,
+          activeTasks: mapped.filter((t) => ['running', 'pending'].includes(t.status)),
+          completedTasks: mapped.filter((t) => ['completed', 'failed', 'cancelled'].includes(t.status)),
+          completedTasksCount: mapped.filter((t) => t.status === 'completed').length,
+          failedTasksCount: mapped.filter((t) => t.status === 'failed').length,
+        });
+        logger.info(LogCategory.TASK_MANAGEMENT, 'Tasks synced from backend', { count: mapped.length });
+      } catch (err) {
+        logger.warn(LogCategory.TASK_MANAGEMENT, 'Failed to sync tasks from backend', { error: err });
+      }
+    },
+
+    addTask: (task) => {
+      const newTask: TaskItem = {
+        id: task.id,
+        title: task.title,
+        type: 'background' as TaskType,
+        status: (task.status === 'in_progress' ? 'running' : task.status || 'pending') as TaskStatus,
+        priority: 'normal',
+        progress: { currentStep: 0, totalSteps: 1, percentage: 0 },
+        createdAt: task.createdAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        canPause: false,
+        canResume: false,
+        canCancel: true,
+        canRetry: false,
+        metadata: { description: task.description, dueAt: task.dueAt },
+      };
+      set((state) => ({
+        tasks: [...state.tasks, newTask],
+        totalTasks: state.totalTasks + 1,
+        activeTasks: [...state.activeTasks, newTask],
+      }));
+      // Fire-and-forget backend create
+      TaskAdapter.createTask({ title: task.title, description: task.description, dueAt: task.dueAt }).catch(() => {});
+      logger.info(LogCategory.TASK_MANAGEMENT, 'Task added (from chat)', { taskId: task.id });
+    },
+
     // ================================================================================
     // 任务创建和管理
     // ================================================================================


### PR DESCRIPTION
## Summary

### TaskAdapter (#160)
- `src/api/adapters/TaskAdapter.ts` — CRUD wrapper for `/api/v1/tasks`
- `useTaskStore.syncTasks()` — fetch and hydrate from backend
- `useTaskStore.addTask()` — for chat-originated tasks (optimistic + fire-and-forget backend)
- Existing store interface unchanged (backward compatible)

### NotificationAdapter (#161)
- `src/api/adapters/NotificationAdapter.ts` — SDK-aligned types + gateway wrapper
- Operations: getNotifications, getUnreadCount, markAsRead, dismiss, send, push subscribe, preferences
- Re-exported from `notificationService.ts` for gradual migration
- Existing NotificationService class unchanged

## Test plan
- [ ] `useTaskStore.getState().syncTasks()` fetches from backend
- [ ] `useTaskStore.getState().addTask({...})` adds locally + fires backend create
- [ ] Existing task UI still works (createTask, startTask, completeTask)
- [ ] NotificationAdapter functions callable independently
- [ ] Existing NotificationService consumers unaffected

Fixes #160, Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)