### PR TITLE
fix(ui): replace require with inline components — fix ESM build error

### DIFF
--- a/src/components/ui/chat/BrowserPanel.tsx
+++ b/src/components/ui/chat/BrowserPanel.tsx
@@ -8,14 +8,17 @@
  */
 
 import React, { useState } from 'react';
-// Safe import — @isa/ui-web dist may not include these yet
-let BrowserViewport: React.FC<any> = () => React.createElement('div', { style: { padding: 40, textAlign: 'center', color: '#6b7280' } }, 'Browser Viewport loading...');
-let ActionLogPanel: React.FC<any> = () => React.createElement('div', { style: { padding: 20, color: '#6b7280' } }, 'Action log loading...');
-try {
-  const uiWeb = require('@isa/ui-web');
-  if (uiWeb.BrowserViewport) BrowserViewport = uiWeb.BrowserViewport as React.FC<any>;
-  if (uiWeb.ActionLogPanel) ActionLogPanel = uiWeb.ActionLogPanel as React.FC<any>;
-} catch { /* fallback */ }
+// Placeholder until @isa/ui-web dist is rebuilt (#293, #294)
+const BrowserViewport: React.FC<any> = ({ isConnected }) => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: '#1e1e2e', color: '#6b7280', fontSize: 14, borderRadius: 8 }}>
+    {isConnected ? 'Waiting for screenshot...' : 'Browser Viewport — rebuild @isa/ui-web to activate'}
+  </div>
+);
+const ActionLogPanel: React.FC<any> = ({ actions = [] }) => (
+  <div style={{ padding: 12, color: '#6b7280', fontSize: 13, border: '1px solid #e5e7eb', borderRadius: 8, height: '100%' }}>
+    Action Log — {actions.length} actions
+  </div>
+);
 
 export interface BrowserPanelProps {
   /** Current screenshot */

--- a/src/components/ui/chat/DesignPanel.tsx
+++ b/src/components/ui/chat/DesignPanel.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Safe import — @isa/ui-web dist may not include DesignCanvas yet
-let DesignCanvas: React.FC<any> = (props) => React.createElement('div', { style: { padding: 40, textAlign: 'center', color: '#6b7280' } }, 'Design Canvas loading...');
-try {
-  const uiWeb = require('@isa/ui-web');
-  if (uiWeb.DesignCanvas) DesignCanvas = uiWeb.DesignCanvas as React.FC<any>;
-} catch { /* fallback */ }
+// Placeholder until @isa/ui-web dist is rebuilt with DesignCanvas (#291)
+const DesignCanvas: React.FC<any> = (props) => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#6b7280', fontSize: 14 }}>
+    {props.isGenerating ? 'Generating design...' : 'Design Canvas — rebuild @isa/ui-web to activate'}
+  </div>
+);
 
 export interface DesignPanelProps {
   /** Design content URL (image) */

--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -7,14 +7,33 @@ import { useMatePresence } from '../../../hooks/useMatePresence';
 import { useMessageStore } from '../../../stores/useMessageStore';
 import { useStreamingStore } from '../../../stores/useStreamingStore';
 import { ModelSelectorDropdown } from './ModelSelectorDropdown';
-// SDK streaming components (#290) — safe import with fallback until @isa/ui-web dist is rebuilt
-let StreamingStatusLine: React.FC<any> = () => null;
-try {
-  const uiWeb = require('@isa/ui-web');
-  if (uiWeb.StreamingStatusLine) {
-    StreamingStatusLine = uiWeb.StreamingStatusLine as React.FC<any>;
-  }
-} catch { /* @isa/ui-web dist not yet rebuilt with streaming components */ }
+// SDK streaming component — inline implementation until @isa/ui-web dist is rebuilt (#290)
+const StreamingStatusLine: React.FC<{
+  phase: string;
+  message?: string;
+  isThinking?: boolean;
+  activeTasks?: number;
+  className?: string;
+}> = ({ phase, message, isThinking, activeTasks, className = '' }) => {
+  const defaultMessages: Record<string, string> = {
+    idle: '', connecting: 'Connecting...', preparing: 'Preparing...',
+    generating: 'Responding...', done: '',
+  };
+  const text = message || defaultMessages[phase] || '';
+  if (!text && !isThinking && !activeTasks) return null;
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`} role="status" aria-live="polite">
+      {phase !== 'idle' && phase !== 'done' && (
+        <span className={`w-1.5 h-1.5 rounded-full ${isThinking ? 'bg-amber-400' : 'bg-blue-400'} animate-pulse`} />
+      )}
+      <span>{isThinking ? 'Thinking...' : text}</span>
+      {activeTasks != null && activeTasks > 0 && (
+        <span className="ml-auto opacity-70">{activeTasks} task{activeTasks !== 1 ? 's' : ''} active</span>
+      )}
+    </div>
+  );
+};
 const log = createLogger('InputAreaLayout');
 
 export interface InputAreaLayoutProps {

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -47,14 +47,30 @@ import { DeepThinking as DeepThinkingOriginal } from '@isa/ui-web';
 import type { ThinkingStep, DeepThinkingProps } from '@isa/ui-web';
 // Cast to work around React types version mismatch between packages
 const DeepThinking = DeepThinkingOriginal as React.FC<DeepThinkingProps>;
-// SDK streaming components (#290) — safe import with fallback until @isa/ui-web dist is rebuilt
-let ThinkingBlock: React.FC<any> = () => null;
-let ToolCallDisplay: React.FC<any> = () => null;
-try {
-  const uiWeb = require('@isa/ui-web');
-  if (uiWeb.ThinkingBlock) ThinkingBlock = uiWeb.ThinkingBlock as React.FC<any>;
-  if (uiWeb.ToolCallDisplay) ToolCallDisplay = uiWeb.ToolCallDisplay as React.FC<any>;
-} catch { /* @isa/ui-web dist not yet rebuilt with streaming components */ }
+// SDK streaming components — inline until @isa/ui-web dist is rebuilt (#290)
+const ThinkingBlock: React.FC<{
+  isThinking: boolean; content: string; autoCollapse?: boolean; className?: string;
+}> = ({ isThinking, content, className = '' }) => {
+  const [expanded, setExpanded] = useState(isThinking);
+  useEffect(() => { if (isThinking) setExpanded(true); }, [isThinking]);
+  useEffect(() => { if (!isThinking) { const t = setTimeout(() => setExpanded(false), 500); return () => clearTimeout(t); } }, [isThinking]);
+  if (!content && !isThinking) return null;
+  return (
+    <div className={`border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-2 ${className}`}>
+      <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center gap-2 px-3 py-2 bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 dark:text-gray-400 text-left">
+        <span style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', fontSize: '8px' }}>▶</span>
+        {isThinking && <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />}
+        <span className="font-medium">{isThinking ? 'Thinking...' : 'Thought process'}</span>
+      </button>
+      {expanded && (
+        <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 font-mono whitespace-pre-wrap max-h-96 overflow-auto">
+          {content}{isThinking && <span className="opacity-40 animate-pulse">▋</span>}
+        </div>
+      )}
+    </div>
+  );
+};
+const ToolCallDisplay: React.FC<any> = () => null; // Placeholder until wired
 import { GentleNotification } from './GentleNotification';
 import type { GentleNotificationType } from './GentleNotification';
 import { EditableMessage } from './EditableMessage';


### PR DESCRIPTION
## Summary
Fix: `Module not found: ESM packages (react-markdown) need to be imported`

The `require('@isa/ui-web')` pattern in Wave 5 safe-imports triggers CJS loading of the dist, which can't handle ESM-only `react-markdown`. Replace with inline component implementations matching the SDK API.

## Test plan
- [ ] `next dev` compiles without errors
- [ ] /app page loads
- [ ] StreamingStatusLine shows status during streaming
- [ ] ThinkingBlock shows during thinking, auto-collapses when done

🤖 Generated with [Claude Code](https://claude.com/claude-code)