### PR TITLE
feat(ui): migrate HIL to /v1/interactive endpoints, silence 502 warning

### DIFF
--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -309,6 +309,75 @@ These existing capabilities set isA_ apart and should be preserved/enhanced, not
 - Computer use / screen control
 - Dispatch (phone → desktop)
 
+### Epic: Agent Capability Consumption — Surface SDK Features in Chat
+
+**Priority**: P0 → P3 (phased E1 → E6)
+**Milestone**: v1.0 — Unified Platform
+**Status**: Ready for design
+
+Currently the frontend reaches a narrow slice of isA_Agent_SDK through isA_Mate: chat, memory, scheduler, tracker. Users and agents cannot see or trigger 20+ SDK services (HIL, triggers, background jobs, webhooks, knowledge graph, vector search, checkpoints, cost metrics, audit) because there is no HTTP surface. The gateway plan (isA_Mate §2.30) exposes 5 capability routers under `/v1/{interactive,proactive,observability,persistence,responsive,autonomous,reactive}/*`. This epic tracks the isA_ UI side of consumption: which chat surfaces render which capability.
+
+**Why conversation-first matters:** isA_ is a companion, not a dashboard. Every capability lands in chat — HIL approvals surface as inline interrupts, trigger fires appear as proactive messages, cost/audit live in a drawer, checkpoints restore via slash command. No standalone settings pages.
+
+#### Sub-Epics
+
+**E1. Interactive (P0) — HIL Consumption**
+- `ExecutionControlService` polls `/v1/interactive/interrupts` (replaces broken `/agents/execution/health` probe)
+- `HILInterruptModal` renders ask_human, tool_authorization, review_and_edit variants
+- `HILInteractionManager` POSTs `/v1/interactive/interrupts/{id}/respond` to resume
+- Audit drawer shows approval history per session
+- Fixes the current 502 / "HIL service not available" warning
+
+**E2. Proactive (P1) — Triggers Panel**
+- Triggers pane in settings for CRUD against `/v1/proactive/triggers`
+- Autonomous event stream from `/v1/autonomous/events` (SSE) surfaces as proactive chat messages ("Your morning brief is ready…")
+- Trigger test dry-run UI for debugging conditions
+- Push notifications ride on top (when available)
+
+**E3. Observable (P1) — Cost & Audit**
+- Cost badge in chat header from `/v1/observability/metrics` (tokens + USD per session)
+- Audit drawer from `/v1/observability/audit` filterable by action type
+- No full-screen dashboards — everything accessible from chat
+
+**E4. Persistent (P2) — Knowledge & Checkpoints**
+- `/v1/persistence/knowledge/search` powers semantic memory lookup in Cmd+K
+- Graph view for `/v1/persistence/graph/{id}` relationships
+- Slash command `/restore <checkpoint_id>` invokes `/v1/persistence/restore` for resume-from-failure
+- Integrates with Companion Memory differentiator (5 memory types)
+
+**E5. Responsive (P2) — Live Progress**
+- `/v1/responsive/stream/{session_id}` (SSE) fuels live node/tool/content progress indicators
+- Complements existing `/v1/chat` SSE for post-hoc/observer views
+- Tool execution badges show timing + status
+
+**E6. Autonomous + Reactive (P3)**
+- Background job surface (`/v1/autonomous/background-jobs`) — user can see async work, not block chat
+- Generic webhook config UI (`/v1/reactive/webhooks`) for third-party ingress
+
+#### Cross-Repo Impact
+
+| Repo | Role |
+|------|------|
+| isA_Mate | Gateway routers (§2.30) — backend exposure |
+| isA_Agent_SDK | SDK-side hooks — query/restore APIs for HIL + checkpoints |
+| isA_App_SDK | 5 new capability clients — `InteractiveClient`, `ProactiveClient`, `ObservabilityClient`, `PersistenceClient`, `ResponsiveClient` in `@isa/transport` |
+| isA_ | UI integration — modals, panels, badges, drawers wired to new clients |
+
+#### Acceptance Criteria (Epic-level)
+
+- [ ] E1: 502 at `/agents/execution/health` is gone; ask_human modal renders and resumes
+- [ ] E2: User creates a cron trigger via UI, sees proactive message when it fires
+- [ ] E3: Cost badge updates live; audit drawer shows last 50 actions
+- [ ] E4: Semantic search finds prior conversation context; `/restore` resumes a failed run
+- [ ] E5: Live progress indicator shows every node/tool event in chat
+- [ ] E6: Background job appears in chat as async work; webhook config saves
+
+#### Out of Scope (for this epic)
+
+- Multi-tenant admin views (handled by isA_Console)
+- Raw Prometheus dashboards (handled by ops, not chat UI)
+- SDK-level changes to agent internals (handled in isA_Agent_SDK epics)
+
 ## Technical Constraints
 
 - Next.js 14 with pages router

--- a/src/api/ExecutionControlService.ts
+++ b/src/api/ExecutionControlService.ts
@@ -28,11 +28,20 @@ import { BaseApiService } from './BaseApiService';
 import { logger, LogCategory } from '../utils/logger';
 import { GATEWAY_CONFIG, GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { authTokenStore } from '../stores/authTokenStore';
-import { 
-  HILInterruptDetectedEvent, 
+import {
+  HILInterruptDetectedEvent,
   HILCheckpointCreatedEvent,
-  HILExecutionStatusData 
+  HILExecutionStatusData
 } from '../types/aguiTypes';
+import type {
+  Interrupt,
+  InterruptListResponse,
+  InterruptResponseBody,
+  ResumeResult as InteractiveResumeResult,
+  ExpiryInfo,
+  AuditEntry,
+  InteractiveHealth,
+} from './types/interactive';
 
 // ================================================================================
 // Type Definitions - HIL执行控制类型定义
@@ -220,10 +229,16 @@ export class ExecutionControlService {
 
   /**
    * 检查HIL执行控制服务健康状态
+   *
+   * Probes the Mate gateway's /v1/interactive/health endpoint
+   * (xenoISA/isA_Mate#404). Failures are downgraded to debug — the old
+   * error log caused the misleading "HIL service not available" spam at
+   * ChatModule.tsx:331 when the backend returned 502/404, even though
+   * HIL interrupt handling should remain enabled regardless.
    */
   async getHealth(): Promise<ExecutionHealth> {
     try {
-      const response = await fetch(GATEWAY_ENDPOINTS.AGENTS.EXECUTION.HEALTH, {
+      const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.HEALTH, {
         method: 'GET',
         headers: this.getRequestHeaders()
       });
@@ -232,13 +247,114 @@ export class ExecutionControlService {
         throw new Error(`Health check failed: ${response.status} ${response.statusText}`);
       }
 
-      const health = await response.json();
-      logger.info(LogCategory.CHAT_FLOW, 'HIL service health check successful', health);
+      const interactive: InteractiveHealth = await response.json();
+      // Map the capability-router shape to the legacy ExecutionHealth
+      // shape so existing callers continue to work.
+      const health: ExecutionHealth = {
+        status: interactive.status === 'healthy' ? 'healthy' : 'down',
+        service: 'mate-interactive',
+        features: {
+          human_in_loop: interactive.features.human_in_loop,
+          approval_workflow: interactive.features.approval_workflow,
+          tool_authorization: interactive.features.tool_authorization,
+          total_interrupts: interactive.graph_info.total_interrupts ?? 0,
+        },
+        graph_info: {
+          nodes: 0,
+          durable: interactive.graph_info.durable ?? false,
+          checkpoints: interactive.graph_info.durable ?? false,
+          environment: 'mate',
+        },
+      };
+      logger.debug(LogCategory.CHAT_FLOW, 'HIL service health check successful', health);
       return health;
     } catch (error) {
-      logger.error(LogCategory.CHAT_FLOW, 'HIL service health check failed', { error });
+      logger.debug(LogCategory.CHAT_FLOW, 'HIL probe inactive — interrupt handling stays enabled', { error });
       throw error;
     }
+  }
+
+  // ================================================================================
+  // /v1/interactive/* client — capability router consumption
+  // (xenoISA/isA_Mate#404, contract INTERACTIVE v1)
+  // ================================================================================
+
+  /**
+   * List pending HIL interrupts for the authenticated user.
+   */
+  async listInterrupts(opts: { cursor?: string; limit?: number } = {}): Promise<InterruptListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const url = `${GATEWAY_ENDPOINTS.MATE.INTERACTIVE.LIST}?${qs.toString()}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.getRequestHeaders('listInterrupts'),
+    });
+    if (!response.ok) {
+      throw new Error(`listInterrupts failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Get a single interrupt by request id.
+   */
+  async getInterrupt(requestId: string): Promise<Interrupt> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.DETAIL(requestId), {
+      method: 'GET',
+      headers: this.getRequestHeaders('getInterrupt'),
+    });
+    if (!response.ok) {
+      throw new Error(`getInterrupt failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Submit the user response for a pending interrupt and resume execution.
+   */
+  async respondToInterrupt(requestId: string, body: InterruptResponseBody): Promise<InteractiveResumeResult> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.RESPOND(requestId), {
+      method: 'POST',
+      headers: this.getRequestHeaders('respondToInterrupt'),
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`respondToInterrupt failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Extend the timeout on a pending interrupt.
+   */
+  async extendTimeout(requestId: string, seconds: number): Promise<ExpiryInfo> {
+    if (!Number.isInteger(seconds) || seconds < 1 || seconds > 3600) {
+      throw new RangeError(`extendTimeout: seconds must be integer in [1, 3600], got ${seconds}`);
+    }
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.TIMEOUT(requestId, seconds), {
+      method: 'PATCH',
+      headers: this.getRequestHeaders('extendTimeout'),
+    });
+    if (!response.ok) {
+      throw new Error(`extendTimeout failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Get approval/response audit history for a completed interrupt.
+   */
+  async getInterruptAudit(requestId: string): Promise<AuditEntry[]> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.AUDIT(requestId), {
+      method: 'GET',
+      headers: this.getRequestHeaders('getInterruptAudit'),
+    });
+    if (!response.ok) {
+      throw new Error(`getInterruptAudit failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
   }
 
   /**

--- a/src/api/__tests__/ExecutionControlService.test.ts
+++ b/src/api/__tests__/ExecutionControlService.test.ts
@@ -7,6 +7,7 @@ vi.mock('../BaseApiService', () => ({
 }));
 
 // Mock gatewayConfig
+const MATE_BASE = 'http://localhost:18789';
 vi.mock('../../config/gatewayConfig', () => ({
   GATEWAY_CONFIG: {
     BASE_URL: 'http://localhost:9080',
@@ -20,6 +21,16 @@ vi.mock('../../config/gatewayConfig', () => ({
         ROLLBACK: 'http://localhost:9080/agents/api/execution/rollback',
         RESUME: 'http://localhost:9080/agents/api/execution/resume',
         RESUME_STREAM: 'http://localhost:9080/agents/api/execution/resume-stream',
+      },
+    },
+    MATE: {
+      INTERACTIVE: {
+        HEALTH: 'http://localhost:18789/v1/interactive/health',
+        LIST: 'http://localhost:18789/v1/interactive/interrupts',
+        DETAIL: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}`,
+        RESPOND: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/respond`,
+        TIMEOUT: (id: string, s: number) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/timeout/${s}`,
+        AUDIT: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
       },
     },
   },
@@ -68,36 +79,34 @@ describe('ExecutionControlService', () => {
   // ============================================================================
 
   describe('getHealth', () => {
-    test('returns health data on success', async () => {
-      const healthData = {
+    test('probes the MATE /v1/interactive/health endpoint and maps to ExecutionHealth', async () => {
+      const interactiveHealth = {
         status: 'healthy',
-        service: 'execution-control',
         features: {
           human_in_loop: true,
           approval_workflow: true,
           tool_authorization: true,
-          total_interrupts: 5,
         },
         graph_info: {
-          nodes: 10,
           durable: true,
-          checkpoints: true,
-          environment: 'development',
+          total_interrupts: 5,
         },
       };
       mockFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue(healthData),
+        json: vi.fn().mockResolvedValue(interactiveHealth),
       });
 
       const result = await service.getHealth();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:9080/agents/api/execution/health',
+        'http://localhost:18789/v1/interactive/health',
         expect.objectContaining({ method: 'GET' })
       );
       expect(result.status).toBe('healthy');
       expect(result.features.human_in_loop).toBe(true);
+      expect(result.features.total_interrupts).toBe(5);
+      expect(result.service).toBe('mate-interactive');
     });
 
     test('throws on non-ok response', async () => {
@@ -116,6 +125,120 @@ describe('ExecutionControlService', () => {
       mockFetch.mockRejectedValue(new Error('Connection refused'));
 
       await expect(service.getHealth()).rejects.toThrow('Connection refused');
+    });
+
+    test('logs at debug (not warn/error) when probe fails — silences misleading warn at ChatModule.tsx:331', async () => {
+      const { logger } = await import('../../utils/logger');
+      mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' });
+
+      await expect(service.getHealth()).rejects.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // Interactive capability router (/v1/interactive/*) — xenoISA/isA_Mate#404
+  // ============================================================================
+
+  describe('Interactive capability client', () => {
+    test('listInterrupts calls the correct endpoint with cursor/limit', async () => {
+      const payload = { pending: [], active_sessions: [], next_cursor: null };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.listInterrupts({ cursor: 'c1', limit: 10 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts?cursor=c1&limit=10',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result).toEqual(payload);
+    });
+
+    test('getInterrupt URL-encodes the request_id', async () => {
+      const payload = {
+        id: 'id with spaces',
+        type: 'ask_human',
+        title: 't',
+        message: 'm',
+        timestamp: '2026-04-20T00:00:00Z',
+        thread_id: 'x',
+        expires_at: null,
+        security_level: 'medium',
+        data: {},
+      };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      await service.getInterrupt('id with spaces');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/id%20with%20spaces',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    test('respondToInterrupt POSTs the body to /respond', async () => {
+      const payload = { session_id: 'req-1', status: 'resumed' };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.respondToInterrupt('req-1', {
+        response: { email: 'a@b.com' },
+        action: 'continue',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/respond',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ response: { email: 'a@b.com' }, action: 'continue' }),
+        })
+      );
+      expect(result.status).toBe('resumed');
+    });
+
+    test('extendTimeout rejects out-of-bounds seconds locally (no fetch)', async () => {
+      await expect(service.extendTimeout('req-1', 0)).rejects.toThrow(RangeError);
+      await expect(service.extendTimeout('req-1', 3601)).rejects.toThrow(RangeError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('extendTimeout PATCHes the correct URL for valid seconds', async () => {
+      const payload = { request_id: 'req-1', new_expires_at: '2026-04-20T01:00:00Z' };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.extendTimeout('req-1', 120);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/timeout/120',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+      expect(result.new_expires_at).toBe('2026-04-20T01:00:00Z');
+    });
+
+    test('getInterruptAudit returns the audit array', async () => {
+      const audit = [
+        { timestamp: '2026-04-20T00:00:00Z', user_id: 'u1', response: 'ok', latency_ms: 100, outcome: 'approved' },
+      ];
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(audit) });
+
+      const result = await service.getInterruptAudit('req-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/audit',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].outcome).toBe('approved');
+    });
+
+    test('each method propagates non-ok responses as Errors', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+      await expect(service.getInterrupt('missing')).rejects.toThrow(/404/);
+      await expect(service.respondToInterrupt('missing', { response: 'x' })).rejects.toThrow(/404/);
+      await expect(service.getInterruptAudit('missing')).rejects.toThrow(/404/);
     });
   });
 
@@ -337,7 +460,11 @@ describe('ExecutionControlService', () => {
     test('returns true when health check succeeds', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ status: 'healthy' }),
+        json: vi.fn().mockResolvedValue({
+          status: 'healthy',
+          features: { human_in_loop: true, approval_workflow: true, tool_authorization: true },
+          graph_info: { durable: true, total_interrupts: 0 },
+        }),
       });
 
       const result = await service.isServiceAvailable();
@@ -351,6 +478,17 @@ describe('ExecutionControlService', () => {
       const result = await service.isServiceAvailable();
 
       expect(result).toBe(false);
+    });
+
+    test('returns false silently (no warn/error) on 502 — fixes ChatModule.tsx:331 spam', async () => {
+      const { logger } = await import('../../utils/logger');
+      mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' });
+
+      const result = await service.isServiceAvailable();
+
+      expect(result).toBe(false);
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/api/types/interactive.ts
+++ b/src/api/types/interactive.ts
@@ -1,0 +1,79 @@
+/**
+ * Types for the /v1/interactive/* capability router on the isA_Mate gateway
+ * (xenoISA/isA_Mate#404). Mirrors the Pydantic DTOs in
+ * isa_mate/execution/hil_router.py and the App_SDK InteractiveClient
+ * (xenoISA/isA_App_SDK#304).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * xenoISA/isA_App_SDK#304 publishes InteractiveClient and its types.
+ */
+
+export type InterruptType =
+  | 'input_validation'
+  | 'tool_authorization'
+  | 'review_and_edit'
+  | 'approve_reject'
+  | 'ask_human'
+  | 'input_collection'
+  | 'oauth'
+  | 'credential_usage';
+
+export type SecurityLevel = 'low' | 'medium' | 'high' | 'critical';
+export type ResponseAction = 'continue' | 'skip' | 'reject';
+export type ResumeStatus = 'resumed' | 'completed' | 'failed';
+export type AuditOutcome = 'approved' | 'rejected' | 'timeout' | 'resumed';
+
+export interface Interrupt {
+  id: string;
+  type: InterruptType;
+  title: string;
+  message: string;
+  timestamp: string; // ISO8601
+  thread_id: string;
+  expires_at: string | null;
+  security_level: SecurityLevel;
+  data: Record<string, unknown>;
+}
+
+export interface InterruptListResponse {
+  pending: Interrupt[];
+  active_sessions: string[];
+  next_cursor: string | null;
+}
+
+export interface InterruptResponseBody {
+  response: unknown;
+  metadata?: Record<string, unknown>;
+  action?: ResponseAction;
+}
+
+export interface ResumeResult {
+  session_id: string;
+  status: ResumeStatus;
+}
+
+export interface ExpiryInfo {
+  request_id: string;
+  new_expires_at: string;
+}
+
+export interface AuditEntry {
+  timestamp: string;
+  user_id: string;
+  response: unknown;
+  latency_ms: number;
+  outcome: AuditOutcome;
+}
+
+export interface InteractiveHealth {
+  status: 'healthy' | 'down';
+  features: {
+    human_in_loop: boolean;
+    approval_workflow: boolean;
+    tool_authorization: boolean;
+  };
+  graph_info: {
+    durable: boolean;
+    total_interrupts: number;
+  };
+}

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -159,6 +159,29 @@ export const GATEWAY_ENDPOINTS = {
       },
       HEALTH: buildMateEndpoint('/health'),
       AUTONOMOUS_EVENTS: buildMateEndpoint('/v1/autonomous/events'),
+      // Human-in-the-Loop capability router — maps to xenoISA/isA_Mate#404
+      // /v1/interactive/*. Replaces the defunct AGENTS.EXECUTION probe that
+      // returns 502 through APISIX (→ isA_Mate PR #424).
+      INTERACTIVE: {
+        HEALTH: buildMateEndpoint('/v1/interactive/health'),
+        LIST: buildMateEndpoint('/v1/interactive/interrupts'),
+        DETAIL: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}`,
+          ),
+        RESPOND: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/respond`,
+          ),
+        TIMEOUT: (id: string, seconds: number) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/timeout/${seconds}`,
+          ),
+        AUDIT: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
+          ),
+      },
     };
   })(),
 

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -325,10 +325,14 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
         // REMOVED: HIL回调注册 - SSEParser已删除
 
-        // 检查HIL服务是否可用
+        // 检查HIL服务是否可用 (xenoISA/isA_Mate#404 → /v1/interactive/health)
         const isServiceAvailable = await executionControlService.isServiceAvailable();
         if (!isServiceAvailable) {
-          log.warn('HIL service not available, but HIL interrupt handling enabled for ask_human');
+          // Downgraded from warn → debug. HIL interrupt handling stays enabled
+          // regardless of probe result (ask_human still works via SSE); the
+          // previous warn caused misleading console noise on every page load
+          // when the backend wasn't yet serving /v1/interactive.
+          log.debug('HIL probe inactive — interrupt handling stays enabled');
           return;
         }
 


### PR DESCRIPTION
## Summary

Migrates the HIL integration in `ExecutionControlService` + `ChatModule` to consume the new `/v1/interactive/*` capability router on isA_Mate (xenoISA/isA_Mate#424 / #404). Swaps the health probe off the defunct `AGENTS.EXECUTION.HEALTH` path — which APISIX routes to the retired `isA_Agent` service at port 8080, yielding 502 — and onto `MATE.INTERACTIVE.HEALTH`, which the Mate gateway serves directly. Downgrades the misleading warn at `ChatModule.tsx:331` to debug.

Closes #302
Parent Epic: xenoISA/isA_Mate#404

## Changes

### `src/config/gatewayConfig.ts`
- New `MATE.INTERACTIVE` block with 6 endpoints: `HEALTH`, `LIST`, `DETAIL(id)`, `RESPOND(id)`, `TIMEOUT(id, s)`, `AUDIT(id)`
- Legacy `AGENTS.EXECUTION` block preserved — callers in `useChatStore.ts`, `useMessageStore.ts`, `hilHandlers.ts` unaffected

### `src/api/ExecutionControlService.ts`
- `getHealth()` now probes `MATE.INTERACTIVE.HEALTH` and maps the new `InteractiveHealth` shape to the legacy `ExecutionHealth` for backwards compat
- Error logging downgraded from `logger.error` → `logger.debug` — failures are no longer noisy
- Five new methods: `listInterrupts`, `getInterrupt`, `respondToInterrupt`, `extendTimeout`, `getInterruptAudit`
- `extendTimeout` validates `seconds ∈ [1, 3600]` locally before hitting the network

### `src/modules/ChatModule.tsx:331`
- `log.warn('HIL service not available, but HIL interrupt handling enabled for ask_human')` → `log.debug('HIL probe inactive — interrupt handling stays enabled')`

### `src/api/types/interactive.ts` (new)
- TS interfaces matching the INTERACTIVE v1 contract — `Interrupt`, `InterruptListResponse`, `InterruptResponseBody`, `ResumeResult`, `ExpiryInfo`, `AuditEntry`, `InteractiveHealth`. Imported as `InteractiveResumeResult` in ExecutionControlService to avoid collision with the legacy `ResumeResult` used by `hilHandlers.ts`
- TODO noted: replace with `@isa/transport` imports once xenoISA/isA_App_SDK#304 publishes `InteractiveClient`

### `docs/product/PRD.md`
- Adds "Agent Capability Consumption" epic describing the E1–E6 UI consumption plan (part of the capability-driven facade work)

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L2 Component (Vitest + mocked fetch) | 28 | Pass (was 23, added 5 new + updated existing getHealth / isServiceAvailable) |

Run: `pnpm test src/api/__tests__/ExecutionControlService.test.ts` → 28 passed.

Key new assertions:
- `getHealth` calls `/v1/interactive/health` (not the old AGENTS path)
- 502 triggers `logger.debug` only — no `warn`/`error` (regression guard for the ChatModule spam)
- `extendTimeout` locally rejects out-of-bounds seconds before any network call
- `respondToInterrupt` body shape matches contract

## Test plan (post-merge, manual)

- [ ] Start Mate locally (`NEXT_PUBLIC_MATE_URL=http://localhost:18789 pnpm dev`) and confirm no `HIL service not available` warn in DevTools console
- [ ] `curl http://localhost:18789/v1/interactive/health` → 200 with features.human_in_loop=true
- [ ] Existing chat flow unchanged — type a message, see stream
- [ ] Legacy HIL resume path (`hilHandlers.ts → resumeExecutionStream`) still works

## Dependencies

- **Backend**: [xenoISA/isA_Mate#424](https://github.com/xenoISA/isA_Mate/pull/424) ships the `/v1/interactive/*` router. Until that merges + deploys, `isServiceAvailable()` silently returns false but no console spam.
- **TS client**: xenoISA/isA_App_SDK#304 will publish `InteractiveClient`. When it lands, swap the local stubs in `src/api/types/interactive.ts` for `import { ... } from '@isa/transport'`.