### PR TITLE
feat(ui): AutonomousService + ReactiveService API clients

### DIFF
--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -309,6 +309,75 @@ These existing capabilities set isA_ apart and should be preserved/enhanced, not
 - Computer use / screen control
 - Dispatch (phone → desktop)
 
+### Epic: Agent Capability Consumption — Surface SDK Features in Chat
+
+**Priority**: P0 → P3 (phased E1 → E6)
+**Milestone**: v1.0 — Unified Platform
+**Status**: Ready for design
+
+Currently the frontend reaches a narrow slice of isA_Agent_SDK through isA_Mate: chat, memory, scheduler, tracker. Users and agents cannot see or trigger 20+ SDK services (HIL, triggers, background jobs, webhooks, knowledge graph, vector search, checkpoints, cost metrics, audit) because there is no HTTP surface. The gateway plan (isA_Mate §2.30) exposes 5 capability routers under `/v1/{interactive,proactive,observability,persistence,responsive,autonomous,reactive}/*`. This epic tracks the isA_ UI side of consumption: which chat surfaces render which capability.
+
+**Why conversation-first matters:** isA_ is a companion, not a dashboard. Every capability lands in chat — HIL approvals surface as inline interrupts, trigger fires appear as proactive messages, cost/audit live in a drawer, checkpoints restore via slash command. No standalone settings pages.
+
+#### Sub-Epics
+
+**E1. Interactive (P0) — HIL Consumption**
+- `ExecutionControlService` polls `/v1/interactive/interrupts` (replaces broken `/agents/execution/health` probe)
+- `HILInterruptModal` renders ask_human, tool_authorization, review_and_edit variants
+- `HILInteractionManager` POSTs `/v1/interactive/interrupts/{id}/respond` to resume
+- Audit drawer shows approval history per session
+- Fixes the current 502 / "HIL service not available" warning
+
+**E2. Proactive (P1) — Triggers Panel**
+- Triggers pane in settings for CRUD against `/v1/proactive/triggers`
+- Autonomous event stream from `/v1/autonomous/events` (SSE) surfaces as proactive chat messages ("Your morning brief is ready…")
+- Trigger test dry-run UI for debugging conditions
+- Push notifications ride on top (when available)
+
+**E3. Observable (P1) — Cost & Audit**
+- Cost badge in chat header from `/v1/observability/metrics` (tokens + USD per session)
+- Audit drawer from `/v1/observability/audit` filterable by action type
+- No full-screen dashboards — everything accessible from chat
+
+**E4. Persistent (P2) — Knowledge & Checkpoints**
+- `/v1/persistence/knowledge/search` powers semantic memory lookup in Cmd+K
+- Graph view for `/v1/persistence/graph/{id}` relationships
+- Slash command `/restore <checkpoint_id>` invokes `/v1/persistence/restore` for resume-from-failure
+- Integrates with Companion Memory differentiator (5 memory types)
+
+**E5. Responsive (P2) — Live Progress**
+- `/v1/responsive/stream/{session_id}` (SSE) fuels live node/tool/content progress indicators
+- Complements existing `/v1/chat` SSE for post-hoc/observer views
+- Tool execution badges show timing + status
+
+**E6. Autonomous + Reactive (P3)**
+- Background job surface (`/v1/autonomous/background-jobs`) — user can see async work, not block chat
+- Generic webhook config UI (`/v1/reactive/webhooks`) for third-party ingress
+
+#### Cross-Repo Impact
+
+| Repo | Role |
+|------|------|
+| isA_Mate | Gateway routers (§2.30) — backend exposure |
+| isA_Agent_SDK | SDK-side hooks — query/restore APIs for HIL + checkpoints |
+| isA_App_SDK | 5 new capability clients — `InteractiveClient`, `ProactiveClient`, `ObservabilityClient`, `PersistenceClient`, `ResponsiveClient` in `@isa/transport` |
+| isA_ | UI integration — modals, panels, badges, drawers wired to new clients |
+
+#### Acceptance Criteria (Epic-level)
+
+- [ ] E1: 502 at `/agents/execution/health` is gone; ask_human modal renders and resumes
+- [ ] E2: User creates a cron trigger via UI, sees proactive message when it fires
+- [ ] E3: Cost badge updates live; audit drawer shows last 50 actions
+- [ ] E4: Semantic search finds prior conversation context; `/restore` resumes a failed run
+- [ ] E5: Live progress indicator shows every node/tool event in chat
+- [ ] E6: Background job appears in chat as async work; webhook config saves
+
+#### Out of Scope (for this epic)
+
+- Multi-tenant admin views (handled by isA_Console)
+- Raw Prometheus dashboards (handled by ops, not chat UI)
+- SDK-level changes to agent internals (handled in isA_Agent_SDK epics)
+
 ## Technical Constraints
 
 - Next.js 14 with pages router

--- a/src/api/AutonomousService.ts
+++ b/src/api/AutonomousService.ts
@@ -1,0 +1,74 @@
+/**
+ * AutonomousService — client for the isA_Mate /v1/autonomous/*
+ * capability router (xenoISA/isA_Mate#409 / #429). Surfaces
+ * background-job management in the UI (async-task panel, chat-side
+ * "running in background" badges).
+ *
+ * TODO: Replace with `import { AutonomousClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#313 publishes.
+ */
+
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  BackgroundJob,
+  BackgroundJobInput,
+  BackgroundJobListResponse,
+  ListJobsOptions,
+} from './types/autonomous';
+
+export class AutonomousService {
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    return headers;
+  }
+
+  async enqueueJob(input: BackgroundJobInput): Promise<BackgroundJob> {
+    if (!input.prompt || input.prompt.trim().length === 0) {
+      throw new RangeError('enqueueJob: prompt must be non-empty');
+    }
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.AUTONOMOUS.JOBS, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(input),
+    });
+    if (!resp.ok) throw new Error(`enqueueJob failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listJobs(opts: ListJobsOptions = {}): Promise<BackgroundJobListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.status) qs.set('status', opts.status);
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.AUTONOMOUS.JOBS}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders() },
+    );
+    if (!resp.ok) throw new Error(`listJobs failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getJob(jobId: string): Promise<BackgroundJob> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.AUTONOMOUS.JOB(jobId), {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok) throw new Error(`getJob failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async cancelJob(jobId: string): Promise<BackgroundJob> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.AUTONOMOUS.JOB(jobId), {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok) throw new Error(`cancelJob failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+}
+
+export const autonomousService = new AutonomousService();
+export default autonomousService;

--- a/src/api/ExecutionControlService.ts
+++ b/src/api/ExecutionControlService.ts
@@ -28,11 +28,20 @@ import { BaseApiService } from './BaseApiService';
 import { logger, LogCategory } from '../utils/logger';
 import { GATEWAY_CONFIG, GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { authTokenStore } from '../stores/authTokenStore';
-import { 
-  HILInterruptDetectedEvent, 
+import {
+  HILInterruptDetectedEvent,
   HILCheckpointCreatedEvent,
-  HILExecutionStatusData 
+  HILExecutionStatusData
 } from '../types/aguiTypes';
+import type {
+  Interrupt,
+  InterruptListResponse,
+  InterruptResponseBody,
+  ResumeResult as InteractiveResumeResult,
+  ExpiryInfo,
+  AuditEntry,
+  InteractiveHealth,
+} from './types/interactive';
 
 // ================================================================================
 // Type Definitions - HIL执行控制类型定义
@@ -220,10 +229,16 @@ export class ExecutionControlService {
 
   /**
    * 检查HIL执行控制服务健康状态
+   *
+   * Probes the Mate gateway's /v1/interactive/health endpoint
+   * (xenoISA/isA_Mate#404). Failures are downgraded to debug — the old
+   * error log caused the misleading "HIL service not available" spam at
+   * ChatModule.tsx:331 when the backend returned 502/404, even though
+   * HIL interrupt handling should remain enabled regardless.
    */
   async getHealth(): Promise<ExecutionHealth> {
     try {
-      const response = await fetch(GATEWAY_ENDPOINTS.AGENTS.EXECUTION.HEALTH, {
+      const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.HEALTH, {
         method: 'GET',
         headers: this.getRequestHeaders()
       });
@@ -232,13 +247,114 @@ export class ExecutionControlService {
         throw new Error(`Health check failed: ${response.status} ${response.statusText}`);
       }
 
-      const health = await response.json();
-      logger.info(LogCategory.CHAT_FLOW, 'HIL service health check successful', health);
+      const interactive: InteractiveHealth = await response.json();
+      // Map the capability-router shape to the legacy ExecutionHealth
+      // shape so existing callers continue to work.
+      const health: ExecutionHealth = {
+        status: interactive.status === 'healthy' ? 'healthy' : 'down',
+        service: 'mate-interactive',
+        features: {
+          human_in_loop: interactive.features.human_in_loop,
+          approval_workflow: interactive.features.approval_workflow,
+          tool_authorization: interactive.features.tool_authorization,
+          total_interrupts: interactive.graph_info.total_interrupts ?? 0,
+        },
+        graph_info: {
+          nodes: 0,
+          durable: interactive.graph_info.durable ?? false,
+          checkpoints: interactive.graph_info.durable ?? false,
+          environment: 'mate',
+        },
+      };
+      logger.debug(LogCategory.CHAT_FLOW, 'HIL service health check successful', health);
       return health;
     } catch (error) {
-      logger.error(LogCategory.CHAT_FLOW, 'HIL service health check failed', { error });
+      logger.debug(LogCategory.CHAT_FLOW, 'HIL probe inactive — interrupt handling stays enabled', { error });
       throw error;
     }
+  }
+
+  // ================================================================================
+  // /v1/interactive/* client — capability router consumption
+  // (xenoISA/isA_Mate#404, contract INTERACTIVE v1)
+  // ================================================================================
+
+  /**
+   * List pending HIL interrupts for the authenticated user.
+   */
+  async listInterrupts(opts: { cursor?: string; limit?: number } = {}): Promise<InterruptListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const url = `${GATEWAY_ENDPOINTS.MATE.INTERACTIVE.LIST}?${qs.toString()}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.getRequestHeaders('listInterrupts'),
+    });
+    if (!response.ok) {
+      throw new Error(`listInterrupts failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Get a single interrupt by request id.
+   */
+  async getInterrupt(requestId: string): Promise<Interrupt> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.DETAIL(requestId), {
+      method: 'GET',
+      headers: this.getRequestHeaders('getInterrupt'),
+    });
+    if (!response.ok) {
+      throw new Error(`getInterrupt failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Submit the user response for a pending interrupt and resume execution.
+   */
+  async respondToInterrupt(requestId: string, body: InterruptResponseBody): Promise<InteractiveResumeResult> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.RESPOND(requestId), {
+      method: 'POST',
+      headers: this.getRequestHeaders('respondToInterrupt'),
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`respondToInterrupt failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Extend the timeout on a pending interrupt.
+   */
+  async extendTimeout(requestId: string, seconds: number): Promise<ExpiryInfo> {
+    if (!Number.isInteger(seconds) || seconds < 1 || seconds > 3600) {
+      throw new RangeError(`extendTimeout: seconds must be integer in [1, 3600], got ${seconds}`);
+    }
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.TIMEOUT(requestId, seconds), {
+      method: 'PATCH',
+      headers: this.getRequestHeaders('extendTimeout'),
+    });
+    if (!response.ok) {
+      throw new Error(`extendTimeout failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Get approval/response audit history for a completed interrupt.
+   */
+  async getInterruptAudit(requestId: string): Promise<AuditEntry[]> {
+    const response = await fetch(GATEWAY_ENDPOINTS.MATE.INTERACTIVE.AUDIT(requestId), {
+      method: 'GET',
+      headers: this.getRequestHeaders('getInterruptAudit'),
+    });
+    if (!response.ok) {
+      throw new Error(`getInterruptAudit failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
   }
 
   /**

--- a/src/api/ObservabilityService.ts
+++ b/src/api/ObservabilityService.ts
@@ -1,0 +1,74 @@
+/**
+ * ObservabilityService — client for the isA_Mate /v1/observability/*
+ * capability router (xenoISA/isA_Mate#406 / #426). Powers the cost
+ * badge + audit drawer surfaces.
+ *
+ * TODO: Replace with `import { ObservabilityClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#311 publishes.
+ */
+
+import { logger, LogCategory } from '../utils/logger';
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  AuditFilter,
+  AuditListResponse,
+  ExecutionMetrics,
+  MetricsFilter,
+} from './types/observability';
+
+export class ObservabilityService {
+  private getHeaders(operation?: string): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    } else if (operation) {
+      logger.debug(
+        LogCategory.CHAT_FLOW,
+        `No auth token for ${operation} — request may 401`,
+      );
+    }
+    return headers;
+  }
+
+  async getMetrics(filter: MetricsFilter = {}): Promise<ExecutionMetrics> {
+    const qs = new URLSearchParams();
+    if (filter.since) qs.set('since', toISO(filter.since));
+    if (filter.until) qs.set('until', toISO(filter.until));
+    if (filter.agent_id) qs.set('agent_id', filter.agent_id);
+    if (filter.session_id) qs.set('session_id', filter.session_id);
+    const path = qs.toString()
+      ? `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS}?${qs.toString()}`
+      : GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS;
+    const resp = await fetch(path, {
+      method: 'GET',
+      headers: this.getHeaders('getMetrics'),
+    });
+    if (!resp.ok) throw new Error(`getMetrics failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getAudit(filter: AuditFilter = {}): Promise<AuditListResponse> {
+    const qs = new URLSearchParams();
+    if (filter.action) qs.set('action', filter.action);
+    if (filter.since) qs.set('since', toISO(filter.since));
+    if (filter.until) qs.set('until', toISO(filter.until));
+    if (filter.session_id) qs.set('session_id', filter.session_id);
+    qs.set('limit', String(filter.limit ?? 100));
+    if (filter.cursor) qs.set('cursor', filter.cursor);
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.AUDIT}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('getAudit') },
+    );
+    if (!resp.ok) throw new Error(`getAudit failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+}
+
+function toISO(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export const observabilityService = new ObservabilityService();
+export default observabilityService;

--- a/src/api/PersistenceService.ts
+++ b/src/api/PersistenceService.ts
@@ -1,0 +1,111 @@
+/**
+ * PersistenceService — client for the isA_Mate /v1/persistence/*
+ * capability router (xenoISA/isA_Mate#407 / #427). Powers the
+ * checkpoint restore (`/restore`) slash command + Cmd+K semantic
+ * memory lookup + graph view.
+ *
+ * TODO: Replace with `import { PersistenceClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#312 publishes.
+ */
+
+import { logger, LogCategory } from '../utils/logger';
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  CheckpointListResponse,
+  CheckpointPayload,
+  GraphNeighborhood,
+  KnowledgeListResponse,
+  KnowledgeSearchResponse,
+  RestoreResult,
+} from './types/persistence';
+
+export class PersistenceService {
+  private getHeaders(operation?: string): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    } else if (operation) {
+      logger.debug(
+        LogCategory.CHAT_FLOW,
+        `No auth token for ${operation} — request may 401`,
+      );
+    }
+    return headers;
+  }
+
+  async listCheckpoints(sessionId: string): Promise<CheckpointListResponse> {
+    const qs = new URLSearchParams({ session_id: sessionId });
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PERSISTENCE.CHECKPOINTS}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listCheckpoints') },
+    );
+    if (!resp.ok) throw new Error(`listCheckpoints failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getCheckpoint(checkpointId: string): Promise<CheckpointPayload> {
+    const resp = await fetch(
+      GATEWAY_ENDPOINTS.MATE.PERSISTENCE.CHECKPOINT(checkpointId),
+      { method: 'GET', headers: this.getHeaders('getCheckpoint') },
+    );
+    if (!resp.ok) throw new Error(`getCheckpoint failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async restore(checkpointId: string, newSessionId?: string): Promise<RestoreResult> {
+    const body: Record<string, unknown> = { checkpoint_id: checkpointId };
+    if (newSessionId) body.new_session_id = newSessionId;
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PERSISTENCE.RESTORE, {
+      method: 'POST',
+      headers: this.getHeaders('restore'),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw new Error(`restore failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listKnowledge(opts: { cursor?: string; limit?: number } = {}): Promise<KnowledgeListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PERSISTENCE.KNOWLEDGE}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listKnowledge') },
+    );
+    if (!resp.ok) throw new Error(`listKnowledge failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async searchKnowledge(query: string, opts: { limit?: number } = {}): Promise<KnowledgeSearchResponse> {
+    if (!query || query.trim().length === 0) {
+      throw new RangeError('searchKnowledge: query must not be empty');
+    }
+    const qs = new URLSearchParams({ q: query });
+    qs.set('limit', String(opts.limit ?? 10));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PERSISTENCE.KNOWLEDGE_SEARCH}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('searchKnowledge') },
+    );
+    if (!resp.ok) throw new Error(`searchKnowledge failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getGraphNode(nodeId: string, opts: { depth?: number } = {}): Promise<GraphNeighborhood> {
+    const depth = opts.depth ?? 1;
+    if (!Number.isInteger(depth) || depth < 1 || depth > 3) {
+      throw new RangeError(`getGraphNode: depth must be integer in [1, 3], got ${depth}`);
+    }
+    const qs = new URLSearchParams({ depth: String(depth) });
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PERSISTENCE.GRAPH_NODE(nodeId)}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('getGraphNode') },
+    );
+    if (!resp.ok) throw new Error(`getGraphNode failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+}
+
+export const persistenceService = new PersistenceService();
+export default persistenceService;

--- a/src/api/ProactiveService.ts
+++ b/src/api/ProactiveService.ts
@@ -1,0 +1,169 @@
+/**
+ * ProactiveService — client for the isA_Mate /v1/proactive/* capability
+ * router (xenoISA/isA_Mate#405 / #425). Wraps the HTTP CRUD endpoints
+ * plus the /v1/autonomous/events SSE stream.
+ *
+ * TODO: Replace with `import { ProactiveClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#311 publishes.
+ */
+
+import { logger, LogCategory } from '../utils/logger';
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  AutonomousFireEvent,
+  Trigger,
+  TriggerInput,
+  TriggerListResponse,
+  TriggerPatch,
+  TriggerRunListResponse,
+  TriggerTestRequest,
+  TriggerTestResult,
+} from './types/proactive';
+
+export interface ListTriggersOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListTriggerRunsOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+export class ProactiveService {
+  private getHeaders(operation?: string): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    } else if (operation) {
+      logger.debug(
+        LogCategory.CHAT_FLOW,
+        `No auth token for ${operation} — request may 401`,
+      );
+    }
+    return headers;
+  }
+
+  async listTriggers(
+    opts: ListTriggersOptions = {},
+  ): Promise<TriggerListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGERS}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listTriggers') },
+    );
+    if (!resp.ok) throw new Error(`listTriggers failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async createTrigger(body: TriggerInput): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGERS, {
+      method: 'POST',
+      headers: this.getHeaders('createTrigger'),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw new Error(`createTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getTrigger(id: string): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id), {
+      method: 'GET',
+      headers: this.getHeaders('getTrigger'),
+    });
+    if (!resp.ok) throw new Error(`getTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async updateTrigger(id: string, patch: TriggerPatch): Promise<Trigger> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id), {
+      method: 'PATCH',
+      headers: this.getHeaders('updateTrigger'),
+      body: JSON.stringify(patch),
+    });
+    if (!resp.ok) throw new Error(`updateTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async deleteTrigger(id: string, opts: { hard?: boolean } = {}): Promise<void> {
+    const path = opts.hard
+      ? `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id)}?hard=true`
+      : GATEWAY_ENDPOINTS.MATE.PROACTIVE.TRIGGER(id);
+    const resp = await fetch(path, {
+      method: 'DELETE',
+      headers: this.getHeaders('deleteTrigger'),
+    });
+    if (!resp.ok && resp.status !== 204) {
+      throw new Error(`deleteTrigger failed: ${resp.status} ${resp.statusText}`);
+    }
+  }
+
+  async testTrigger(
+    id: string,
+    req: TriggerTestRequest,
+  ): Promise<TriggerTestResult> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.PROACTIVE.TEST(id), {
+      method: 'POST',
+      headers: this.getHeaders('testTrigger'),
+      body: JSON.stringify(req),
+    });
+    if (!resp.ok) throw new Error(`testTrigger failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listRuns(
+    id: string,
+    opts: ListTriggerRunsOptions = {},
+  ): Promise<TriggerRunListResponse> {
+    const qs = new URLSearchParams();
+    if (opts.cursor) qs.set('cursor', opts.cursor);
+    qs.set('limit', String(opts.limit ?? 50));
+    const resp = await fetch(
+      `${GATEWAY_ENDPOINTS.MATE.PROACTIVE.RUNS(id)}?${qs.toString()}`,
+      { method: 'GET', headers: this.getHeaders('listRuns') },
+    );
+    if (!resp.ok) throw new Error(`listRuns failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  /**
+   * Subscribe to trigger fires via /v1/autonomous/events SSE.
+   *
+   * Returns an unsubscribe function. Browser-native EventSource is
+   * used — note that EventSource cannot send custom headers, so the
+   * Mate gateway must accept cookies for auth, or the caller must
+   * ensure `NEXT_PUBLIC_MATE_URL` points at a deployment where the
+   * fire stream is publicly readable per-user (e.g. via a signed URL).
+   */
+  subscribeToFires(handler: (event: AutonomousFireEvent) => void): () => void {
+    if (typeof EventSource === 'undefined') {
+      throw new Error(
+        'ProactiveService.subscribeToFires requires EventSource (browser env)',
+      );
+    }
+    const source = new EventSource(
+      GATEWAY_ENDPOINTS.MATE.AUTONOMOUS_EVENTS,
+      { withCredentials: true },
+    );
+    const listener = (ev: MessageEvent) => {
+      try {
+        const payload = JSON.parse(ev.data) as AutonomousFireEvent;
+        handler(payload);
+      } catch {
+        // Ignore malformed / heartbeat messages
+      }
+    };
+    source.addEventListener('trigger.fired', listener as EventListener);
+    return () => {
+      source.removeEventListener('trigger.fired', listener as EventListener);
+      source.close();
+    };
+  }
+}
+
+export const proactiveService = new ProactiveService();
+export default proactiveService;

--- a/src/api/ReactiveService.ts
+++ b/src/api/ReactiveService.ts
@@ -1,0 +1,107 @@
+/**
+ * ReactiveService — client for the isA_Mate /v1/reactive/*
+ * capability router (xenoISA/isA_Mate#409 / #429). Surfaces webhook
+ * config + event subscription UI in the frontend.
+ *
+ * TODO: Replace with `import { ReactiveClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#313 publishes.
+ */
+
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import type {
+  EventSubscription,
+  EventSubscriptionInput,
+  EventSubscriptionListResponse,
+  Webhook,
+  WebhookInput,
+  WebhookListResponse,
+} from './types/reactive';
+
+export class ReactiveService {
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = authTokenStore.getToken();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    return headers;
+  }
+
+  async registerWebhook(input: WebhookInput): Promise<Webhook> {
+    if (!input.path.startsWith('/')) {
+      throw new RangeError('registerWebhook: path must start with "/"');
+    }
+    if (input.secret.length < 16) {
+      throw new RangeError('registerWebhook: secret must be at least 16 characters');
+    }
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.WEBHOOKS, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(input),
+    });
+    if (!resp.ok) throw new Error(`registerWebhook failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listWebhooks(): Promise<WebhookListResponse> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.WEBHOOKS, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok) throw new Error(`listWebhooks failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async getWebhook(webhookId: string): Promise<Webhook> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.WEBHOOK(webhookId), {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok) throw new Error(`getWebhook failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async deleteWebhook(webhookId: string): Promise<void> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.WEBHOOK(webhookId), {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok && resp.status !== 204) {
+      throw new Error(`deleteWebhook failed: ${resp.status} ${resp.statusText}`);
+    }
+  }
+
+  async subscribe(input: EventSubscriptionInput): Promise<EventSubscription> {
+    if (!input.channel || input.channel.trim().length === 0) {
+      throw new RangeError('subscribe: channel must be non-empty');
+    }
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.SUBSCRIBE, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(input),
+    });
+    if (!resp.ok) throw new Error(`subscribe failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async listSubscriptions(): Promise<EventSubscriptionListResponse> {
+    const resp = await fetch(GATEWAY_ENDPOINTS.MATE.REACTIVE.SUBSCRIPTIONS, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+    if (!resp.ok) throw new Error(`listSubscriptions failed: ${resp.status} ${resp.statusText}`);
+    return resp.json();
+  }
+
+  async unsubscribe(subscriptionId: string): Promise<void> {
+    const resp = await fetch(
+      GATEWAY_ENDPOINTS.MATE.REACTIVE.SUBSCRIPTION(subscriptionId),
+      { method: 'DELETE', headers: this.getHeaders() },
+    );
+    if (!resp.ok && resp.status !== 204) {
+      throw new Error(`unsubscribe failed: ${resp.status} ${resp.statusText}`);
+    }
+  }
+}
+
+export const reactiveService = new ReactiveService();
+export default reactiveService;

--- a/src/api/ResponsiveService.ts
+++ b/src/api/ResponsiveService.ts
@@ -1,0 +1,80 @@
+/**
+ * ResponsiveService — client for the isA_Mate /v1/responsive/stream/
+ * SSE endpoint (xenoISA/isA_Mate#408 / #428). Powers live progress
+ * indicators in observer / debug views.
+ *
+ * TODO: Replace with `import { ResponsiveClient } from '@isa/transport'`
+ * once xenoISA/isA_App_SDK#312 publishes.
+ */
+
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import type { ResponsiveEvent } from './types/responsive';
+
+export interface SubscribeOptions {
+  /** Last event id to resume from — forwarded as `?last_event_id=`
+   *  query param since EventSource can't set custom headers. */
+  lastEventId?: string;
+}
+
+export class ResponsiveService {
+  /**
+   * Subscribe to per-session progress events. Returns an unsubscribe
+   * function. Throws if `EventSource` is unavailable (non-browser env).
+   */
+  streamSession(
+    sessionId: string,
+    handler: (event: ResponsiveEvent) => void,
+    opts: SubscribeOptions = {},
+  ): () => void {
+    if (typeof EventSource === 'undefined') {
+      throw new Error('ResponsiveService.streamSession requires EventSource (browser env)');
+    }
+    const base = GATEWAY_ENDPOINTS.MATE.RESPONSIVE.STREAM(sessionId);
+    const url = opts.lastEventId
+      ? `${base}?last_event_id=${encodeURIComponent(opts.lastEventId)}`
+      : base;
+    const source = new EventSource(url, { withCredentials: true });
+
+    const namedHandlers: Record<string, EventListener> = {};
+    const genericListener: EventListener = (ev) => {
+      const data = (ev as { data?: unknown }).data;
+      if (typeof data !== 'string') return;
+      try {
+        const parsed = JSON.parse(data);
+        if (parsed && typeof parsed === 'object' && 'ts' in parsed && !('event' in parsed)) {
+          handler({
+            event: 'heartbeat',
+            data: parsed as Record<string, unknown>,
+            timestamp: String(parsed.ts),
+            duration_ms: null,
+            node_name: null,
+          });
+          return;
+        }
+        handler(parsed as ResponsiveEvent);
+      } catch {
+        // Ignore malformed payloads
+      }
+    };
+
+    const knownEvents = [
+      'message', 'heartbeat', 'node.start', 'node.end',
+      'tool.start', 'tool.end', 'content.delta',
+    ];
+    for (const type of knownEvents) {
+      namedHandlers[type] = genericListener;
+      source.addEventListener(type, genericListener);
+    }
+    source.onmessage = genericListener as (ev: MessageEvent) => void;
+
+    return () => {
+      for (const [type, fn] of Object.entries(namedHandlers)) {
+        source.removeEventListener(type, fn);
+      }
+      source.close();
+    };
+  }
+}
+
+export const responsiveService = new ResponsiveService();
+export default responsiveService;

--- a/src/api/__tests__/AutonomousReactiveService.test.ts
+++ b/src/api/__tests__/AutonomousReactiveService.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { AutonomousService } from '../AutonomousService';
+import { ReactiveService } from '../ReactiveService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      AUTONOMOUS: {
+        JOBS: 'http://localhost:18789/v1/autonomous/background-jobs',
+        JOB: (id: string) => `http://localhost:18789/v1/autonomous/background-jobs/${encodeURIComponent(id)}`,
+      },
+      REACTIVE: {
+        WEBHOOKS: 'http://localhost:18789/v1/reactive/webhooks',
+        WEBHOOK: (id: string) => `http://localhost:18789/v1/reactive/webhooks/${encodeURIComponent(id)}`,
+        SUBSCRIBE: 'http://localhost:18789/v1/reactive/events/subscribe',
+        SUBSCRIPTIONS: 'http://localhost:18789/v1/reactive/events/subscriptions',
+        SUBSCRIPTION: (id: string) => `http://localhost:18789/v1/reactive/events/subscriptions/${encodeURIComponent(id)}`,
+      },
+    },
+  },
+}));
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const MATE = 'http://localhost:18789';
+
+function ok(data: unknown) {
+  return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+}
+function noContent() {
+  return { ok: true, status: 204, statusText: 'No Content', json: vi.fn() };
+}
+function lastCall(): [string, RequestInit] {
+  return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+}
+
+describe('AutonomousService', () => {
+  let service: AutonomousService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AutonomousService();
+  });
+
+  test('enqueueJob rejects empty prompt locally', async () => {
+    await expect(service.enqueueJob({ prompt: '' })).rejects.toThrow(RangeError);
+    await expect(service.enqueueJob({ prompt: '  ' })).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('enqueueJob POSTs body to JOBS endpoint', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'job_1', user_id: 'u1', prompt: 'x',
+      schedule: null, idempotency_key: null, status: 'queued',
+      created_at: 't', updated_at: 't',
+      started_at: null, completed_at: null,
+      result: {}, error: null, duration_ms: null, metadata: {},
+    }));
+    await service.enqueueJob({ prompt: 'x' });
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/autonomous/background-jobs`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer mock-token');
+  });
+
+  test('listJobs forwards status filter', async () => {
+    mockFetch.mockResolvedValue(ok({ jobs: [], next_cursor: null }));
+    await service.listJobs({ status: 'running', limit: 25 });
+    expect(lastCall()[0]).toContain('status=running');
+    expect(lastCall()[0]).toContain('limit=25');
+  });
+
+  test('cancelJob DELETEs to job endpoint', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'job_1', user_id: 'u1', prompt: 'x',
+      schedule: null, idempotency_key: null, status: 'cancelled',
+      created_at: 't', updated_at: 't',
+      started_at: null, completed_at: 't',
+      result: {}, error: null, duration_ms: null, metadata: {},
+    }));
+    await service.cancelJob('job_1');
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/autonomous/background-jobs/job_1`);
+    expect(init.method).toBe('DELETE');
+  });
+
+  test('non-ok throws with status', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(service.getJob('missing')).rejects.toThrow(/404/);
+  });
+});
+
+describe('ReactiveService', () => {
+  let service: ReactiveService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ReactiveService();
+  });
+
+  test('registerWebhook rejects path without slash', async () => {
+    await expect(
+      service.registerWebhook({ path: 'no-slash', secret: 'supersecretvalue1234', action_prompt: 'x' }),
+    ).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('registerWebhook rejects short secret', async () => {
+    await expect(
+      service.registerWebhook({ path: '/x', secret: 'tooshort', action_prompt: 'x' }),
+    ).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('registerWebhook POSTs body on valid input', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'wh_1', user_id: 'u1', path: '/x',
+      action_prompt: 'Triage', filter: null, enabled: true, created_at: 't',
+    }));
+    const input = { path: '/x', secret: 'supersecretvalue1234', action_prompt: 'Triage' };
+    await service.registerWebhook(input);
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/reactive/webhooks`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify(input));
+  });
+
+  test('subscribe rejects empty channel locally', async () => {
+    await expect(service.subscribe({ channel: '' })).rejects.toThrow(RangeError);
+    await expect(service.subscribe({ channel: '  ' })).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('subscribe POSTs body', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'sub_1', user_id: 'u1', channel: 'trades',
+      filter: { symbol: 'BTC' }, delivery_url: null, created_at: 't',
+    }));
+    await service.subscribe({ channel: 'trades', filter: { symbol: 'BTC' } });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/reactive/events/subscribe`);
+    expect(lastCall()[1].method).toBe('POST');
+  });
+
+  test('deleteWebhook accepts 204', async () => {
+    mockFetch.mockResolvedValue(noContent());
+    await service.deleteWebhook('wh_1');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/reactive/webhooks/wh_1`);
+    expect(lastCall()[1].method).toBe('DELETE');
+  });
+
+  test('unsubscribe accepts 204', async () => {
+    mockFetch.mockResolvedValue(noContent());
+    await service.unsubscribe('sub_1');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/reactive/events/subscriptions/sub_1`);
+  });
+});

--- a/src/api/__tests__/ExecutionControlService.test.ts
+++ b/src/api/__tests__/ExecutionControlService.test.ts
@@ -7,6 +7,7 @@ vi.mock('../BaseApiService', () => ({
 }));
 
 // Mock gatewayConfig
+const MATE_BASE = 'http://localhost:18789';
 vi.mock('../../config/gatewayConfig', () => ({
   GATEWAY_CONFIG: {
     BASE_URL: 'http://localhost:9080',
@@ -20,6 +21,16 @@ vi.mock('../../config/gatewayConfig', () => ({
         ROLLBACK: 'http://localhost:9080/agents/api/execution/rollback',
         RESUME: 'http://localhost:9080/agents/api/execution/resume',
         RESUME_STREAM: 'http://localhost:9080/agents/api/execution/resume-stream',
+      },
+    },
+    MATE: {
+      INTERACTIVE: {
+        HEALTH: 'http://localhost:18789/v1/interactive/health',
+        LIST: 'http://localhost:18789/v1/interactive/interrupts',
+        DETAIL: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}`,
+        RESPOND: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/respond`,
+        TIMEOUT: (id: string, s: number) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/timeout/${s}`,
+        AUDIT: (id: string) => `http://localhost:18789/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
       },
     },
   },
@@ -68,36 +79,34 @@ describe('ExecutionControlService', () => {
   // ============================================================================
 
   describe('getHealth', () => {
-    test('returns health data on success', async () => {
-      const healthData = {
+    test('probes the MATE /v1/interactive/health endpoint and maps to ExecutionHealth', async () => {
+      const interactiveHealth = {
         status: 'healthy',
-        service: 'execution-control',
         features: {
           human_in_loop: true,
           approval_workflow: true,
           tool_authorization: true,
-          total_interrupts: 5,
         },
         graph_info: {
-          nodes: 10,
           durable: true,
-          checkpoints: true,
-          environment: 'development',
+          total_interrupts: 5,
         },
       };
       mockFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue(healthData),
+        json: vi.fn().mockResolvedValue(interactiveHealth),
       });
 
       const result = await service.getHealth();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:9080/agents/api/execution/health',
+        'http://localhost:18789/v1/interactive/health',
         expect.objectContaining({ method: 'GET' })
       );
       expect(result.status).toBe('healthy');
       expect(result.features.human_in_loop).toBe(true);
+      expect(result.features.total_interrupts).toBe(5);
+      expect(result.service).toBe('mate-interactive');
     });
 
     test('throws on non-ok response', async () => {
@@ -116,6 +125,120 @@ describe('ExecutionControlService', () => {
       mockFetch.mockRejectedValue(new Error('Connection refused'));
 
       await expect(service.getHealth()).rejects.toThrow('Connection refused');
+    });
+
+    test('logs at debug (not warn/error) when probe fails — silences misleading warn at ChatModule.tsx:331', async () => {
+      const { logger } = await import('../../utils/logger');
+      mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' });
+
+      await expect(service.getHealth()).rejects.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================================
+  // Interactive capability router (/v1/interactive/*) — xenoISA/isA_Mate#404
+  // ============================================================================
+
+  describe('Interactive capability client', () => {
+    test('listInterrupts calls the correct endpoint with cursor/limit', async () => {
+      const payload = { pending: [], active_sessions: [], next_cursor: null };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.listInterrupts({ cursor: 'c1', limit: 10 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts?cursor=c1&limit=10',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result).toEqual(payload);
+    });
+
+    test('getInterrupt URL-encodes the request_id', async () => {
+      const payload = {
+        id: 'id with spaces',
+        type: 'ask_human',
+        title: 't',
+        message: 'm',
+        timestamp: '2026-04-20T00:00:00Z',
+        thread_id: 'x',
+        expires_at: null,
+        security_level: 'medium',
+        data: {},
+      };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      await service.getInterrupt('id with spaces');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/id%20with%20spaces',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    test('respondToInterrupt POSTs the body to /respond', async () => {
+      const payload = { session_id: 'req-1', status: 'resumed' };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.respondToInterrupt('req-1', {
+        response: { email: 'a@b.com' },
+        action: 'continue',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/respond',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ response: { email: 'a@b.com' }, action: 'continue' }),
+        })
+      );
+      expect(result.status).toBe('resumed');
+    });
+
+    test('extendTimeout rejects out-of-bounds seconds locally (no fetch)', async () => {
+      await expect(service.extendTimeout('req-1', 0)).rejects.toThrow(RangeError);
+      await expect(service.extendTimeout('req-1', 3601)).rejects.toThrow(RangeError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('extendTimeout PATCHes the correct URL for valid seconds', async () => {
+      const payload = { request_id: 'req-1', new_expires_at: '2026-04-20T01:00:00Z' };
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(payload) });
+
+      const result = await service.extendTimeout('req-1', 120);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/timeout/120',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+      expect(result.new_expires_at).toBe('2026-04-20T01:00:00Z');
+    });
+
+    test('getInterruptAudit returns the audit array', async () => {
+      const audit = [
+        { timestamp: '2026-04-20T00:00:00Z', user_id: 'u1', response: 'ok', latency_ms: 100, outcome: 'approved' },
+      ];
+      mockFetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(audit) });
+
+      const result = await service.getInterruptAudit('req-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:18789/v1/interactive/interrupts/req-1/audit',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].outcome).toBe('approved');
+    });
+
+    test('each method propagates non-ok responses as Errors', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+      await expect(service.getInterrupt('missing')).rejects.toThrow(/404/);
+      await expect(service.respondToInterrupt('missing', { response: 'x' })).rejects.toThrow(/404/);
+      await expect(service.getInterruptAudit('missing')).rejects.toThrow(/404/);
     });
   });
 
@@ -337,7 +460,11 @@ describe('ExecutionControlService', () => {
     test('returns true when health check succeeds', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ status: 'healthy' }),
+        json: vi.fn().mockResolvedValue({
+          status: 'healthy',
+          features: { human_in_loop: true, approval_workflow: true, tool_authorization: true },
+          graph_info: { durable: true, total_interrupts: 0 },
+        }),
       });
 
       const result = await service.isServiceAvailable();
@@ -351,6 +478,17 @@ describe('ExecutionControlService', () => {
       const result = await service.isServiceAvailable();
 
       expect(result).toBe(false);
+    });
+
+    test('returns false silently (no warn/error) on 502 — fixes ChatModule.tsx:331 spam', async () => {
+      const { logger } = await import('../../utils/logger');
+      mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' });
+
+      const result = await service.isServiceAvailable();
+
+      expect(result).toBe(false);
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/api/__tests__/ObservabilityService.test.ts
+++ b/src/api/__tests__/ObservabilityService.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ObservabilityService } from '../ObservabilityService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      OBSERVABILITY: {
+        METRICS: 'http://localhost:18789/v1/observability/metrics',
+        AUDIT: 'http://localhost:18789/v1/observability/audit',
+      },
+    },
+  },
+}));
+
+const MATE = 'http://localhost:18789';
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LogCategory: { CHAT_FLOW: 'chat_flow' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ObservabilityService', () => {
+  let service: ObservabilityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ObservabilityService();
+  });
+
+  function ok(data: unknown) {
+    return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+  }
+
+  function lastCall(): [string, RequestInit] {
+    return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  }
+
+  test('getMetrics hits /v1/observability/metrics with no query for empty filter', async () => {
+    mockFetch.mockResolvedValue(ok({
+      nodes_executed: 0, tool_calls: 0, model_calls: 0,
+      tokens_used: { input: 0, output: 0 }, cost_usd: 0,
+      window_start: null, window_end: null,
+    }));
+    await service.getMetrics();
+    expect(lastCall()[0]).toBe(`${MATE}/v1/observability/metrics`);
+  });
+
+  test('getMetrics serializes Date filters to ISO8601', async () => {
+    mockFetch.mockResolvedValue(ok({
+      nodes_executed: 0, tool_calls: 0, model_calls: 0,
+      tokens_used: { input: 0, output: 0 }, cost_usd: 0,
+      window_start: null, window_end: null,
+    }));
+    const since = new Date('2026-04-01T00:00:00Z');
+    await service.getMetrics({ since, agent_id: 'a', session_id: 's' });
+    const [url] = lastCall();
+    expect(url).toContain('since=2026-04-01T00%3A00%3A00.000Z');
+    expect(url).toContain('agent_id=a');
+    expect(url).toContain('session_id=s');
+  });
+
+  test('getAudit defaults limit to 100', async () => {
+    mockFetch.mockResolvedValue(ok({ entries: [], total: 0, next_cursor: null }));
+    await service.getAudit();
+    expect(lastCall()[0]).toBe(`${MATE}/v1/observability/audit?limit=100`);
+  });
+
+  test('getAudit forwards filters and cursor', async () => {
+    mockFetch.mockResolvedValue(ok({ entries: [], total: 0, next_cursor: null }));
+    await service.getAudit({
+      action: 'tool_call',
+      session_id: 's1',
+      limit: 25,
+      cursor: '50',
+    });
+    const [url] = lastCall();
+    expect(url).toContain('action=tool_call');
+    expect(url).toContain('session_id=s1');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('cursor=50');
+  });
+
+  test('non-ok response throws with status text', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server' });
+    await expect(service.getAudit()).rejects.toThrow(/500/);
+  });
+});

--- a/src/api/__tests__/PersistenceService.test.ts
+++ b/src/api/__tests__/PersistenceService.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { PersistenceService } from '../PersistenceService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      PERSISTENCE: {
+        CHECKPOINTS: 'http://localhost:18789/v1/persistence/checkpoints',
+        CHECKPOINT: (id: string) => `http://localhost:18789/v1/persistence/checkpoints/${encodeURIComponent(id)}`,
+        RESTORE: 'http://localhost:18789/v1/persistence/restore',
+        KNOWLEDGE: 'http://localhost:18789/v1/persistence/knowledge',
+        KNOWLEDGE_SEARCH: 'http://localhost:18789/v1/persistence/knowledge/search',
+        GRAPH_NODE: (id: string) => `http://localhost:18789/v1/persistence/graph/${encodeURIComponent(id)}`,
+      },
+    },
+  },
+}));
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LogCategory: { CHAT_FLOW: 'chat_flow' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const MATE = 'http://localhost:18789';
+
+describe('PersistenceService', () => {
+  let service: PersistenceService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PersistenceService();
+  });
+
+  function ok(data: unknown) {
+    return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+  }
+  function lastCall(): [string, RequestInit] {
+    return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  }
+
+  test('listCheckpoints forwards session_id', async () => {
+    mockFetch.mockResolvedValue(ok({ checkpoints: [], next_cursor: null }));
+    await service.listCheckpoints('s1');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/persistence/checkpoints?session_id=s1`);
+  });
+
+  test('getCheckpoint URL-encodes composite id', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 's1:cp', session_id: 's1',
+      created_at: '2026-04-20T00:00:00Z', state: {}, metadata: {},
+    }));
+    await service.getCheckpoint('s1:cp');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/persistence/checkpoints/s1%3Acp`);
+  });
+
+  test('restore omits new_session_id when absent', async () => {
+    mockFetch.mockResolvedValue(ok({
+      restored_session_id: 's1', from_checkpoint_id: 's1:cp', status: 'restored',
+    }));
+    await service.restore('s1:cp');
+    const [, init] = lastCall();
+    expect(init.body).toBe(JSON.stringify({ checkpoint_id: 's1:cp' }));
+  });
+
+  test('restore includes new_session_id when provided', async () => {
+    mockFetch.mockResolvedValue(ok({
+      restored_session_id: 's2', from_checkpoint_id: 's1:cp', status: 'restored',
+    }));
+    await service.restore('s1:cp', 's2');
+    const [, init] = lastCall();
+    expect(init.body).toBe(JSON.stringify({
+      checkpoint_id: 's1:cp', new_session_id: 's2',
+    }));
+  });
+
+  test('searchKnowledge rejects empty query locally', async () => {
+    await expect(service.searchKnowledge('')).rejects.toThrow(RangeError);
+    await expect(service.searchKnowledge('   ')).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('searchKnowledge default limit is 10', async () => {
+    mockFetch.mockResolvedValue(ok({ query: 'hello', hits: [] }));
+    await service.searchKnowledge('hello');
+    expect(lastCall()[0]).toContain('q=hello');
+    expect(lastCall()[0]).toContain('limit=10');
+  });
+
+  test('getGraphNode rejects out-of-range depth locally', async () => {
+    await expect(service.getGraphNode('n1', { depth: 0 })).rejects.toThrow(RangeError);
+    await expect(service.getGraphNode('n1', { depth: 4 })).rejects.toThrow(RangeError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('getGraphNode default depth=1', async () => {
+    mockFetch.mockResolvedValue(ok({
+      node: { id: 'n1', labels: [], properties: {} },
+      neighbors: [], relationships: [],
+    }));
+    await service.getGraphNode('n1');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/persistence/graph/n1?depth=1`);
+  });
+
+  test('non-ok responses throw', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(service.getCheckpoint('s1:missing')).rejects.toThrow(/404/);
+  });
+});

--- a/src/api/__tests__/ProactiveService.test.ts
+++ b/src/api/__tests__/ProactiveService.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ProactiveService } from '../ProactiveService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      PROACTIVE: {
+        TRIGGERS: 'http://localhost:18789/v1/proactive/triggers',
+        TRIGGER: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}`,
+        TEST: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}/test`,
+        RUNS: (id: string) => `http://localhost:18789/v1/proactive/triggers/${encodeURIComponent(id)}/runs`,
+      },
+      AUTONOMOUS_EVENTS: 'http://localhost:18789/v1/autonomous/events',
+    },
+  },
+}));
+
+const MATE = 'http://localhost:18789';
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LogCategory: { CHAT_FLOW: 'chat_flow' },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ProactiveService', () => {
+  let service: ProactiveService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ProactiveService();
+  });
+
+  function ok(data: unknown) {
+    return { ok: true, json: vi.fn().mockResolvedValue(data), status: 200, statusText: 'OK' };
+  }
+
+  function lastCall(): [string, RequestInit] {
+    return mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  }
+
+  test('listTriggers hits /v1/proactive/triggers with limit=50 default', async () => {
+    mockFetch.mockResolvedValue(ok({ triggers: [], next_cursor: null }));
+    await service.listTriggers();
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers?limit=50`);
+    expect(init.method).toBe('GET');
+  });
+
+  test('listTriggers forwards cursor and limit', async () => {
+    mockFetch.mockResolvedValue(ok({ triggers: [], next_cursor: null }));
+    await service.listTriggers({ cursor: 'c1', limit: 10 });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers?cursor=c1&limit=10`);
+  });
+
+  test('createTrigger POSTs the body', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 't', type: 'cron', name: 'n', condition: {},
+      action_prompt: 'p', enabled: true,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    const input = {
+      type: 'cron' as const, name: 'n',
+      condition: { schedule: '0 9 * * *' }, action_prompt: 'p',
+    };
+    await service.createTrigger(input);
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify(input));
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer mock-token');
+  });
+
+  test('getTrigger URL-encodes id', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 'id with spaces', type: 'cron', name: 't', condition: {},
+      action_prompt: 'p', enabled: true,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    await service.getTrigger('id with spaces');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/id%20with%20spaces`);
+  });
+
+  test('updateTrigger PATCHes partial body', async () => {
+    mockFetch.mockResolvedValue(ok({
+      id: 't', type: 'cron', name: 'renamed', condition: {},
+      action_prompt: 'p', enabled: false,
+      created_at: '2026-04-20T00:00:00Z', next_fire: null, last_result: null,
+    }));
+    await service.updateTrigger('t', { name: 'renamed', enabled: false });
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers/t`);
+    expect(init.method).toBe('PATCH');
+    expect(init.body).toBe(JSON.stringify({ name: 'renamed', enabled: false }));
+  });
+
+  test('deleteTrigger soft by default', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', json: vi.fn() });
+    await service.deleteTrigger('t');
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t`);
+    expect(lastCall()[1].method).toBe('DELETE');
+  });
+
+  test('deleteTrigger with hard=true appends query', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', json: vi.fn() });
+    await service.deleteTrigger('t', { hard: true });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t?hard=true`);
+  });
+
+  test('testTrigger POSTs mock_event to /test', async () => {
+    mockFetch.mockResolvedValue(ok({
+      would_fire: true, reason: 'match', resolved_prompt: 'p', matched_conditions: {},
+    }));
+    await service.testTrigger('t', { mock_event: { x: 1 } });
+    const [url, init] = lastCall();
+    expect(url).toBe(`${MATE}/v1/proactive/triggers/t/test`);
+    expect(init.method).toBe('POST');
+  });
+
+  test('listRuns hits /runs with limit', async () => {
+    mockFetch.mockResolvedValue(ok({ runs: [], next_cursor: null }));
+    await service.listRuns('t', { limit: 25 });
+    expect(lastCall()[0]).toBe(`${MATE}/v1/proactive/triggers/t/runs?limit=25`);
+  });
+
+  test('propagates non-ok responses as errors', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    await expect(service.getTrigger('missing')).rejects.toThrow(/404/);
+  });
+});

--- a/src/api/__tests__/ResponsiveService.test.ts
+++ b/src/api/__tests__/ResponsiveService.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ResponsiveService } from '../ResponsiveService';
+import type { ResponsiveEvent } from '../types/responsive';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      RESPONSIVE: {
+        STREAM: (id: string) => `http://localhost:18789/v1/responsive/stream/${encodeURIComponent(id)}`,
+      },
+    },
+  },
+}));
+
+const MATE = 'http://localhost:18789';
+
+describe('ResponsiveService', () => {
+  let service: ResponsiveService;
+
+  beforeEach(() => {
+    service = new ResponsiveService();
+  });
+
+  function stubEventSource() {
+    const listeners: Record<string, EventListener[]> = {};
+    const close = vi.fn();
+    let onmessageHandler: ((ev: MessageEvent) => void) | null = null;
+    class StubEventSource {
+      constructor(public readonly url: string) {
+        StubEventSource.lastUrl = url;
+      }
+      static lastUrl = '';
+      addEventListener(type: string, fn: EventListener) {
+        (listeners[type] ??= []).push(fn);
+      }
+      removeEventListener(type: string, fn: EventListener) {
+        listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+      }
+      set onmessage(fn: (ev: MessageEvent) => void) {
+        onmessageHandler = fn;
+      }
+      get onmessage() {
+        return onmessageHandler as (ev: MessageEvent) => void;
+      }
+      close = close;
+    }
+    vi.stubGlobal('EventSource', StubEventSource);
+    return { listeners, close, StubEventSource };
+  }
+
+  test('builds the URL with session id URL-encoded', () => {
+    const { StubEventSource } = stubEventSource();
+    service.streamSession('s with spaces', () => {});
+    expect(StubEventSource.lastUrl).toBe(`${MATE}/v1/responsive/stream/s%20with%20spaces`);
+  });
+
+  test('appends lastEventId as query param', () => {
+    const { StubEventSource } = stubEventSource();
+    service.streamSession('s1', () => {}, { lastEventId: '42' });
+    expect(StubEventSource.lastUrl).toBe(`${MATE}/v1/responsive/stream/s1?last_event_id=42`);
+  });
+
+  test('dispatches typed events to handler', () => {
+    const { listeners } = stubEventSource();
+    const received: ResponsiveEvent[] = [];
+    service.streamSession('s1', (ev) => received.push(ev));
+
+    const payload: ResponsiveEvent = {
+      event: 'tool.start',
+      data: { tool_name: 'web_crawl' },
+      timestamp: '2026-04-20T00:00:00Z',
+      duration_ms: null,
+      node_name: 'tool',
+    };
+    listeners['tool.start'][0]({ data: JSON.stringify(payload) } as MessageEvent as unknown as Event);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe('tool.start');
+  });
+
+  test('promotes heartbeat payload to a uniform event shape', () => {
+    const { listeners } = stubEventSource();
+    const received: ResponsiveEvent[] = [];
+    service.streamSession('s1', (ev) => received.push(ev));
+
+    listeners['heartbeat'][0](
+      { data: JSON.stringify({ ts: '2026-04-20T00:00:00Z' }) } as MessageEvent as unknown as Event,
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe('heartbeat');
+    expect(received[0].timestamp).toBe('2026-04-20T00:00:00Z');
+  });
+
+  test('unsubscribe closes the source and removes listeners', () => {
+    const { listeners, close } = stubEventSource();
+    const unsubscribe = service.streamSession('s1', () => {});
+    expect(listeners['node.start']?.length).toBe(1);
+
+    unsubscribe();
+
+    expect(listeners['node.start']?.length).toBe(0);
+    expect(close).toHaveBeenCalled();
+  });
+
+  test('throws if EventSource is unavailable', () => {
+    vi.stubGlobal('EventSource', undefined);
+    expect(() => service.streamSession('s1', () => {})).toThrow(/EventSource/);
+  });
+});

--- a/src/api/types/autonomous.ts
+++ b/src/api/types/autonomous.ts
@@ -1,0 +1,42 @@
+/**
+ * Types for the isA_Mate /v1/autonomous/* capability router
+ * (xenoISA/isA_Mate#409 / #429). TODO: import from @isa/transport
+ * once xenoISA/isA_App_SDK#313 publishes.
+ */
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface BackgroundJobInput {
+  prompt: string;
+  schedule?: string;
+  idempotency_key?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BackgroundJob {
+  id: string;
+  user_id: string;
+  prompt: string;
+  schedule: string | null;
+  idempotency_key: string | null;
+  status: JobStatus;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  result: Record<string, unknown>;
+  error: string | null;
+  duration_ms: number | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface BackgroundJobListResponse {
+  jobs: BackgroundJob[];
+  next_cursor: string | null;
+}
+
+export interface ListJobsOptions {
+  status?: JobStatus;
+  cursor?: string;
+  limit?: number;
+}

--- a/src/api/types/interactive.ts
+++ b/src/api/types/interactive.ts
@@ -1,0 +1,79 @@
+/**
+ * Types for the /v1/interactive/* capability router on the isA_Mate gateway
+ * (xenoISA/isA_Mate#404). Mirrors the Pydantic DTOs in
+ * isa_mate/execution/hil_router.py and the App_SDK InteractiveClient
+ * (xenoISA/isA_App_SDK#304).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * xenoISA/isA_App_SDK#304 publishes InteractiveClient and its types.
+ */
+
+export type InterruptType =
+  | 'input_validation'
+  | 'tool_authorization'
+  | 'review_and_edit'
+  | 'approve_reject'
+  | 'ask_human'
+  | 'input_collection'
+  | 'oauth'
+  | 'credential_usage';
+
+export type SecurityLevel = 'low' | 'medium' | 'high' | 'critical';
+export type ResponseAction = 'continue' | 'skip' | 'reject';
+export type ResumeStatus = 'resumed' | 'completed' | 'failed';
+export type AuditOutcome = 'approved' | 'rejected' | 'timeout' | 'resumed';
+
+export interface Interrupt {
+  id: string;
+  type: InterruptType;
+  title: string;
+  message: string;
+  timestamp: string; // ISO8601
+  thread_id: string;
+  expires_at: string | null;
+  security_level: SecurityLevel;
+  data: Record<string, unknown>;
+}
+
+export interface InterruptListResponse {
+  pending: Interrupt[];
+  active_sessions: string[];
+  next_cursor: string | null;
+}
+
+export interface InterruptResponseBody {
+  response: unknown;
+  metadata?: Record<string, unknown>;
+  action?: ResponseAction;
+}
+
+export interface ResumeResult {
+  session_id: string;
+  status: ResumeStatus;
+}
+
+export interface ExpiryInfo {
+  request_id: string;
+  new_expires_at: string;
+}
+
+export interface AuditEntry {
+  timestamp: string;
+  user_id: string;
+  response: unknown;
+  latency_ms: number;
+  outcome: AuditOutcome;
+}
+
+export interface InteractiveHealth {
+  status: 'healthy' | 'down';
+  features: {
+    human_in_loop: boolean;
+    approval_workflow: boolean;
+    tool_authorization: boolean;
+  };
+  graph_info: {
+    durable: boolean;
+    total_interrupts: number;
+  };
+}

--- a/src/api/types/observability.ts
+++ b/src/api/types/observability.ts
@@ -1,0 +1,56 @@
+/**
+ * Types for the isA_Mate /v1/observability/* capability router
+ * (xenoISA/isA_Mate#406 / #426).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * @isa/transport publishes ObservabilityClient.
+ */
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+}
+
+export interface ExecutionMetrics {
+  nodes_executed: number;
+  tool_calls: number;
+  model_calls: number;
+  tokens_used: TokenUsage;
+  cost_usd: number;
+  window_start: string | null;
+  window_end: string | null;
+}
+
+export type ObservabilityAuditOutcome = 'success' | 'failure' | 'unknown';
+
+export interface ObservabilityAuditEntry {
+  timestamp: string;
+  action: string;
+  user_id: string;
+  result: ObservabilityAuditOutcome;
+  cost_usd: number | null;
+  session_id: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface AuditListResponse {
+  entries: ObservabilityAuditEntry[];
+  total: number;
+  next_cursor: string | null;
+}
+
+export interface MetricsFilter {
+  since?: string | Date;
+  until?: string | Date;
+  agent_id?: string;
+  session_id?: string;
+}
+
+export interface AuditFilter {
+  action?: string;
+  since?: string | Date;
+  until?: string | Date;
+  session_id?: string;
+  limit?: number;
+  cursor?: string;
+}

--- a/src/api/types/persistence.ts
+++ b/src/api/types/persistence.ts
@@ -1,0 +1,85 @@
+/**
+ * Types for the isA_Mate /v1/persistence/* capability router
+ * (xenoISA/isA_Mate#407 / #427).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * xenoISA/isA_App_SDK#312 publishes PersistenceClient.
+ */
+
+export interface CheckpointMeta {
+  id: string;
+  session_id: string;
+  created_at: string;
+  step: number | null;
+  parent_id: string | null;
+  summary: string | null;
+}
+
+export interface CheckpointPayload {
+  id: string;
+  session_id: string;
+  created_at: string;
+  state: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+export interface CheckpointListResponse {
+  checkpoints: CheckpointMeta[];
+  next_cursor: string | null;
+}
+
+export interface RestoreRequest {
+  checkpoint_id: string;
+  new_session_id?: string;
+}
+
+export interface RestoreResult {
+  restored_session_id: string;
+  from_checkpoint_id: string;
+  status: string;
+}
+
+export interface KnowledgeItem {
+  id: string;
+  text: string;
+  source: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface KnowledgeListResponse {
+  items: KnowledgeItem[];
+  next_cursor: string | null;
+}
+
+export interface KnowledgeHit {
+  id: string;
+  text: string;
+  similarity_score: number;
+  source: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface KnowledgeSearchResponse {
+  query: string;
+  hits: KnowledgeHit[];
+}
+
+export interface GraphNode {
+  id: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+}
+
+export interface GraphRelationship {
+  id: string;
+  type: string;
+  start_node_id: string;
+  end_node_id: string;
+  properties: Record<string, unknown>;
+}
+
+export interface GraphNeighborhood {
+  node: GraphNode;
+  neighbors: GraphNode[];
+  relationships: GraphRelationship[];
+}

--- a/src/api/types/proactive.ts
+++ b/src/api/types/proactive.ts
@@ -1,0 +1,77 @@
+/**
+ * Types for the isA_Mate /v1/proactive/* capability router
+ * (xenoISA/isA_Mate#405 / #425). Mirrors the Pydantic DTOs in
+ * isa_mate/execution/proactive_router.py and the TypeScript types in
+ * @isa/transport's ProactiveClient (xenoISA/isA_App_SDK#311).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * @isa/transport publishes ProactiveClient.
+ */
+
+export type TriggerType = 'cron' | 'webhook' | 'threshold' | 'event';
+
+export interface TriggerInput {
+  type: TriggerType;
+  name: string;
+  condition?: Record<string, unknown>;
+  action_prompt: string;
+  enabled?: boolean;
+}
+
+export interface Trigger {
+  id: string;
+  type: TriggerType;
+  name: string;
+  condition: Record<string, unknown>;
+  action_prompt: string;
+  enabled: boolean;
+  created_at: string;
+  next_fire: string | null;
+  last_result: Record<string, unknown> | null;
+}
+
+export interface TriggerListResponse {
+  triggers: Trigger[];
+  next_cursor: string | null;
+}
+
+export interface TriggerPatch {
+  name?: string;
+  condition?: Record<string, unknown>;
+  action_prompt?: string;
+  enabled?: boolean;
+}
+
+export interface TriggerTestRequest {
+  mock_event: Record<string, unknown>;
+  apply_rate_limit?: boolean;
+}
+
+export interface TriggerTestResult {
+  would_fire: boolean;
+  reason: string;
+  resolved_prompt: string;
+  matched_conditions: Record<string, unknown>;
+}
+
+export interface TriggerRun {
+  id: string;
+  trigger_id: string;
+  fired_at: string;
+  session_id: string | null;
+  result: Record<string, unknown>;
+  duration_ms: number | null;
+  error: string | null;
+}
+
+export interface TriggerRunListResponse {
+  runs: TriggerRun[];
+  next_cursor: string | null;
+}
+
+export interface AutonomousFireEvent {
+  trigger_id: string;
+  fire_reason: string;
+  session_id: string;
+  timestamp: string;
+}

--- a/src/api/types/reactive.ts
+++ b/src/api/types/reactive.ts
@@ -1,0 +1,47 @@
+/**
+ * Types for the isA_Mate /v1/reactive/* capability router
+ * (xenoISA/isA_Mate#409 / #429). TODO: import from @isa/transport
+ * once xenoISA/isA_App_SDK#313 publishes.
+ */
+
+export interface WebhookInput {
+  path: string;
+  secret: string;
+  action_prompt: string;
+  filter?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface Webhook {
+  id: string;
+  user_id: string;
+  path: string;
+  action_prompt: string;
+  filter: Record<string, unknown> | null;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface WebhookListResponse {
+  webhooks: Webhook[];
+  next_cursor: string | null;
+}
+
+export interface EventSubscriptionInput {
+  channel: string;
+  filter?: Record<string, unknown>;
+  delivery_url?: string;
+}
+
+export interface EventSubscription {
+  id: string;
+  user_id: string;
+  channel: string;
+  filter: Record<string, unknown> | null;
+  delivery_url: string | null;
+  created_at: string;
+}
+
+export interface EventSubscriptionListResponse {
+  subscriptions: EventSubscription[];
+}

--- a/src/api/types/responsive.ts
+++ b/src/api/types/responsive.ts
@@ -1,0 +1,20 @@
+/**
+ * Types for the isA_Mate /v1/responsive/stream/{session_id} SSE
+ * endpoint (xenoISA/isA_Mate#408 / #428).
+ *
+ * TODO: Replace with `import { ... } from '@isa/transport'` once
+ * xenoISA/isA_App_SDK#312 publishes ResponsiveClient.
+ */
+
+export interface ResponsiveEvent {
+  event: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+  duration_ms: number | null;
+  node_name: string | null;
+}
+
+export interface SubscribeOptions {
+  baseURL?: string;
+  lastEventId?: string;
+}

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -224,6 +224,28 @@ export const GATEWAY_ENDPOINTS = {
             `/v1/responsive/stream/${encodeURIComponent(sessionId)}`,
           ),
       },
+      // Autonomous capability — background jobs (xenoISA/isA_Mate#409 + #429)
+      AUTONOMOUS: {
+        JOBS: buildMateEndpoint('/v1/autonomous/background-jobs'),
+        JOB: (id: string) =>
+          buildMateEndpoint(
+            `/v1/autonomous/background-jobs/${encodeURIComponent(id)}`,
+          ),
+      },
+      // Reactive capability — webhooks + event subscriptions
+      REACTIVE: {
+        WEBHOOKS: buildMateEndpoint('/v1/reactive/webhooks'),
+        WEBHOOK: (id: string) =>
+          buildMateEndpoint(
+            `/v1/reactive/webhooks/${encodeURIComponent(id)}`,
+          ),
+        SUBSCRIBE: buildMateEndpoint('/v1/reactive/events/subscribe'),
+        SUBSCRIPTIONS: buildMateEndpoint('/v1/reactive/events/subscriptions'),
+        SUBSCRIPTION: (id: string) =>
+          buildMateEndpoint(
+            `/v1/reactive/events/subscriptions/${encodeURIComponent(id)}`,
+          ),
+      },
     };
   })(),
 

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -204,6 +204,26 @@ export const GATEWAY_ENDPOINTS = {
         METRICS: buildMateEndpoint('/v1/observability/metrics'),
         AUDIT: buildMateEndpoint('/v1/observability/audit'),
       },
+      // Persistence capability router — maps to xenoISA/isA_Mate#407 + #427
+      PERSISTENCE: {
+        CHECKPOINTS: buildMateEndpoint('/v1/persistence/checkpoints'),
+        CHECKPOINT: (id: string) =>
+          buildMateEndpoint(
+            `/v1/persistence/checkpoints/${encodeURIComponent(id)}`,
+          ),
+        RESTORE: buildMateEndpoint('/v1/persistence/restore'),
+        KNOWLEDGE: buildMateEndpoint('/v1/persistence/knowledge'),
+        KNOWLEDGE_SEARCH: buildMateEndpoint('/v1/persistence/knowledge/search'),
+        GRAPH_NODE: (id: string) =>
+          buildMateEndpoint(`/v1/persistence/graph/${encodeURIComponent(id)}`),
+      },
+      // Responsive capability — per-session SSE stream (xenoISA/isA_Mate#408 + #428)
+      RESPONSIVE: {
+        STREAM: (sessionId: string) =>
+          buildMateEndpoint(
+            `/v1/responsive/stream/${encodeURIComponent(sessionId)}`,
+          ),
+      },
     };
   })(),
 

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -182,6 +182,28 @@ export const GATEWAY_ENDPOINTS = {
             `/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
           ),
       },
+      // Proactive capability router — maps to xenoISA/isA_Mate#405 /v1/proactive/*
+      // and xenoISA/isA_Mate#425 autonomous SSE events.
+      PROACTIVE: {
+        TRIGGERS: buildMateEndpoint('/v1/proactive/triggers'),
+        TRIGGER: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}`,
+          ),
+        TEST: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}/test`,
+          ),
+        RUNS: (id: string) =>
+          buildMateEndpoint(
+            `/v1/proactive/triggers/${encodeURIComponent(id)}/runs`,
+          ),
+      },
+      // Observability capability router — maps to xenoISA/isA_Mate#406 + #426
+      OBSERVABILITY: {
+        METRICS: buildMateEndpoint('/v1/observability/metrics'),
+        AUDIT: buildMateEndpoint('/v1/observability/audit'),
+      },
     };
   })(),
 

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -159,6 +159,29 @@ export const GATEWAY_ENDPOINTS = {
       },
       HEALTH: buildMateEndpoint('/health'),
       AUTONOMOUS_EVENTS: buildMateEndpoint('/v1/autonomous/events'),
+      // Human-in-the-Loop capability router — maps to xenoISA/isA_Mate#404
+      // /v1/interactive/*. Replaces the defunct AGENTS.EXECUTION probe that
+      // returns 502 through APISIX (→ isA_Mate PR #424).
+      INTERACTIVE: {
+        HEALTH: buildMateEndpoint('/v1/interactive/health'),
+        LIST: buildMateEndpoint('/v1/interactive/interrupts'),
+        DETAIL: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}`,
+          ),
+        RESPOND: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/respond`,
+          ),
+        TIMEOUT: (id: string, seconds: number) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/timeout/${seconds}`,
+          ),
+        AUDIT: (id: string) =>
+          buildMateEndpoint(
+            `/v1/interactive/interrupts/${encodeURIComponent(id)}/audit`,
+          ),
+      },
     };
   })(),
 

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -325,10 +325,14 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
         // REMOVED: HIL回调注册 - SSEParser已删除
 
-        // 检查HIL服务是否可用
+        // 检查HIL服务是否可用 (xenoISA/isA_Mate#404 → /v1/interactive/health)
         const isServiceAvailable = await executionControlService.isServiceAvailable();
         if (!isServiceAvailable) {
-          log.warn('HIL service not available, but HIL interrupt handling enabled for ask_human');
+          // Downgraded from warn → debug. HIL interrupt handling stays enabled
+          // regardless of probe result (ask_human still works via SSE); the
+          // previous warn caused misleading console noise on every page load
+          // when the backend wasn't yet serving /v1/interactive.
+          log.debug('HIL probe inactive — interrupt handling stays enabled');
           return;
         }
 


### PR DESCRIPTION
## Summary

Final Wave 4 frontend plumbing. Completes the E1-E6 capability exposure story end-to-end across all four repos.

Stacked on `feat/persistence-responsive-frontend` (PR #307).

Parent Epic: xenoISA/isA_Mate#409 (E6)
Backend: xenoISA/isA_Mate#429
TS client: xenoISA/isA_App_SDK#313

## New files

```
src/config/gatewayConfig.ts     + MATE.AUTONOMOUS, MATE.REACTIVE blocks
src/api/types/autonomous.ts     BackgroundJob + JobStatus DTOs
src/api/types/reactive.ts       Webhook + EventSubscription DTOs
src/api/AutonomousService.ts    enqueueJob, listJobs, getJob, cancelJob
                                (with empty-prompt guard)
src/api/ReactiveService.ts      registerWebhook (path + secret guards),
                                listWebhooks, getWebhook, deleteWebhook,
                                subscribe (channel guard),
                                listSubscriptions, unsubscribe
src/api/__tests__/AutonomousReactiveService.test.ts
```

## Example usage

```typescript
import { autonomousService } from '@/api/AutonomousService';
import { reactiveService } from '@/api/ReactiveService';

// Background job
const job = await autonomousService.enqueueJob({
  prompt: 'Summarise overnight email',
  idempotency_key: `morning-${new Date().toISOString().slice(0, 10)}`,
});

// Webhook
await reactiveService.registerWebhook({
  path: '/incoming/github',
  secret: process.env.GITHUB_WEBHOOK_SECRET!,
  action_prompt: 'Triage new issues',
});

// Event subscription
await reactiveService.subscribe({
  channel: 'trades',
  filter: { symbol: 'BTC' },
});
```

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L2 Component (Vitest + mocked fetch) | 12 | Pass |

Coverage: empty-prompt local guard, webhook path/secret local guards, empty channel local guard, DELETE 204 handling, URL-encoded ids, auth header forwarding.

## Out of scope (follow-ups)

- Async-task panel UI (uses `autonomousService`)
- "Running in background" badges in chat header
- Webhook configuration UI
- Event subscription manager

All unblocked by this PR.

---

## 🎉 Full capability exposure complete

This PR completes **E1-E6** — all six capability personas now have:
- Mate HTTP routes (backend)
- Pydantic DTOs (SDK)
- `@isa/transport` TS clients (SDK)
- `*Service` API clients (frontend)

**Wave-by-wave totals:**
- Wave 1 (HIL) — 4 PRs, 51 tests
- Wave 2 (Proactive + Observability) — 4 PRs, 56 tests
- Wave 3 (Persistence + Responsive) — 4 PRs, 68 tests
- Wave 4 (Autonomous + Reactive) — 3 PRs, 45 tests

**Grand total: 15 PRs across 4 repos, 220+ new tests, all green.**