### PR TITLE
fix(chat): show response for non-streaming results + fix page scroll

### DIFF
--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -159,18 +159,37 @@ export function adaptMateEvent(
     }
 
     case 'result': {
-      // Final result — close the text message and finish the run
-      if (currentMessageId) {
+      // Final result — if no text message was started, emit start+content+end
+      if (!currentMessageId) {
+        currentMessageId = generateId('msg');
         results.push({
-          type: 'text_message_end',
+          type: 'text_message_start',
           thread_id: threadId,
           timestamp: now,
           run_id: context.runId,
           message_id: currentMessageId,
-          final_content: event.content,
+          role: 'assistant',
         });
-        currentMessageId = null;
+        if (event.content) {
+          results.push({
+            type: 'text_message_content',
+            thread_id: threadId,
+            timestamp: now,
+            run_id: context.runId,
+            message_id: currentMessageId,
+            delta: event.content,
+          });
+        }
       }
+      results.push({
+        type: 'text_message_end',
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        message_id: currentMessageId,
+        final_content: event.content,
+      });
+      currentMessageId = null;
       results.push({
         type: 'run_finished',
         thread_id: threadId,

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -102,7 +102,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
 
   return (
     <div
-      className={`min-h-dvh w-full flex flex-col bg-[var(--surface-bg,#0f172a)] text-[var(--text-primary,#fff)] relative ${className}`}
+      className={`h-dvh w-full flex flex-col overflow-hidden bg-[var(--surface-bg,#0f172a)] text-[var(--text-primary,#fff)] relative ${className}`}
     >
       {/* Platform Navigation — disabled pending PlatformNav component fix
           The compiled @isa/ui-web PlatformNav renders a React element where


### PR DESCRIPTION
## Summary
1. **No response**: MateEventAdapter skipped text_message_end when no prior text event. Now emits full start+content+end for direct result events.
2. **Page scrolls**: AppLayout used min-h-dvh → content overflowed viewport. Changed to h-dvh + overflow-hidden.

## Test plan
- [ ] Send "hi" → response bubble appears with Mate's reply
- [ ] Chat messages scroll within the chat area (not the whole page)
- [ ] Long conversations scroll correctly with auto-scroll to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)