### PR TITLE
feat(ui): ProactiveService + ObservabilityService API clients

### DIFF
--- a/src/api/ObservabilityService.ts
+++ b/src/api/ObservabilityService.ts
@@ -1,0 +1,74 @@
+/**
+ * ObservabilityService — client for the isA_Mate /v1/observability/*
+ * capability router (xenoISA/isA_Mate#406 / #426). Powers the cost
+ * badge + audit drawer surfaces.
+ *
+ * TODO: Replace with `import { ObservabilityClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#311 publishes.
+ */
+
+import { logger, LogCategory } from '../utils/logger';
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  AuditFilter,
+  AuditListResponse,
+  ExecutionMetrics,
+  MetricsFilter,
+} from './types/observability';
+
+export class ObservabilityService {
+  private getHeaders(operation?: string): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    } else if (operation) {
+      logger.debug(
+        LogCategory.CHAT_FLOW,
+        `No auth token for ${operation} — request may 401`,
+      );
+    }
+    return headers;
+  }
+
+  async getMetrics(filter: MetricsFilter = {}): Promise<ExecutionMetrics> {
+    const qs = new URLSearchParams();
+    if (filter.since) qs.set('since', toISO(filter.since));
+    if (filter.until) qs.set('until', toISO(filter.until));
+    if (filter.agent_id) qs.set('agent_id', filter.agent_id);
+    if (filter.session_id) qs.set('session_id', filter.session_id);
+    const path = qs.toString()
+      ? `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS}?${qs.toString()}`
+      : GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS;
+    const resp = await fetch(path, {
+      method: 'GET',
+      headers: this.getHeaders('getMetrics'),
+    });
+    if (!resp.ok) throw new Error(`getMetrics failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getAudit(filter: AuditFilter = {}): Promise<AuditListResponse> {
+    const qs = new URLSearchParams();
+    if (filter.action) qs.set('action', filter.action);
+    if (filter.since) qs.set('since', toISO(filter.since));
+    if (filter.until) qs.set('until', toISO(filter.until));
+    if (filter.session_id) qs.set('session_id', filter.session_id);
+    qs.set('limit', String(filter.limit ?? 100));
+    if (filter.cursor) qs.set('cursor', filter.cursor);
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.AUDIT}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('getAudit') },
+    );
+    if (!resp.ok) throw new Error(`getAudit failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+}
+
+function toISO(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export const observabilityService = new ObservabilityService();
+export default observabilityService;

--- a/src/api/ProactiveService.ts
+++ b/src/api/ProactiveService.ts
@@ -1,0 +1,169 @@
+/**
+ * ProactiveService — client for the isA_Mate /v1/proactive/* capability
+ * router (xenoISA/isA_Mate#405 / #425). Wraps the HTTP CRUD endpoints
+ * plus the /v1/autonomous/events SSE stream.
+ *
+ * TODO: Replace with `import { ProactiveClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#311 publishes.
+ */
+
+import { logger, LogCategory } from '../utils/logger';
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  AutonomousFireEvent,
+  Trigger,
+  TriggerInput,
+  TriggerListResponse,
+  TriggerPatch,
+  TriggerRunListResponse,
+  TriggerTestRequest,
+  TriggerTestResult,
+} from './types/proactive';
+
+export interface ListTriggersOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListTriggerRunsOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+export class ProactiveService {
+  private getHeaders(operation?: string): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    } else if (operation) {
+      logger.debug(
+        LogCategory.CHAT_FLOW,
+        `No auth token for ${operation} — request may 401`,
+      );
+    }
+    return headers;
+  }
+
+  async listTriggers(
+    opts: ListTriggersOptions = {},
+  ): Promise<TriggerListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGERS}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listTriggers') },
+    );
+    if (!resp.ok) throw new Error(`listTriggers failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async createTrigger(body: TriggerInput): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGERS, {
+      method: 'POST',
+      headers: this.getHeaders('createTrigger'),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw new Error(`createTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getTrigger(id: string): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id), {
+      method: 'GET',
+      headers: this.getHeaders('getTrigger'),
+    });
+    if (!resp.ok) throw new Error(`getTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async updateTrigger(id: string, patch: TriggerPatch): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id), {
+      method: 'PATCH',
+      headers: this.getHeaders('updateTrigger'),
+      body: JSON.stringify(patch),
+    });
+    if (!resp.ok) throw new Error(`updateTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async deleteTrigger(id: string, opts: { hard?: boolean } = {}): Promise<void> {
+    const path = opts.hard
+      ? `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id)}?hard=true`
+      : GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id);
+    const resp = await fetch(path, {
+      method: 'DELETE',
+      headers: this.getHeaders('deleteTrigger'),
+    });
+    if (!resp.ok && resp.status !== 204) {
+      throw new Error(`deleteTrigger failed: ${resp.status} ${resp.statusText}`);
+    }
+  }
+
+  async testTrigger(
+    id: string,
+    req: TriggerTestRequest,
+  ): Promise<TriggerTestResult> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TEST(id), {
+      method: 'POST',
+      headers: this.getHeaders('testTrigger'),
+      body: JSON.stringify(req),
+    });
+    if (!resp.ok) throw new Error(`testTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listRuns(
+    id: string,
+    opts: ListTriggerRunsOptions = {},
+  ): Promise<TriggerRunListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.RUNS(id)}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listRuns') },
+    );
+    if (!resp.ok) throw new Error(`listRuns failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  /**
+   * Subscribe to trigger fires via /v1/autonomous/events SSE.
+   *
+   * Returns an unsubscribe function. Browser-native EventSource is
+   * used — note that EventSource cannot send custom headers, so the
+   * Mate gateway must accept cookies for auth, or the caller must
+   * ensure `NEXT_PUBLIC_MATE_URL` points at a deployment where the
+   * fire stream is publicly readable per-user (e.g. via a signed URL).
+   */
+  subscribeToFires(handler: (event: AutonomousFireEvent) => void): () => void {
+    if (typeof EventSource === 'undefined') {
+      throw new Error(
+        'ProactiveService.subscribeToFires requires EventSource (browser env)',
+      );
+    }
+    const source = new EventSource(
+      GATEWAY_ENDPOINTS.MATE.AUTONOMOUS_EVENTS,
+      { withCredentials: true },
+    );
+    const listener = (ev: MessageEvent) => {
+      try {
+        const payload = JSON.parse(ev.data) as AutonomousFireEvent;
+        handler(payload);
+      } catch {
+        // Ignore malformed / heartbeat messages
+      }
+    };
+    source.addEventListener('trigger.fired', listener as EventListener);
+    return () => {
+      source.removeEventListener('trigger.fired', listener as EventListener);
+      source.close();
+    };
+  }
+}
+
+export const proactiveService = new ProactiveService();
+export default proactiveService;

--- a/src/api/__tests__/ObservabilityService.test.ts
+++ b/src/api/__tests__/ObservabilityService.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ObservabilityService } from '../ObservabilityService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      OBSERVABILITY: {
+        METRICS: 'http://localhost:18789/v1/observability/metrics',
+        AUDIT: 'http://localhost:18789/v1/observability/audit',
+      },
+    },
+  },
+}));
+
+const MATE = 'http://localhost:18789';
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LogCategory: { CHAT_FLOW: 'chat_flow' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ObservabilityService', () => {
+  let service: ObservabilityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ObservabilityService();
+  });
+
+  function ok(data: unknown) {
+    return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+  }
+
+  function lastCall(): [string, RequestInit] {
+    return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  }
+
+  test('getMetrics hits /v1/observability/metrics with no query for empty filter', async () => {
+    mockFetch.mockResolvedValue(ok({
+      nodes_executed: 0, tool_calls: 0, model_calls: 0,
+      tokens_used: { input: 0, output: 0 }, cost_usd: 0,
+      window_start: null, window_end: null,
+    }));
+    await service.getMetrics();
+    expect(lastCall()[0]).toBe(`${MATE}/v1/observability/metrics`);
+  });
+
+  test('getMetrics serializes Date filters to ISO8601', async () => {
+    mockFetch.mockResolvedValue(ok({
+      nodes_executed: 0, tool_calls: 0, model_calls: 0,
+      tokens_used: { input: 0, output: 0 }, cost_usd: 0,
+      window_start: null, window_end: null,
+    }));
+    const since = new Date('2026-04-01T00:00:00Z');
+    await service.getMetrics({ since, agent_id: 'a', session_id: 's' });
+    const [url] = lastCall();
+    expect(url).toContain('since=2026-04-01T00%3A00%3A00.000Z');
+    expect(url).toContain('agent_id=a');
+    expect(url).toContain('session_id=s');
+  });
+
+  test('getAudit defaults limit to 100', async () => {
+    mockFetch.mockResolvedValue(ok({ entries: [], total: 0, next_cursor: null }));
+    await service.getAudit();
+    expect(lastCall()[0]).toBe(`${MATE}/v1/observability/audit?limit=100`);
+  });
+
+  test('getAudit forwards filters and cursor', async () => {
+    mockFetch.mockResolvedValue(ok({ entries: [], total: 0, next_cursor: null }));
+    await service.getAudit({
+      action: 'tool_call',
+      session_id: 's1',
+      limit: 25,
+      cursor: '50',
+    });
+    const [url] = lastCall();
+    expect(url).toContain('action=tool_call');
+    expect(url).toContain('session_id=s1');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('cursor=50');
+  });
+
+  test('non-ok response throws with status text', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server' });
+    await expect(service.getAudit()).rejects.toThrow(/500/);
+  });
+});

--- a/src/api/__tests__/ProactiveService.test.ts
+++ b/src/api/__tests__/ProactiveService.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ProactiveService } from '../ProactiveService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      PROACTIVE: {
+        TRIGGERS: 'http://localhost:18789/v1/proactive/triggers',
+        TRIGGER: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}`,
+        TEST: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}/test`,
+        RUNS: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}/runs`,
+      },
+      AUTONOMOUS_EVENTS: 'http://localhost:18789/v1/autonomous/events',
+    },
+  },
+}));
+
+const MATE = 'http://localhost:18789';
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LogCategory: { CHAT_FLOW: 'chat_flow' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ProactiveService', () => {
+  let service: ProactiveService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ProactiveService();
+  });
+
+  function ok(data: unknown) {
+    return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+  }
+
+  function lastCall(): [string, RequestInit] {
+    return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  }
+
+  test('listTriggers hits /v1/proactive/triggers with limit=50 default', async () => {
+    mockFetch.mockResolvedValue(ok({ triggers: [], next_cursor: null }));
+    await service.listTriggers();
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers?limit=50`);
+    expect(init.method).toBe('GET');
+  });
+
+  test('listTriggers forwards cursor and limit', async () => {
+    mockFetch.mockResolvedValue(ok({ triggers: [], next_cursor: null }));
+    await service.listTriggers({ cursor: 'c1', limit: 10 });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers?cursor=c1&limit=10`);
+  });
+
+  test('createTrigger POSTs the body', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 't', type: 'cron', name: 'n', condition: {},
+      action_prompt: 'p', enabled: true,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    const input = {
+      type: 'cron' as const, name: 'n',
+      condition: { schedule: '0 9 * * *' }, action_prompt: 'p',
+    };
+    await service.createTrigger(input);
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify(input));
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer mock-token');
+  });
+
+  test('getTrigger URL-encodes id', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'id with spaces', type: 'cron', name: 't', condition: {},
+      action_prompt: 'p', enabled: true,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    await service.getTrigger('id with spaces');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/id%20with%20spaces`);
+  });
+
+  test('updateTrigger PATCHes partial body', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 't', type: 'cron', name: 'renamed', condition: {},
+      action_prompt: 'p', enabled: false,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    await service.updateTrigger('t', { name: 'renamed', enabled: false });
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers/t`);
+    expect(init.method).toBe('PATCH');
+    expect(init.body).toBe(JSON.stringify({ name: 'renamed', enabled: false }));
+  });
+
+  test('deleteTrigger soft by default', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', json: vi.fn() });
+    await service.deleteTrigger('t');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t`);
+    expect(lastCall()[1].method).toBe('DELETE');
+  });
+
+  test('deleteTrigger with hard=true appends query', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', json: vi.fn() });
+    await service.deleteTrigger('t', { hard: true });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t?hard=true`);
+  });
+
+  test('testTrigger POSTs mock_event to /test', async () => {
+    mockFetch.mockResolvedValue(ok({
+      would_fire: true, reason: 'match', resolved_prompt: 'p', matched_conditions: {},
+    }));
+    await service.testTrigger('t', { mock_event: { x: 1 } });
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers/t/test`);
+    expect(init.method).toBe('POST');
+  });
+
+  test('listRuns hits /runs with limit', async () => {
+    mockFetch.mockResolvedValue(ok({ runs: [], next_cursor: null }));
+    await service.listRuns('t', { limit: 25 });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t/runs?limit=25`);
+  });
+
+  test('propagates non-ok responses as errors', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(service.getTrigger('missing')).rejects.toThrow(/404/);
+  });
+});

--- a/src/api/types/observability.ts
+++ b/src/api/types/observability.ts
@@ -1,0 +1,56 @@
+/**
+ * Types for the isA_Mate /v1/observability/* capability router
+ * (xenoISA/isA_Mate#406 / #426).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * @isa/transport publishes ObservabilityClient.
+ */
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+}
+
+export interface ExecutionMetrics {
+  nodes_executed: number;
+  tool_calls: number;
+  model_calls: number;
+  tokens_used: TokenUsage;
+  cost_usd: number;
+  window_start: string | null;
+  window_end: string | null;
+}
+
+export type ObservabilityAuditOutcome = 'success' | 'failure' | 'unknown';
+
+export interface ObservabilityAuditEntry {
+  timestamp: string;
+  action: string;
+  user_id: string;
+  result: ObservabilityAuditOutcome;
+  cost_usd: number | null;
+  session_id: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface AuditListResponse {
+  entries: ObservabilityAuditEntry[];
+  total: number;
+  next_cursor: string | null;
+}
+
+export interface MetricsFilter {
+  since?: string | Date;
+  until?: string | Date;
+  agent_id?: string;
+  session_id?: string;
+}
+
+export interface AuditFilter {
+  action?: string;
+  since?: string | Date;
+  until?: string | Date;
+  session_id?: string;
+  limit?: number;
+  cursor?: string;
+}

--- a/src/api/types/proactive.ts
+++ b/src/api/types/proactive.ts
@@ -1,0 +1,77 @@
+/**
+ * Types for the isA_Mate /v1/proactive/* capability router
+ * (xenoISA/isA_Mate#405 / #425). Mirrors the Pydantic DTOs in
+ * isa_mate/execution/proactive_router.py and the TypeScript types in
+ * @isa/transport's ProactiveClient (xenoISA/isA_App_SDK#311).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * @isa/transport publishes ProactiveClient.
+ */
+
+export type TriggerType = 'cron' | 'webhook' | 'threshold' | 'event';
+
+export interface TriggerInput {
+  type: TriggerType;
+  name: string;
+  condition?: Record<string, unknown>;
+  action_prompt: string;
+  enabled?: boolean;
+}
+
+export interface Trigger {
+  id: string;
+  type: TriggerType;
+  name: string;
+  condition: Record<string, unknown>;
+  action_prompt: string;
+  enabled: boolean;
+  created_at: string;
+  next_fire: string | null;
+  last_result: Record<string, unknown> | null;
+}
+
+export interface TriggerListResponse {
+  triggers: Trigger[];
+  next_cursor: string | null;
+}
+
+export interface TriggerPatch {
+  name?: string;
+  condition?: Record<string, unknown>;
+  action_prompt?: string;
+  enabled?: boolean;
+}
+
+export interface TriggerTestRequest {
+  mock_event: Record<string, unknown>;
+  apply_rate_limit?: boolean;
+}
+
+export interface TriggerTestResult {
+  would_fire: boolean;
+  reason: string;
+  resolved_prompt: string;
+  matched_conditions: Record<string, unknown>;
+}
+
+export interface TriggerRun {
+  id: string;
+  trigger_id: string;
+  fired_at: string;
+  session_id: string | null;
+  result: Record<string, unknown>;
+  duration_ms: number | null;
+  error: string | null;
+}
+
+export interface TriggerRunListResponse {
+  runs: TriggerRun[];
+  next_cursor: string | null;
+}
+
+export interface AutonomousFireEvent {
+  trigger_id: string;
+  fire_reason: string;
+  session_id: string;
+  timestamp: string;
+}

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -182,6 +182,28 @@ export const GATEWAY_ENDPOINTS = {
             `/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
           ),
       },
+      // Proactive capability router — maps to xenoISA/isA_Mate#405 /v1/proactive/*
+      // and xenoISA/isA_Mate#425 autonomous SSE events.
+      PROACTIVE: {
+        TRIGGERS: buildMateEndpoint('/v1/proactive/triggers'),
+        TRIGGER: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}`,
+          ),
+        TEST: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}/test`,
+          ),
+        RUNS: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}/runs`,
+          ),
+      },
+      // Observability capability router — maps to xenoISA/isA_Mate#406 + #426
+      OBSERVABILITY: {
+        METRICS: buildMateEndpoint('/v1/observability/metrics'),
+        AUDIT: buildMateEndpoint('/v1/observability/audit'),
+      },
     };
   })(),
 


### PR DESCRIPTION
## Summary

Wave 2 frontend plumbing: gateway config entries, TypeScript types, and API client services for the isA_Mate proactive and observability capability routers. Surfaces UI (triggers panel, cost badge, audit drawer) land in follow-up PRs — this one unblocks all of them.

Stacked on `feat/302-hil-migrate-interactive` (PR #305) — merges cleanly once that lands.

Parent Epic: xenoISA/isA_Mate#405 (E2), xenoISA/isA_Mate#406 (E3)
Backend: xenoISA/isA_Mate#425, xenoISA/isA_Mate#426
TS client: xenoISA/isA_App_SDK#311

## New files

```
src/config/gatewayConfig.ts       + MATE.PROACTIVE, MATE.OBSERVABILITY blocks
src/api/types/proactive.ts        Trigger + TriggerListResponse + AutonomousFireEvent DTOs
src/api/types/observability.ts    ExecutionMetrics + AuditEntry DTOs
src/api/ProactiveService.ts       CRUD + testTrigger + listRuns + subscribeToFires
src/api/ObservabilityService.ts   getMetrics + getAudit (ISO8601/Date filter handling)
src/api/__tests__/ProactiveService.test.ts
src/api/__tests__/ObservabilityService.test.ts
```

All DTO modules carry `// TODO: Replace with '@isa/transport'` markers so we swap to the published client when xenoISA/isA_App_SDK#311 lands.

## Example usage

```typescript
import { proactiveService } from '@/api/ProactiveService';
import { observabilityService } from '@/api/ObservabilityService';

const triggers = await proactiveService.listTriggers({ limit: 20 });
const created = await proactiveService.createTrigger({
  type: 'cron',
  name: 'morning-brief',
  condition: { schedule: '0 9 * * *' },
  action_prompt: 'Summarise overnight activity',
});

const unsubscribe = proactiveService.subscribeToFires((ev) => {
  console.log('trigger fired', ev.trigger_id);
});

const metrics = await observabilityService.getMetrics({
  since: new Date('2026-04-01'),
});
const audit = await observabilityService.getAudit({ action: 'tool_call', limit: 50 });
```

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L2 Component (Vitest + mocked fetch) | 15 | Pass (10 proactive + 5 observability) |

Run: `pnpm test src/api/__tests__/ProactiveService.test.ts src/api/__tests__/ObservabilityService.test.ts` → 15 passed.

Coverage highlights:
- CRUD URLs with proper URL-encoding for trigger ids
- Soft (`DELETE`) vs hard (`?hard=true`) delete
- Default `limit=50` on list, `limit=100` on audit
- Query string forwarding for cursors and filters
- Date → ISO8601 serialization for `since`/`until`
- Non-ok responses throw with status text
- Auth header (`Bearer mock-token`) forwarded when token is available

## Out of scope (follow-ups per epic plan)

- **Triggers settings panel** — CRUD UI via `proactiveService`
- **Autonomous proactive messages** — chat-integrated surface fed by `subscribeToFires`
- **Cost badge** in chat header via `observabilityService.getMetrics`
- **Audit drawer** via `observabilityService.getAudit`

The API layer shipped here is the dependency for all four. Splitting the UI work into its own PRs keeps review cognitive load manageable and lets design decisions land incrementally.