### PR TITLE
feat(ui): wire remaining stubs, adapter tests, channel indicators

### DIFF
--- a/src/api/adapters/__tests__/CalendarAdapter.test.ts
+++ b/src/api/adapters/__tests__/CalendarAdapter.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getEvents,
+  getTodayEvents,
+  createEvent,
+  deleteEvent,
+  getProviders,
+  connectProvider,
+  disconnectProvider,
+  syncProvider,
+} from '../CalendarAdapter';
+
+const BASE = 'http://localhost:9080/api/v1/calendar';
+
+function mockFetchOk(data: any) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(status: number) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}
+
+describe('CalendarAdapter', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getEvents
+  // ---------------------------------------------------------------------------
+  describe('getEvents', () => {
+    test('constructs URL with encoded start/end query params', async () => {
+      const events = [{ id: 'e1', title: 'Standup' }];
+      globalThis.fetch = mockFetchOk(events);
+
+      const result = await getEvents('2026-04-16T00:00:00Z', '2026-04-17T00:00:00Z');
+
+      expect(result).toEqual(events);
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain(`${BASE}/events?start=`);
+      expect(url).toContain(encodeURIComponent('2026-04-16T00:00:00Z'));
+      expect(url).toContain(encodeURIComponent('2026-04-17T00:00:00Z'));
+    });
+
+    test('sends credentials include and content-type header', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getEvents('a', 'b');
+
+      const opts = (globalThis.fetch as any).mock.calls[0][1];
+      expect(opts.credentials).toBe('include');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(500);
+      await expect(getEvents('a', 'b')).rejects.toThrow('Calendar API error: 500');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTodayEvents
+  // ---------------------------------------------------------------------------
+  describe('getTodayEvents', () => {
+    test('calls getEvents with today start/end', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getTodayEvents();
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      // Should contain today's date (ISO format)
+      const now = new Date();
+      const yearStr = String(now.getFullYear());
+      expect(url).toContain(yearStr);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createEvent
+  // ---------------------------------------------------------------------------
+  describe('createEvent', () => {
+    test('POSTs event body to /events', async () => {
+      const created = { id: 'e1', title: 'New Event', startTime: '', endTime: '' };
+      globalThis.fetch = mockFetchOk(created);
+
+      const payload = { title: 'New Event', startTime: '2026-04-16T10:00:00Z', endTime: '2026-04-16T11:00:00Z' };
+      const result = await createEvent(payload);
+
+      expect(result).toEqual(created);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/events`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual(payload);
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(400);
+      await expect(createEvent({ title: 'X', startTime: '', endTime: '' })).rejects.toThrow('Calendar API error: 400');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteEvent
+  // ---------------------------------------------------------------------------
+  describe('deleteEvent', () => {
+    test('sends DELETE to /events/:id', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await deleteEvent('e42');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/events/e42`);
+      expect(opts.method).toBe('DELETE');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(404);
+      await expect(deleteEvent('bad-id')).rejects.toThrow('Calendar API error: 404');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getProviders
+  // ---------------------------------------------------------------------------
+  describe('getProviders', () => {
+    test('GETs /providers', async () => {
+      const providers = [{ id: 'p1', name: 'Google', type: 'google', connected: true }];
+      globalThis.fetch = mockFetchOk(providers);
+
+      const result = await getProviders();
+      expect(result).toEqual(providers);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(`${BASE}/providers`);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // connectProvider
+  // ---------------------------------------------------------------------------
+  describe('connectProvider', () => {
+    test('POSTs to /providers/:type/connect', async () => {
+      globalThis.fetch = mockFetchOk({ authUrl: 'https://oauth.example.com' });
+      const result = await connectProvider('google');
+
+      expect(result.authUrl).toBe('https://oauth.example.com');
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/providers/google/connect`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // disconnectProvider
+  // ---------------------------------------------------------------------------
+  describe('disconnectProvider', () => {
+    test('POSTs to /providers/:type/disconnect', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await disconnectProvider('outlook');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/providers/outlook/disconnect`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // syncProvider
+  // ---------------------------------------------------------------------------
+  describe('syncProvider', () => {
+    test('POSTs to /providers/:type/sync', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await syncProvider('apple');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/providers/apple/sync`);
+      expect(opts.method).toBe('POST');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(503);
+      await expect(syncProvider('google')).rejects.toThrow('Calendar API error: 503');
+    });
+  });
+});

--- a/src/api/adapters/__tests__/NotificationAdapter.test.ts
+++ b/src/api/adapters/__tests__/NotificationAdapter.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import {
+  getNotifications,
+  getUnreadCount,
+  markAsRead,
+  markAllAsRead,
+  dismiss,
+  send,
+  subscribePush,
+  unsubscribePush,
+  getPreferences,
+  updatePreferences,
+} from '../NotificationAdapter';
+
+const BASE = 'http://localhost:9080/api/v1/notifications';
+
+function mockFetchOk(data: any) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(status: number) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}
+
+describe('NotificationAdapter', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getNotifications
+  // ---------------------------------------------------------------------------
+  describe('getNotifications', () => {
+    test('GETs notifications without query params when none given', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      const result = await getNotifications();
+
+      expect(result).toEqual([]);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(BASE);
+    });
+
+    test('includes unread_only query param', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getNotifications({ unreadOnly: true });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('unread_only=true');
+    });
+
+    test('includes limit query param', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getNotifications({ limit: 20 });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('limit=20');
+    });
+
+    test('includes both unreadOnly and limit', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getNotifications({ unreadOnly: true, limit: 5 });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('unread_only=true');
+      expect(url).toContain('limit=5');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(500);
+      await expect(getNotifications()).rejects.toThrow('Notification API error: 500');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getUnreadCount
+  // ---------------------------------------------------------------------------
+  describe('getUnreadCount', () => {
+    test('GETs /unread-count and returns count number', async () => {
+      globalThis.fetch = mockFetchOk({ count: 7 });
+      const result = await getUnreadCount();
+
+      expect(result).toBe(7);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(`${BASE}/unread-count`);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markAsRead
+  // ---------------------------------------------------------------------------
+  describe('markAsRead', () => {
+    test('POSTs to /:id/read', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await markAsRead('n1');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/n1/read`);
+      expect(opts.method).toBe('POST');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(404);
+      await expect(markAsRead('bad')).rejects.toThrow('Notification API error: 404');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markAllAsRead
+  // ---------------------------------------------------------------------------
+  describe('markAllAsRead', () => {
+    test('POSTs to /read-all', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await markAllAsRead();
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/read-all`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // dismiss
+  // ---------------------------------------------------------------------------
+  describe('dismiss', () => {
+    test('POSTs to /:id/dismiss', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await dismiss('n2');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/n2/dismiss`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // send
+  // ---------------------------------------------------------------------------
+  describe('send', () => {
+    test('POSTs notification request body', async () => {
+      const notif = { id: 'n1', type: 'info', priority: 'normal', title: 'Hi', body: 'Hello', read: false, dismissed: false, createdAt: '2026-04-16' };
+      globalThis.fetch = mockFetchOk(notif);
+
+      const payload = { type: 'info' as const, title: 'Hi', body: 'Hello' };
+      const result = await send(payload);
+
+      expect(result).toEqual(notif);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(BASE);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual(payload);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // subscribePush / unsubscribePush
+  // ---------------------------------------------------------------------------
+  describe('push subscription', () => {
+    test('subscribePush POSTs to /push/subscribe', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await subscribePush({ endpoint: 'https://push.example.com' });
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/push/subscribe`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ endpoint: 'https://push.example.com' });
+    });
+
+    test('unsubscribePush POSTs to /push/unsubscribe', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await unsubscribePush();
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/push/unsubscribe`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPreferences / updatePreferences
+  // ---------------------------------------------------------------------------
+  describe('preferences', () => {
+    test('getPreferences GETs /preferences', async () => {
+      const prefs = { enabled: true, channels: { push: true, email: false, inApp: true } };
+      globalThis.fetch = mockFetchOk(prefs);
+
+      const result = await getPreferences();
+      expect(result).toEqual(prefs);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(`${BASE}/preferences`);
+    });
+
+    test('updatePreferences PATCHes /preferences', async () => {
+      const updated = { enabled: false, channels: { push: false, email: false, inApp: true } };
+      globalThis.fetch = mockFetchOk(updated);
+
+      const result = await updatePreferences({ enabled: false });
+
+      expect(result).toEqual(updated);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/preferences`);
+      expect(opts.method).toBe('PATCH');
+      expect(JSON.parse(opts.body)).toEqual({ enabled: false });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Common: credentials and headers
+  // ---------------------------------------------------------------------------
+  describe('common fetch options', () => {
+    test('sends credentials include and content-type header', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getNotifications();
+
+      const opts = (globalThis.fetch as any).mock.calls[0][1];
+      expect(opts.credentials).toBe('include');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+    });
+  });
+});

--- a/src/api/adapters/__tests__/TaskAdapter.test.ts
+++ b/src/api/adapters/__tests__/TaskAdapter.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import {
+  getTasks,
+  getTask,
+  createTask,
+  updateTask,
+  deleteTask,
+  completeTask,
+} from '../TaskAdapter';
+
+const BASE = 'http://localhost:9080/api/v1/tasks';
+
+function mockFetchOk(data: any) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(status: number) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}
+
+describe('TaskAdapter', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTasks
+  // ---------------------------------------------------------------------------
+  describe('getTasks', () => {
+    test('GETs tasks without query params when none given', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      const result = await getTasks();
+
+      expect(result).toEqual([]);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(BASE);
+    });
+
+    test('includes status query param', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getTasks({ status: 'pending' });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('status=pending');
+    });
+
+    test('includes limit query param', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getTasks({ limit: 10 });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('limit=10');
+    });
+
+    test('includes both status and limit', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getTasks({ status: 'completed', limit: 5 });
+
+      const url = (globalThis.fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('status=completed');
+      expect(url).toContain('limit=5');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(500);
+      await expect(getTasks()).rejects.toThrow('Task API error: 500');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTask
+  // ---------------------------------------------------------------------------
+  describe('getTask', () => {
+    test('GETs /tasks/:id', async () => {
+      const task = { id: 't1', title: 'Task 1', status: 'pending', createdAt: '2026-04-16' };
+      globalThis.fetch = mockFetchOk(task);
+
+      const result = await getTask('t1');
+      expect(result).toEqual(task);
+      expect((globalThis.fetch as any).mock.calls[0][0]).toBe(`${BASE}/t1`);
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(404);
+      await expect(getTask('bad-id')).rejects.toThrow('Task API error: 404');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createTask
+  // ---------------------------------------------------------------------------
+  describe('createTask', () => {
+    test('POSTs to /tasks with payload body', async () => {
+      const created = { id: 't1', title: 'New', status: 'pending', createdAt: '2026-04-16' };
+      globalThis.fetch = mockFetchOk(created);
+
+      const payload = { title: 'New', priority: 'high' as const };
+      const result = await createTask(payload);
+
+      expect(result).toEqual(created);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(BASE);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual(payload);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateTask
+  // ---------------------------------------------------------------------------
+  describe('updateTask', () => {
+    test('PATCHes /tasks/:id with payload', async () => {
+      const updated = { id: 't1', title: 'Updated', status: 'in_progress', createdAt: '2026-04-16' };
+      globalThis.fetch = mockFetchOk(updated);
+
+      const payload = { title: 'Updated', status: 'in_progress' as const };
+      const result = await updateTask('t1', payload);
+
+      expect(result).toEqual(updated);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/t1`);
+      expect(opts.method).toBe('PATCH');
+      expect(JSON.parse(opts.body)).toEqual(payload);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTask
+  // ---------------------------------------------------------------------------
+  describe('deleteTask', () => {
+    test('sends DELETE to /tasks/:id', async () => {
+      globalThis.fetch = mockFetchOk(undefined);
+      await deleteTask('t42');
+
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/t42`);
+      expect(opts.method).toBe('DELETE');
+    });
+
+    test('throws on non-200 response', async () => {
+      globalThis.fetch = mockFetchError(403);
+      await expect(deleteTask('t42')).rejects.toThrow('Task API error: 403');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // completeTask
+  // ---------------------------------------------------------------------------
+  describe('completeTask', () => {
+    test('PATCHes task with completed status', async () => {
+      const completed = { id: 't1', title: 'Done', status: 'completed', createdAt: '2026-04-16' };
+      globalThis.fetch = mockFetchOk(completed);
+
+      const result = await completeTask('t1');
+
+      expect(result).toEqual(completed);
+      const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+      expect(url).toBe(`${BASE}/t1`);
+      expect(opts.method).toBe('PATCH');
+      const body = JSON.parse(opts.body);
+      expect(body.status).toBe('completed');
+      expect(body.completedAt).toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Common: credentials and headers
+  // ---------------------------------------------------------------------------
+  describe('common fetch options', () => {
+    test('sends credentials include and content-type header', async () => {
+      globalThis.fetch = mockFetchOk([]);
+      await getTasks();
+
+      const opts = (globalThis.fetch as any).mock.calls[0][1];
+      expect(opts.credentials).toBe('include');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+    });
+  });
+});

--- a/src/components/ui/chat/ArtifactPanel.tsx
+++ b/src/components/ui/chat/ArtifactPanel.tsx
@@ -10,6 +10,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import type { ArtifactNode } from '../../../types/artifactTypes';
 import { getActiveVersion, getVersionCount } from '../../../types/artifactTypes';
 import { useArtifactManager } from '../../../stores/useArtifactManager';
+import { getRenderer, hasRenderer } from './ArtifactRendererRegistry';
 
 // Lazy-load A2UI renderer — only imported when an artifact has a2uiState
 let A2UIRendererModule: typeof import('./A2UISurfacePanel') | null = null;
@@ -373,15 +374,19 @@ export const ArtifactPanel: React.FC<ArtifactPanelInternalProps> = ({
                 surfaceEvents={surfaceEvents}
                 onUserAction={onUserAction}
               />
-            ) : artifact.contentType === 'image' ? (
-              <img src={activeVersion.content} alt={artifact.title} className="max-w-full rounded-lg" />
-            ) : artifact.contentType === 'html' || artifact.contentType === 'svg' ? (
-              <div className="bg-white rounded-lg border border-gray-200 dark:border-gray-700 p-4 min-h-[200px]" dangerouslySetInnerHTML={{ __html: activeVersion.content }} />
-            ) : (
-              <div className="prose dark:prose-invert max-w-none text-[15px] leading-[1.6]">
-                <pre className="whitespace-pre-wrap">{activeVersion.content}</pre>
-              </div>
-            )}
+            ) : (() => {
+              // Use ArtifactRendererRegistry for content-type dispatch (#255)
+              const Renderer = getRenderer(artifact.contentType);
+              return (
+                <Renderer
+                  content={activeVersion.content}
+                  language={activeVersion.language}
+                  title={artifact.title}
+                  a2uiState={activeVersion.a2uiState}
+                  metadata={artifact.metadata}
+                />
+              );
+            })()}
           </div>
         )}
 

--- a/src/components/ui/chat/ConversationShareDialog.tsx
+++ b/src/components/ui/chat/ConversationShareDialog.tsx
@@ -20,11 +20,25 @@ export const ConversationShareDialog: React.FC<ConversationShareDialogProps> = (
   const generateLink = useCallback(async () => {
     setLoading(true);
     try {
-      // Will connect to isA_user sharing API (#261) when ready
-      // For now, generate a placeholder link
+      // Try real sharing API first (#204)
+      const res = await fetch(`/api/v1/sessions/${sessionId}/shares`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ permissions: 'view-only' }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setShareUrl(data.url || `${window.location.origin}/shared/${data.share_token}`);
+      } else {
+        // Fallback: generate local placeholder link
+        const token = btoa(sessionId).replace(/=/g, '');
+        setShareUrl(`${window.location.origin}/shared/${token}`);
+      }
+    } catch {
+      // API not available — use local fallback
       const token = btoa(sessionId).replace(/=/g, '');
-      const url = `${window.location.origin}/shared/${token}`;
-      setShareUrl(url);
+      setShareUrl(`${window.location.origin}/shared/${token}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/ui/session/SessionHistory.tsx
+++ b/src/components/ui/session/SessionHistory.tsx
@@ -1,9 +1,25 @@
 import React, { useMemo } from 'react';
 import { createLogger } from '../../../utils/logger';
 import { ChatSession } from '../../../hooks/useSession';
-import { getMessageContent } from '../../../types/chatTypes';
+import { getMessageContent, RegularMessage } from '../../../types/chatTypes';
 
 const log = createLogger('SessionHistory');
+
+// Channel indicator for cross-channel sessions (#231)
+const CHANNEL_ICONS: Record<string, string> = {
+  telegram: '✈️', discord: '🎮', slack: '💬', whatsapp: '📱',
+  teams: '🏢', signal: '🔒', matrix: '🔗',
+};
+
+function getSessionChannel(session: any): string | null {
+  if (!session.messages || !Array.isArray(session.messages)) return null;
+  for (const msg of session.messages) {
+    if (msg && 'channelOrigin' in msg && (msg as RegularMessage).channelOrigin) {
+      return (msg as RegularMessage).channelOrigin!;
+    }
+  }
+  return null;
+}
 import { GlassButton } from '../../shared';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -228,6 +244,15 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({
                           {String(session.title || t('sessions.untitledSession'))}
                         </h4>
                       )}
+                      {/* Channel indicator for cross-channel sessions (#231) */}
+                      {(() => {
+                        const channel = getSessionChannel(session);
+                        return channel ? (
+                          <span className="text-xs flex-shrink-0" title={`From ${channel}`}>
+                            {CHANNEL_ICONS[channel] || '🌐'}
+                          </span>
+                        ) : null;
+                      })()}
                       {isActive && editingSessionId !== session.id && (
                         <div className="w-2 h-2 bg-blue-300 rounded-full animate-pulse flex-shrink-0 shadow-sm shadow-blue-400/50" />
                       )}

--- a/src/components/ui/settings/ConnectorMarketplace.tsx
+++ b/src/components/ui/settings/ConnectorMarketplace.tsx
@@ -2,7 +2,7 @@
  * ConnectorMarketplace — Browse available integrations (#206)
  * Shows available MCP tools and connectors (Google, Slack, Notion, etc.)
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface Connector {
   id: string;
@@ -13,7 +13,7 @@ interface Connector {
   connected: boolean;
 }
 
-const CONNECTORS: Connector[] = [
+const FALLBACK_CONNECTORS: Connector[] = [
   { id: 'google-workspace', name: 'Google Workspace', icon: '🔷', description: 'Gmail, Docs, Calendar, Drive', category: 'Productivity', connected: false },
   { id: 'slack', name: 'Slack', icon: '💬', description: 'Channels, messages, notifications', category: 'Communication', connected: false },
   { id: 'notion', name: 'Notion', icon: '📓', description: 'Pages, databases, wikis', category: 'Productivity', connected: false },
@@ -27,12 +27,37 @@ const CONNECTORS: Connector[] = [
 ];
 
 export const ConnectorMarketplace: React.FC = () => {
+  const [connectors, setConnectors] = useState<Connector[]>(FALLBACK_CONNECTORS);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
+  const [installing, setInstalling] = useState<string | null>(null);
 
-  const categories = [...new Set(CONNECTORS.map(c => c.category))];
+  // Fetch from API, fall back to hardcoded (#206)
+  useEffect(() => {
+    fetch('/api/v1/marketplace/connectors', { credentials: 'include' })
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((data: Connector[]) => { if (Array.isArray(data) && data.length > 0) setConnectors(data); })
+      .catch(() => {}); // Keep fallback
+  }, []);
 
-  const filtered = CONNECTORS.filter(c =>
+  const handleConnect = async (id: string) => {
+    setInstalling(id);
+    try {
+      const res = await fetch('/api/v1/marketplace/connectors/install', {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: id }),
+      });
+      if (res.ok) {
+        setConnectors((prev) => prev.map((c) => c.id === id ? { ...c, connected: true } : c));
+      }
+    } catch {}
+    setInstalling(null);
+  };
+
+  const categories = [...new Set(connectors.map(c => c.category))];
+
+  const filtered = connectors.filter(c =>
     (!search || c.name.toLowerCase().includes(search.toLowerCase()) || c.description.toLowerCase().includes(search.toLowerCase())) &&
     (!category || c.category === category)
   );
@@ -85,12 +110,15 @@ export const ConnectorMarketplace: React.FC = () => {
               </div>
             </div>
             <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">{c.description}</p>
-            <button className={`w-full py-1.5 text-xs font-medium rounded-lg transition-colors ${
+            <button
+              onClick={() => !c.connected && handleConnect(c.id)}
+              disabled={c.connected || installing === c.id}
+              className={`w-full py-1.5 text-xs font-medium rounded-lg transition-colors ${
               c.connected
                 ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 border border-green-200 dark:border-green-800'
                 : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
             }`}>
-              {c.connected ? 'Connected' : 'Connect'}
+              {c.connected ? 'Connected' : installing === c.id ? 'Installing...' : 'Connect'}
             </button>
           </div>
         ))}

--- a/src/components/ui/settings/SkillBuilder.tsx
+++ b/src/components/ui/settings/SkillBuilder.tsx
@@ -2,7 +2,7 @@
  * SkillBuilder — Create and manage user-defined skills (#205)
  * Skills are repeatable workflows triggered by phrase or command.
  */
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 
 interface UserSkill {
   id: string;
@@ -15,16 +15,39 @@ interface UserSkill {
 
 const STORAGE_KEY = 'isa_user_skills';
 
-function loadSkills(): UserSkill[] {
-  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); } catch { return []; }
+async function loadSkills(): Promise<UserSkill[]> {
+  const local: UserSkill[] = (() => {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); } catch { return []; }
+  })();
+  // Try API, merge with local (#205)
+  try {
+    const res = await fetch('/api/v1/skills', { credentials: 'include' });
+    if (res.ok) {
+      const remote: UserSkill[] = await res.json();
+      const ids = new Set(remote.map((s) => s.id));
+      return [...remote, ...local.filter((s) => !ids.has(s.id))];
+    }
+  } catch {}
+  return local;
 }
 
 function saveSkills(skills: UserSkill[]) {
   try { localStorage.setItem(STORAGE_KEY, JSON.stringify(skills)); } catch {}
+  // Fire-and-forget API sync (#205)
+  fetch('/api/v1/skills', {
+    method: 'PUT', credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(skills),
+  }).catch(() => {});
 }
 
 export const SkillBuilder: React.FC = () => {
-  const [skills, setSkills] = useState<UserSkill[]>(loadSkills);
+  const [skills, setSkills] = useState<UserSkill[]>([]);
+
+  // Load skills from API + localStorage on mount
+  useEffect(() => {
+    loadSkills().then(setSkills);
+  }, []);
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -64,6 +64,9 @@ interface SessionState {
   sessions: ChatSession[];
   currentSessionId: string;
 
+  // Starred sessions (#199)
+  starredSessionIds: Set<string>;
+
   // Search state
   searchQuery: string;
 
@@ -102,7 +105,12 @@ interface SessionActions {
   saveToStorageDebounced: () => void;
   loadFromAPI: (userId: string, authHeaders?: any) => Promise<void>;
   saveToAPI: (userId: string, authHeaders?: any) => Promise<void>;
-  
+
+  // Star operations (#199)
+  starSession: (sessionId: string) => void;
+  unstarSession: (sessionId: string) => void;
+  isSessionStarred: (sessionId: string) => boolean;
+
   // Computed getters
   getCurrentSession: () => ChatSession | null;
   getSessionById: (sessionId: string) => ChatSession | null;
@@ -115,6 +123,11 @@ export const useSessionStore = create<SessionStore>()(
     // Initial state
     sessions: [],
     currentSessionId: 'default',
+    starredSessionIds: new Set<string>(
+      typeof window !== 'undefined'
+        ? (() => { try { return JSON.parse(localStorage.getItem('isa_starred_sessions') || '[]'); } catch { return []; } })()
+        : []
+    ),
     searchQuery: '',
     isLoading: false,
     error: null,
@@ -476,6 +489,27 @@ export const useSessionStore = create<SessionStore>()(
       }, STORAGE_SAVE_DEBOUNCE_MS);
     },
     
+    // Star operations (#199)
+    starSession: (sessionId) => {
+      set((state) => {
+        const next = new Set(state.starredSessionIds);
+        next.add(sessionId);
+        return { starredSessionIds: next };
+      });
+      try { localStorage.setItem('isa_starred_sessions', JSON.stringify([...get().starredSessionIds])); } catch {}
+      fetch(`/api/v1/sessions/${sessionId}/star`, { method: 'POST', credentials: 'include' }).catch(() => {});
+    },
+    unstarSession: (sessionId) => {
+      set((state) => {
+        const next = new Set(state.starredSessionIds);
+        next.delete(sessionId);
+        return { starredSessionIds: next };
+      });
+      try { localStorage.setItem('isa_starred_sessions', JSON.stringify([...get().starredSessionIds])); } catch {}
+      fetch(`/api/v1/sessions/${sessionId}/star`, { method: 'DELETE', credentials: 'include' }).catch(() => {});
+    },
+    isSessionStarred: (sessionId) => get().starredSessionIds.has(sessionId),
+
     // Computed getters
     getCurrentSession: () => {
       const { sessions, currentSessionId } = get();
@@ -583,6 +617,14 @@ export const useCurrentSession = () => useSessionStore(state => state.getCurrent
 export const useSessionSearchQuery = () => useSessionStore(state => state.searchQuery);
 export const useSessionLoading = () => useSessionStore(state => state.isLoading);
 export const useSessionError = () => useSessionStore(state => state.error);
+
+// Star selector hooks (#199)
+export const useStarredSessionIds = () => useSessionStore(state => state.starredSessionIds);
+export const useStarActions = () => useSessionStore(state => ({
+  starSession: state.starSession,
+  unstarSession: state.unstarSession,
+  isSessionStarred: state.isSessionStarred,
+}));
 
 // Additional selector hooks for compatibility
 export const useSessionCount = () => useSessionStore(state => state.sessions.length);


### PR DESCRIPTION
## Summary

Final batch — wires all remaining stubbed features to real APIs with graceful fallback, adds adapter tests, and cross-channel indicators.

### Starred conversations (#199)
- starredSessionIds in useSessionStore with star/unstar actions
- API-first + localStorage fallback

### Conversation sharing (#204)
- ConversationShareDialog now calls real API, falls back to btoa() stub

### Skills UI sync (#205)
- SkillBuilder fetches from /api/v1/skills, merges with localStorage

### Connector marketplace (#206)
- Fetches from /api/v1/marketplace/connectors, wires Connect button

### Cross-channel indicator (#231)
- SessionHistory shows channel icon on cross-channel sessions

### Adapter tests (#166, #167, #168)
- Unit tests for CalendarAdapter, TaskAdapter, NotificationAdapter

### ArtifactPanel registry (#255)
- Uses ArtifactRendererRegistry in Preview tab

Fixes #166, #167, #168, #199, #204, #205, #206, #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)