### PR TITLE
fix(ui): safe-import SDK components with fallback for stale dist

### DIFF
--- a/src/components/ui/chat/BrowserPanel.tsx
+++ b/src/components/ui/chat/BrowserPanel.tsx
@@ -8,11 +8,14 @@
  */
 
 import React, { useState } from 'react';
-import { BrowserViewport as BrowserViewportOriginal, ActionLogPanel as ActionLogPanelOriginal } from '@isa/ui-web';
-
-// Cast for React types version mismatch
-const BrowserViewport = BrowserViewportOriginal as React.FC<any>;
-const ActionLogPanel = ActionLogPanelOriginal as React.FC<any>;
+// Safe import — @isa/ui-web dist may not include these yet
+let BrowserViewport: React.FC<any> = () => React.createElement('div', { style: { padding: 40, textAlign: 'center', color: '#6b7280' } }, 'Browser Viewport loading...');
+let ActionLogPanel: React.FC<any> = () => React.createElement('div', { style: { padding: 20, color: '#6b7280' } }, 'Action log loading...');
+try {
+  const uiWeb = require('@isa/ui-web');
+  if (uiWeb.BrowserViewport) BrowserViewport = uiWeb.BrowserViewport as React.FC<any>;
+  if (uiWeb.ActionLogPanel) ActionLogPanel = uiWeb.ActionLogPanel as React.FC<any>;
+} catch { /* fallback */ }
 
 export interface BrowserPanelProps {
   /** Current screenshot */

--- a/src/components/ui/chat/DesignPanel.tsx
+++ b/src/components/ui/chat/DesignPanel.tsx
@@ -8,10 +8,12 @@
  */
 
 import React from 'react';
-import { DesignCanvas as DesignCanvasOriginal } from '@isa/ui-web';
-
-// Cast for React types version mismatch
-const DesignCanvas = DesignCanvasOriginal as React.FC<any>;
+// Safe import — @isa/ui-web dist may not include DesignCanvas yet
+let DesignCanvas: React.FC<any> = (props) => React.createElement('div', { style: { padding: 40, textAlign: 'center', color: '#6b7280' } }, 'Design Canvas loading...');
+try {
+  const uiWeb = require('@isa/ui-web');
+  if (uiWeb.DesignCanvas) DesignCanvas = uiWeb.DesignCanvas as React.FC<any>;
+} catch { /* fallback */ }
 
 export interface DesignPanelProps {
   /** Design content URL (image) */

--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -7,10 +7,14 @@ import { useMatePresence } from '../../../hooks/useMatePresence';
 import { useMessageStore } from '../../../stores/useMessageStore';
 import { useStreamingStore } from '../../../stores/useStreamingStore';
 import { ModelSelectorDropdown } from './ModelSelectorDropdown';
-// SDK streaming components (#290)
-import { StreamingStatusLine as SDKStreamingStatusLine } from '@isa/ui-web';
-// Cast for React types version mismatch
-const StreamingStatusLine = SDKStreamingStatusLine as React.FC<any>;
+// SDK streaming components (#290) — safe import with fallback until @isa/ui-web dist is rebuilt
+let StreamingStatusLine: React.FC<any> = () => null;
+try {
+  const uiWeb = require('@isa/ui-web');
+  if (uiWeb.StreamingStatusLine) {
+    StreamingStatusLine = uiWeb.StreamingStatusLine as React.FC<any>;
+  }
+} catch { /* @isa/ui-web dist not yet rebuilt with streaming components */ }
 const log = createLogger('InputAreaLayout');
 
 export interface InputAreaLayoutProps {

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -47,10 +47,14 @@ import { DeepThinking as DeepThinkingOriginal } from '@isa/ui-web';
 import type { ThinkingStep, DeepThinkingProps } from '@isa/ui-web';
 // Cast to work around React types version mismatch between packages
 const DeepThinking = DeepThinkingOriginal as React.FC<DeepThinkingProps>;
-// SDK streaming components (#290)
-import { ThinkingBlock as ThinkingBlockOriginal, ToolCallDisplay as ToolCallDisplayOriginal } from '@isa/ui-web';
-const ThinkingBlock = ThinkingBlockOriginal as React.FC<any>;
-const ToolCallDisplay = ToolCallDisplayOriginal as React.FC<any>;
+// SDK streaming components (#290) — safe import with fallback until @isa/ui-web dist is rebuilt
+let ThinkingBlock: React.FC<any> = () => null;
+let ToolCallDisplay: React.FC<any> = () => null;
+try {
+  const uiWeb = require('@isa/ui-web');
+  if (uiWeb.ThinkingBlock) ThinkingBlock = uiWeb.ThinkingBlock as React.FC<any>;
+  if (uiWeb.ToolCallDisplay) ToolCallDisplay = uiWeb.ToolCallDisplay as React.FC<any>;
+} catch { /* @isa/ui-web dist not yet rebuilt with streaming components */ }
 import { GentleNotification } from './GentleNotification';
 import type { GentleNotificationType } from './GentleNotification';
 import { EditableMessage } from './EditableMessage';


### PR DESCRIPTION
## Summary
Fix SSR crash: `Element type is invalid: expected a string but got: undefined`

Replace static ES imports of new @isa/ui-web components with try/catch require() + null fallback. Components that don't exist in the built dist gracefully render nothing instead of crashing.

## Test plan
- [ ] /app loads without SSR error
- [ ] Components render as fallback text when dist is stale
- [ ] Components render correctly when dist is rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)