### PR TITLE
feat(ui): eager warmup trigger on page load (#276)

### DIFF
--- a/src/api/__tests__/mateService.warmup.test.ts
+++ b/src/api/__tests__/mateService.warmup.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { MateService } from '../mateService';
+import { BaseApiService } from '../BaseApiService';
+
+vi.mock('../BaseApiService', () => {
+  const mockGet = vi.fn();
+  const mockPost = vi.fn();
+  return {
+    BaseApiService: vi.fn().mockImplementation(() => ({
+      get: mockGet,
+      post: mockPost,
+    })),
+  };
+});
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    MATE: {
+      BASE: 'http://mate.test',
+      HEALTH: 'http://mate.test/health',
+      CONTEXT_WARMUP: 'http://mate.test/v1/context/warmup',
+      MEMORY: {
+        SESSIONS: 'http://mate.test/v1/memory/sessions',
+        SESSION_MESSAGES: 'http://mate.test/v1/memory/sessions/{sessionId}/messages',
+        KNOWLEDGE: 'http://mate.test/v1/memory/knowledge',
+        KNOWLEDGE_ITEM: 'http://mate.test/v1/memory/knowledge/{itemId}',
+      },
+      SCHEDULER: {
+        JOBS: 'http://mate.test/v1/scheduler/jobs',
+        JOB: 'http://mate.test/v1/scheduler/jobs/{jobId}',
+        JOB_RUN: 'http://mate.test/v1/scheduler/jobs/{jobId}/run',
+      },
+      TOOLS: 'http://mate.test/v1/tools',
+    },
+  },
+  buildUrlWithParams: (url: string) => url,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  LogCategory: { API_REQUEST: 'api_request' },
+}));
+
+const getPost = () => {
+  const mod = vi.mocked(BaseApiService);
+  return mod.mock.results[0]?.value.post as ReturnType<typeof vi.fn>;
+};
+
+describe('MateService.triggerWarmup', () => {
+  let service: MateService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new MateService();
+  });
+
+  test('POSTs to the warmup endpoint with an empty body', async () => {
+    getPost().mockResolvedValueOnce({ success: true, data: {}, statusCode: 200 });
+
+    await service.triggerWarmup();
+
+    expect(getPost()).toHaveBeenCalledWith('http://mate.test/v1/context/warmup', {});
+  });
+
+  test('resolves silently when backend returns 404 (older Mate, no endpoint)', async () => {
+    getPost().mockResolvedValueOnce({ success: false, statusCode: 404, error: 'Not Found' });
+
+    await expect(service.triggerWarmup()).resolves.toBeUndefined();
+  });
+
+  test('resolves silently when BaseApiService reports non-success without 404', async () => {
+    getPost().mockResolvedValueOnce({ success: false, statusCode: 500, error: 'Internal' });
+
+    await expect(service.triggerWarmup()).resolves.toBeUndefined();
+  });
+
+  test('resolves silently when the POST throws (network failure)', async () => {
+    getPost().mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await expect(service.triggerWarmup()).resolves.toBeUndefined();
+  });
+});

--- a/src/api/mateService.ts
+++ b/src/api/mateService.ts
@@ -75,6 +75,33 @@ export class MateService {
     }
   }
 
+  /**
+   * Fire-and-forget warmup ping — primes Mate's RuntimeContextHelper cache
+   * so the user's first message doesn't pay a 10-15s cold-start cost.
+   *
+   * Contract: MUST NOT throw. Older Mate versions without the endpoint
+   * return 404 — treated as a no-op. Network errors are swallowed.
+   */
+  async triggerWarmup(): Promise<void> {
+    try {
+      log.info('Warming up Mate backend');
+      const response = await this.apiService.post<unknown>(
+        GATEWAY_ENDPOINTS.MATE.CONTEXT_WARMUP,
+        {}
+      );
+      if (response.success) return;
+      if (response.statusCode === 404) {
+        log.info('Mate warmup endpoint not available (404) — skipping');
+        return;
+      }
+      log.warn('Mate warmup non-success', { statusCode: response.statusCode, error: response.error });
+    } catch (error) {
+      log.warn('Mate warmup threw (ignored)', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   // ================================================================================
   // Memory — Sessions & Messages
   // ================================================================================

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -158,6 +158,7 @@ export const GATEWAY_ENDPOINTS = {
         JOB_RUN: buildMateEndpoint('/v1/scheduler/jobs/{jobId}/run'),
       },
       HEALTH: buildMateEndpoint('/health'),
+      CONTEXT_WARMUP: buildMateEndpoint('/v1/context/warmup'),
       AUTONOMOUS_EVENTS: buildMateEndpoint('/v1/autonomous/events'),
       // Human-in-the-Loop capability router — maps to xenoISA/isA_Mate#404
       // /v1/interactive/*. Replaces the defunct AGENTS.EXECUTION probe that

--- a/src/hooks/__tests__/useMatePresence.warmup.test.ts
+++ b/src/hooks/__tests__/useMatePresence.warmup.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+import { shouldTriggerWarmup, WARMUP_TTL_MS } from '../useMatePresence';
+
+describe('shouldTriggerWarmup — debounce predicate', () => {
+  test('returns true when never fired before (now=Date.now, prev=0)', () => {
+    // In real usage Date.now() is far beyond TTL vs the initial 0 sentinel.
+    expect(shouldTriggerWarmup(Date.now(), 0)).toBe(true);
+  });
+
+  test('returns false inside the TTL window', () => {
+    const now = 10 * 60 * 1000; // 10 min
+    const fired = now - (WARMUP_TTL_MS - 1); // just inside TTL
+    expect(shouldTriggerWarmup(now, fired)).toBe(false);
+  });
+
+  test('returns true exactly at TTL boundary', () => {
+    const now = 10 * 60 * 1000;
+    const fired = now - WARMUP_TTL_MS;
+    expect(shouldTriggerWarmup(now, fired)).toBe(true);
+  });
+
+  test('returns true beyond the TTL window', () => {
+    const now = 20 * 60 * 1000;
+    const fired = now - (WARMUP_TTL_MS + 1);
+    expect(shouldTriggerWarmup(now, fired)).toBe(true);
+  });
+
+  test('accepts a custom TTL override', () => {
+    expect(shouldTriggerWarmup(100, 50, 100)).toBe(false);
+    expect(shouldTriggerWarmup(200, 50, 100)).toBe(true);
+  });
+
+  test('WARMUP_TTL_MS matches the 5-minute RuntimeContextHelper cache window', () => {
+    expect(WARMUP_TTL_MS).toBe(5 * 60 * 1000);
+  });
+});

--- a/src/hooks/useMatePresence.ts
+++ b/src/hooks/useMatePresence.ts
@@ -5,6 +5,10 @@
  *
  * Returns live online/offline status, active channels, and working state.
  * Polls every 30 seconds. Handles Mate-offline gracefully.
+ *
+ * Also fires a fire-and-forget warmup ping on the first successful health
+ * check of a session so the user's first message doesn't pay the
+ * RuntimeContextHelper cold-start cost (#276).
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -13,6 +17,27 @@ import { useMessageStore } from '../stores/useMessageStore';
 import type { MateHealthResponse } from '../types/mateTypes';
 
 const POLL_INTERVAL_MS = 30_000;
+export const WARMUP_TTL_MS = 5 * 60 * 1000; // matches RuntimeContextHelper cache TTL
+
+// Module-level debounce so remounts in the same session don't re-fire.
+let lastWarmupAt = 0;
+
+/** Pure predicate — exported for unit tests. */
+export function shouldTriggerWarmup(now: number, previouslyFiredAt: number, ttlMs: number = WARMUP_TTL_MS): boolean {
+  return now - previouslyFiredAt >= ttlMs;
+}
+
+/** Test-only: reset module state between test cases. */
+export function __resetWarmupForTests(): void {
+  lastWarmupAt = 0;
+}
+
+/** Test-only: inspect last warmup timestamp. */
+export function __getLastWarmupAtForTests(): number {
+  return lastWarmupAt;
+}
+
+export type WarmupStatus = 'idle' | 'warming' | 'ready';
 
 export interface MatePresenceState {
   isOnline: boolean;
@@ -21,6 +46,7 @@ export interface MatePresenceState {
   isWorking: boolean;
   lastChecked: Date | null;
   error: string | null;
+  warmupStatus: WarmupStatus;
 }
 
 export function useMatePresence(): MatePresenceState {
@@ -31,9 +57,23 @@ export function useMatePresence(): MatePresenceState {
     isWorking: false,
     lastChecked: null,
     error: null,
+    warmupStatus: 'idle',
   });
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const triggerWarmupIfNeeded = useCallback(() => {
+    const now = Date.now();
+    if (!shouldTriggerWarmup(now, lastWarmupAt)) return;
+    lastWarmupAt = now;
+    setState((prev) => ({ ...prev, warmupStatus: 'warming' }));
+    // Fire-and-forget — triggerWarmup never throws
+    getMateService()
+      .triggerWarmup()
+      .finally(() => {
+        setState((prev) => ({ ...prev, warmupStatus: 'ready' }));
+      });
+  }, []);
 
   const poll = useCallback(async () => {
     try {
@@ -43,14 +83,18 @@ export function useMatePresence(): MatePresenceState {
         (d) => d.status === 'delegating' || d.status === 'working'
       );
 
-      setState({
+      setState((prev) => ({
+        ...prev,
         isOnline: true,
         status: health.status,
         channels: health.channels ?? [],
         isWorking: working,
         lastChecked: new Date(),
         error: null,
-      });
+      }));
+
+      // Fire eager warmup on the first successful health check (debounced)
+      triggerWarmupIfNeeded();
     } catch (err) {
       setState((prev) => ({
         ...prev,
@@ -61,7 +105,7 @@ export function useMatePresence(): MatePresenceState {
         error: err instanceof Error ? err.message : String(err),
       }));
     }
-  }, []);
+  }, [triggerWarmupIfNeeded]);
 
   useEffect(() => {
     // Initial poll


### PR DESCRIPTION
## Summary
Adds a fire-and-forget warmup ping to prime Mate's RuntimeContextHelper cache on page load so the first message doesn't pay the 10-15s cold-start cost.

## Changes
- **`src/config/gatewayConfig.ts`** — new `MATE.CONTEXT_WARMUP` endpoint (`/v1/context/warmup`).
- **`src/api/mateService.ts`** — `triggerWarmup()` POSTs to the endpoint; on 404 (older Mate without the endpoint) or network error, logs and resolves silently. Never throws.
- **`src/hooks/useMatePresence.ts`** — on first successful health check, fires warmup; tracks `warmupStatus: 'idle' | 'warming' | 'ready'`. Module-level debounce (5 min) survives remounts.
- **Pure predicate** `shouldTriggerWarmup(now, prevAt, ttl?)` extracted for direct unit testing.

## Acceptance Criteria
- [x] Warmup request fires within 2s of page load — triggered right after the first successful health poll.
- [x] Only fires once per session (or once per 5 min if tab stays open) — module-level `lastWarmupAt` + TTL check.
- [x] Does not block any UI interaction — fire-and-forget, no await in the poll path.
- [x] Gracefully handles 404 — `triggerWarmup` swallows it.
- [x] No user-visible change — `warmupStatus` is opt-in telemetry for future TTFT work (#277).

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit (shouldTriggerWarmup debounce) | 6 | ✓ Pass |
| L2 Component (MateService.triggerWarmup) | 4 | ✓ Pass |

Full vitest suite: 446 passed / 9 pre-existing failures / 0 regressions.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)