### PR TITLE
feat(ui): consume SDK streaming components — ThinkingBlock + StreamingStatusLine (#281)

### DIFF
--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -7,6 +7,10 @@ import { useMatePresence } from '../../../hooks/useMatePresence';
 import { useMessageStore } from '../../../stores/useMessageStore';
 import { useStreamingStore } from '../../../stores/useStreamingStore';
 import { ModelSelectorDropdown } from './ModelSelectorDropdown';
+// SDK streaming components (#290)
+import { StreamingStatusLine as SDKStreamingStatusLine } from '@isa/ui-web';
+// Cast for React types version mismatch
+const StreamingStatusLine = SDKStreamingStatusLine as React.FC<any>;
 const log = createLogger('InputAreaLayout');
 
 export interface InputAreaLayoutProps {
@@ -409,22 +413,24 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
         </div>
       )}
 
-      {/* Mate status line */}
-      <div className="mb-2 px-1 flex items-center gap-2">
-        <span className={`text-xs font-display ${!isOnline ? 'text-white/30' : 'text-[var(--mate-accent)]/60'}`}>
-          {isActivelyStreaming
-            ? 'Responding...'
-            : !isOnline
-              ? 'Connecting...'
-              : isWorking
-                ? `Working on ${activeDelegationCount} task${activeDelegationCount !== 1 ? 's' : ''}...`
-                : ''}
-        </span>
-        {isOnline && channels.length > 0 && !isLoading && (
-          <span className="text-xs text-white/30">
-            Active on {channels.length} channel{channels.length !== 1 ? 's' : ''}
-          </span>
-        )}
+      {/* Mate status line — SDK StreamingStatusLine (#290) */}
+      <div className="mb-2 px-1">
+        <StreamingStatusLine
+          phase={
+            isActivelyStreaming ? 'generating'
+            : !isOnline ? 'connecting'
+            : isWorking ? 'preparing'
+            : 'idle'
+          }
+          message={
+            isWorking && !isActivelyStreaming
+              ? `Working on ${activeDelegationCount} task${activeDelegationCount !== 1 ? 's' : ''}...`
+              : undefined
+          }
+          isThinking={useStreamingStore.getState().isThinking}
+          activeTasks={isWorking ? activeDelegationCount : undefined}
+          className="text-xs"
+        />
       </div>
 
       {/* Model Selector — above input, Claude-style (#194) */}

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -47,6 +47,10 @@ import { DeepThinking as DeepThinkingOriginal } from '@isa/ui-web';
 import type { ThinkingStep, DeepThinkingProps } from '@isa/ui-web';
 // Cast to work around React types version mismatch between packages
 const DeepThinking = DeepThinkingOriginal as React.FC<DeepThinkingProps>;
+// SDK streaming components (#290)
+import { ThinkingBlock as ThinkingBlockOriginal, ToolCallDisplay as ToolCallDisplayOriginal } from '@isa/ui-web';
+const ThinkingBlock = ThinkingBlockOriginal as React.FC<any>;
+const ToolCallDisplay = ToolCallDisplayOriginal as React.FC<any>;
 import { GentleNotification } from './GentleNotification';
 import type { GentleNotificationType } from './GentleNotification';
 import { EditableMessage } from './EditableMessage';
@@ -788,8 +792,19 @@ export const MessageList = memo<MessageListProps>(({
           </div>
         )}
 
+        {/* Live Thinking — streaming chain-of-thought via SDK ThinkingBlock (#290) */}
+        {message.role === 'assistant' && message.isStreaming && message.type === 'regular' && (message as RegularMessage).thinkingContent && (
+          <div className="ml-12 mb-3">
+            <ThinkingBlock
+              isThinking={true}
+              content={(message as RegularMessage).thinkingContent || ''}
+              autoCollapse={true}
+            />
+          </div>
+        )}
+
         {/* Deep Thinking — collapsible reasoning block above assistant response (#185) */}
-        {message.role === 'assistant' && message.type === 'regular' && (message as RegularMessage).thinkingSteps && (message as RegularMessage).thinkingSteps!.length > 0 && (
+        {message.role === 'assistant' && message.type === 'regular' && !message.isStreaming && (message as RegularMessage).thinkingSteps && (message as RegularMessage).thinkingSteps!.length > 0 && (
           <div className="ml-12 mb-3">
             <DeepThinking
               steps={(message as RegularMessage).thinkingSteps!.map((s): ThinkingStep => ({


### PR DESCRIPTION
## Summary
- Replace ad-hoc inline status text in InputAreaLayout with SDK `StreamingStatusLine` (phase-aware, aria-live accessible)
- Add live `ThinkingBlock` during streaming in MessageList (auto-collapses when done)
- Keep `DeepThinking` for completed thinking display (post-stream)
- Import `ToolCallDisplay` for future tool call rendering

**Parent Epic**: #280 (Wave 5)

## Test plan
- [ ] Send message → StreamingStatusLine shows "Responding..." during stream
- [ ] With thinking model → ThinkingBlock appears above response during stream, collapses after
- [ ] Offline → status shows "Connecting..."
- [ ] Multiple tasks → status shows task count
- [ ] Existing DeepThinking still works for completed messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)