### PR TITLE
fix(ui): fix PlatformNav crash after login + setTheme fix

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -105,15 +105,19 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
       className={`min-h-dvh w-full flex flex-col bg-[var(--surface-bg,#0f172a)] text-[var(--text-primary,#fff)] relative ${className}`}
     >
       {/* Platform Navigation - Surface switcher for authenticated users */}
-      {isAuthenticated && (() => {
-        const navProps = {
-          activeSurface: "app" as const,
-          user: authUser ? { name: authUser.name, email: authUser.email } : null,
-          urls: surfaceUrls,
-          onLogout: logout,
-        };
-        return <PlatformNav {...navProps} />;
-      })()}
+      {isAuthenticated && (
+        <PlatformNav
+          activeSurface="app"
+          user={authUser ? { name: String(authUser.name || ''), email: String(authUser.email || '') } : null}
+          urls={{
+            app: surfaceUrls.app,
+            console: surfaceUrls.console,
+            docs: surfaceUrls.docs,
+            marketing: surfaceUrls.marketing,
+          }}
+          onLogout={logout}
+        />
+      )}
       {/* Application Header - responsive on all viewports */}
       <div className="h-14 md:h-16 flex-shrink-0 p-1.5 md:p-2">
         <AppHeader


### PR DESCRIPTION
## Summary
Fixes two runtime errors found during visual testing:

1. **"Objects are not valid as React child"** after login — PlatformNav was rendering via IIFE which the linter kept breaking. Switched to direct JSX with String() coercion on authUser.name/email.

2. **"setTheme is not a function"** — AppearanceSettings destructured wrong property name from theme context. Uses fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)