### PR TITLE
feat(ui): TTFT telemetry for chat messages (#277)

### DIFF
--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -8,12 +8,14 @@ import { useChatStore } from '../../stores/useChatStore';
 import { useMessageStore } from '../../stores/useMessageStore';
 import { useBranchStore } from '../../stores/useBranchStore';
 import { useUserStore } from '../../stores/useUserStore';
+import { usePerformanceStore } from '../../stores/usePerformanceStore';
 import { logger, LogCategory, createLogger } from '../../utils/logger';
 import { detectPluginTrigger, executePlugin } from '../../plugins';
 import { ArtifactMessage } from '../../types/chatTypes';
 import { AppId } from '../../types/appTypes';
 import { CreditConsumption } from '../../types/userTypes';
 import { isDelegationTool } from '../../constants/delegationTeams';
+import { MessageTimingTracker, formatTimingLog } from '../../utils/messageTiming';
 
 const log = createLogger('ChatModule:Message');
 
@@ -53,6 +55,16 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     setHuntSearchResults,
   } = deps;
 
+  // Commit message timing to the performance store and log in dev mode (#277).
+  const commitMessageTiming = (tracker: MessageTimingTracker) => {
+    const snapshot = tracker.snapshot();
+    usePerformanceStore.getState().recordTiming(snapshot);
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.debug(formatTimingLog(snapshot));
+    }
+  };
+
   // Deduct credits after a completed message send:
   // optimistic UI update first, then backend consume. Revert on backend failure.
   const consumeCreditsAfterSend = (reason: string, amount = 1) => {
@@ -87,6 +99,9 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
       setShowUpgradeModal(true);
       return;
     }
+
+    const timing = new MessageTimingTracker();
+    timing.markSent();
 
     let sessionId = currentSessionId;
 
@@ -219,6 +234,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
         await sendFn({
           onStreamStart: (messageId: string, status?: string) => {
+            timing.markStreamStart();
             // Remove the placeholder — don't finishStreamingMessage (which persists empty content)
             const messages = useMessageStore.getState().messages;
             const lastMsg = messages[messages.length - 1];
@@ -232,18 +248,21 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
             useChatStore.getState().setExecutingPlan(true);
           },
           onStreamContent: (contentChunk: string) => {
+            timing.markFirstToken();
             useChatStore.getState().appendToStreamingMessage(contentChunk);
           },
           onStreamStatus: (status: string) => {
             useChatStore.getState().updateStreamingStatus(status);
           },
           onStreamComplete: () => {
+            timing.markComplete();
             useChatStore.getState().finishStreamingMessage();
             useChatStore.getState().setChatLoading(false);
             useChatStore.getState().setIsTyping(false);
             useChatStore.getState().setExecutingPlan(false);
             logger.info(LogCategory.CHAT_FLOW, 'Message sending completed successfully');
 
+            commitMessageTiming(timing);
             consumeCreditsAfterSend('message_send');
 
             // Artifact edit-to-version: if this was an artifact edit, create new version (#256)
@@ -321,6 +340,9 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
     log.info('Credit check passed for multimodal, proceeding with message send');
 
+    const timing = new MessageTimingTracker();
+    timing.markSent();
+
     const enrichedMetadata = {
       ...metadata,
       user_id: authUserSub || (() => { throw new Error('User not authenticated') })(),
@@ -351,22 +373,26 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
       await chatService.sendMultimodalMessage(content, enrichedMetadata, token, {
         onStreamStart: (messageId: string, status?: string) => {
+          timing.markStreamStart();
           useChatStore.getState().startStreamingMessage(messageId, status);
           useChatStore.getState().setExecutingPlan(true);
         },
         onStreamContent: (contentChunk: string) => {
+          timing.markFirstToken();
           useChatStore.getState().appendToStreamingMessage(contentChunk);
         },
         onStreamStatus: (status: string) => {
           useChatStore.getState().updateStreamingStatus(status);
         },
         onStreamComplete: () => {
+          timing.markComplete();
           useChatStore.getState().finishStreamingMessage();
           useChatStore.getState().setChatLoading(false);
           useChatStore.getState().setIsTyping(false);
           useChatStore.getState().setExecutingPlan(false);
           logger.info(LogCategory.CHAT_FLOW, 'Multimodal message sending completed successfully');
 
+          commitMessageTiming(timing);
           consumeCreditsAfterSend('multimodal_send');
         },
         onError: (error: Error) => {

--- a/src/stores/__tests__/usePerformanceStore.test.ts
+++ b/src/stores/__tests__/usePerformanceStore.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { usePerformanceStore, selectLastMessageTiming } from '../usePerformanceStore';
+import type { MessageTiming } from '../../utils/messageTiming';
+
+const sample: MessageTiming = {
+  ttft_ms: 1200,
+  stream_start_ms: 80,
+  stream_duration_ms: 400,
+  total_ms: 1600,
+  timestamp: '2026-04-21T00:00:00.000Z',
+};
+
+describe('usePerformanceStore', () => {
+  beforeEach(() => {
+    usePerformanceStore.getState().clear();
+  });
+
+  test('initial state is null', () => {
+    expect(usePerformanceStore.getState().lastMessageTiming).toBeNull();
+  });
+
+  test('recordTiming replaces the previous timing', () => {
+    usePerformanceStore.getState().recordTiming(sample);
+    expect(usePerformanceStore.getState().lastMessageTiming).toEqual(sample);
+
+    const next: MessageTiming = { ...sample, ttft_ms: 500, timestamp: '2026-04-21T00:00:01.000Z' };
+    usePerformanceStore.getState().recordTiming(next);
+    expect(usePerformanceStore.getState().lastMessageTiming).toEqual(next);
+  });
+
+  test('clear() resets to null', () => {
+    usePerformanceStore.getState().recordTiming(sample);
+    usePerformanceStore.getState().clear();
+    expect(usePerformanceStore.getState().lastMessageTiming).toBeNull();
+  });
+
+  test('selectLastMessageTiming selector returns the current timing', () => {
+    usePerformanceStore.getState().recordTiming(sample);
+    expect(selectLastMessageTiming(usePerformanceStore.getState())).toEqual(sample);
+  });
+});

--- a/src/stores/usePerformanceStore.ts
+++ b/src/stores/usePerformanceStore.ts
@@ -1,0 +1,24 @@
+/**
+ * Performance telemetry store — holds timing data for the last message send (#277).
+ *
+ * Kept separate from useStreamingStore (which manages buffer/timer state) because
+ * this is pure observability, accessed by future dashboards / dev overlays and
+ * not coupled to streaming lifecycle.
+ */
+
+import { create } from 'zustand';
+import type { MessageTiming } from '../utils/messageTiming';
+
+interface PerformanceStore {
+  lastMessageTiming: MessageTiming | null;
+  recordTiming: (timing: MessageTiming) => void;
+  clear: () => void;
+}
+
+export const usePerformanceStore = create<PerformanceStore>((set) => ({
+  lastMessageTiming: null,
+  recordTiming: (timing) => set({ lastMessageTiming: timing }),
+  clear: () => set({ lastMessageTiming: null }),
+}));
+
+export const selectLastMessageTiming = (s: PerformanceStore) => s.lastMessageTiming;

--- a/src/utils/__tests__/messageTiming.test.ts
+++ b/src/utils/__tests__/messageTiming.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'vitest';
+import { MessageTimingTracker, formatTimingLog, type MessageTiming } from '../messageTiming';
+
+describe('MessageTimingTracker', () => {
+  test('snapshot is all null before any marks', () => {
+    const t = new MessageTimingTracker(() => 0);
+    const s = t.snapshot();
+    expect(s.ttft_ms).toBeNull();
+    expect(s.stream_start_ms).toBeNull();
+    expect(s.stream_duration_ms).toBeNull();
+    expect(s.total_ms).toBeNull();
+  });
+
+  test('computes all four metrics from t0..t3', () => {
+    // Clock that returns each value once in order.
+    const times = [100, 150, 250, 900];
+    let i = 0;
+    const now = () => times[i++];
+    const t = new MessageTimingTracker(now);
+
+    t.markSent();         // t0 = 100
+    t.markStreamStart();  // t1 = 150
+    t.markFirstToken();   // t2 = 250
+    t.markComplete();     // t3 = 900
+
+    const s = t.snapshot();
+    expect(s.stream_start_ms).toBe(50);
+    expect(s.ttft_ms).toBe(150);
+    expect(s.stream_duration_ms).toBe(650);
+    expect(s.total_ms).toBe(800);
+    expect(typeof s.timestamp).toBe('string');
+  });
+
+  test('markStreamStart / markFirstToken / markComplete are each idempotent (first call wins)', () => {
+    const clock = { v: 0 };
+    const now = () => clock.v;
+
+    const t = new MessageTimingTracker(now);
+    clock.v = 10; t.markSent();
+    clock.v = 20; t.markStreamStart();
+    clock.v = 30; t.markStreamStart();  // second call ignored
+    clock.v = 40; t.markFirstToken();
+    clock.v = 50; t.markFirstToken();   // second call ignored
+    clock.v = 60; t.markComplete();
+    clock.v = 70; t.markComplete();     // second call ignored
+
+    const s = t.snapshot();
+    expect(s.stream_start_ms).toBe(10);   // 20 - 10
+    expect(s.ttft_ms).toBe(30);           // 40 - 10
+    expect(s.total_ms).toBe(50);          // 60 - 10
+  });
+
+  test('ttft stays null when no content token arrives', () => {
+    const times = [0, 5, 100]; // t0, t1, t3 (no t2)
+    let i = 0;
+    const t = new MessageTimingTracker(() => times[i++]);
+    t.markSent();
+    t.markStreamStart();
+    t.markComplete();
+    const s = t.snapshot();
+    expect(s.stream_start_ms).toBe(5);
+    expect(s.ttft_ms).toBeNull();
+    expect(s.stream_duration_ms).toBeNull();
+    expect(s.total_ms).toBe(100);
+  });
+});
+
+describe('formatTimingLog', () => {
+  test('renders all metrics', () => {
+    const t: MessageTiming = {
+      ttft_ms: 1234.7,
+      stream_start_ms: 56.2,
+      stream_duration_ms: 789,
+      total_ms: 2000,
+      timestamp: '2026-04-21T00:00:00.000Z',
+    };
+    const out = formatTimingLog(t);
+    expect(out).toContain('[PERF]');
+    expect(out).toContain('TTFT: 1235ms');
+    expect(out).toContain('stream_start: 56ms');
+    expect(out).toContain('duration: 789ms');
+    expect(out).toContain('total: 2000ms');
+  });
+
+  test('renders em-dash for null fields', () => {
+    const t: MessageTiming = {
+      ttft_ms: null,
+      stream_start_ms: 10,
+      stream_duration_ms: null,
+      total_ms: 100,
+      timestamp: '2026-04-21T00:00:00.000Z',
+    };
+    const out = formatTimingLog(t);
+    expect(out).toContain('TTFT: —');
+    expect(out).toContain('duration: —');
+    expect(out).toContain('stream_start: 10ms');
+    expect(out).toContain('total: 100ms');
+  });
+});

--- a/src/utils/messageTiming.ts
+++ b/src/utils/messageTiming.ts
@@ -1,0 +1,68 @@
+/**
+ * Message timing tracker — measures chat-send latency landmarks (#277).
+ *
+ *   t0 = handleSendMessage() called
+ *   t1 = first SSE event of any kind (stream start)
+ *   t2 = first content token (TTFT)
+ *   t3 = stream complete
+ *
+ * Derived metrics:
+ *   stream_start_ms    = t1 - t0
+ *   ttft_ms            = t2 - t0    (time-to-first-token)
+ *   stream_duration_ms = t3 - t2
+ *   total_ms           = t3 - t0
+ */
+
+export interface MessageTiming {
+  ttft_ms: number | null;
+  stream_start_ms: number | null;
+  stream_duration_ms: number | null;
+  total_ms: number | null;
+  timestamp: string;
+}
+
+type NowFn = () => number;
+
+export class MessageTimingTracker {
+  private t0: number | null = null;
+  private t1: number | null = null;
+  private t2: number | null = null;
+  private t3: number | null = null;
+  private readonly now: NowFn;
+
+  constructor(now: NowFn = () => performance.now()) {
+    this.now = now;
+  }
+
+  markSent(): void {
+    this.t0 = this.now();
+  }
+
+  markStreamStart(): void {
+    if (this.t1 === null) this.t1 = this.now();
+  }
+
+  markFirstToken(): void {
+    if (this.t2 === null) this.t2 = this.now();
+  }
+
+  markComplete(): void {
+    if (this.t3 === null) this.t3 = this.now();
+  }
+
+  snapshot(): MessageTiming {
+    return {
+      stream_start_ms: this.t0 !== null && this.t1 !== null ? this.t1 - this.t0 : null,
+      ttft_ms: this.t0 !== null && this.t2 !== null ? this.t2 - this.t0 : null,
+      stream_duration_ms: this.t2 !== null && this.t3 !== null ? this.t3 - this.t2 : null,
+      total_ms: this.t0 !== null && this.t3 !== null ? this.t3 - this.t0 : null,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+/** Formatted one-line console log for dev-mode visibility. */
+export function formatTimingLog(t: MessageTiming): string {
+  const fmt = (v: number | null) => (v === null ? '—' : `${Math.round(v)}ms`);
+  return `[PERF] TTFT: ${fmt(t.ttft_ms)} | stream_start: ${fmt(t.stream_start_ms)} | duration: ${fmt(t.stream_duration_ms)} | total: ${fmt(t.total_ms)}`;
+}


### PR DESCRIPTION
## Summary
Measures four latency landmarks on every chat send so we can verify whether the Mate warmup work (#276, isA_MCP#525) actually reaches users.

- `t0` — `handleSendMessage()` called
- `t1` — first SSE event (`onStreamStart`)
- `t2` — first content token (`onStreamContent`)
- `t3` — stream complete (`onStreamComplete`)

Derived: `stream_start_ms`, `ttft_ms`, `stream_duration_ms`, `total_ms`.

## Changes
- **`src/utils/messageTiming.ts`** — `MessageTimingTracker` class + `formatTimingLog()`. Pure, injectable clock.
- **`src/stores/usePerformanceStore.ts`** — `{ lastMessageTiming, recordTiming, clear }`. Kept separate from `useStreamingStore` (buffer/timer state) because this is observability.
- **`src/modules/handlers/messageHandlers.ts`** — wire tracker into regular + multimodal send paths; commit to store + `console.debug` in dev.

## Acceptance Criteria
- [x] TTFT measured for every sent message — `markFirstToken()` fires on first `onStreamContent`.
- [x] Timing data stored in Zustand store (`usePerformanceStore.lastMessageTiming`).
- [x] Dev-mode console logging of all 4 metrics (`[PERF] TTFT: 1234ms | ...`).
- [x] No user-visible UI change in production (`process.env.NODE_ENV !== 'production'` guard).
- [x] Works with both streaming and non-streaming responses — null-safe arithmetic in `snapshot()`.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit (MessageTimingTracker, formatTimingLog) | 6 | ✓ Pass |
| L2 Component (usePerformanceStore) | 4 | ✓ Pass |

Full vitest suite: 456 passed / 9 pre-existing failures / **0 regressions**.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)