### PR TITLE
feat(ui): progressive warmup status in chat UI (#278)

### DIFF
--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -4,6 +4,7 @@ import { FileUpload } from './FileUpload';
 import { GlassChatInput, GlassCard, GlassButton, IntelligentModeSettings } from '../../shared';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { useMatePresence } from '../../../hooks/useMatePresence';
+import { useProgressiveStage } from '../../../hooks/useProgressiveStage';
 import { useMessageStore } from '../../../stores/useMessageStore';
 import { useStreamingStore } from '../../../stores/useStreamingStore';
 import { ModelSelectorDropdown } from './ModelSelectorDropdown';
@@ -85,6 +86,8 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
   const { t } = useTranslation();
   const { isOnline, isWorking, channels } = useMatePresence();
   const stopStreaming = useStreamingStore((s) => s.stopStreaming);
+  const sendStartedAt = useStreamingStore((s) => s.sendStartedAt);
+  const progressiveStage = useProgressiveStage(sendStartedAt);
   const allMessages = useMessageStore((s) => s.messages);
   const lastMsg = allMessages[allMessages.length - 1];
   const isActivelyStreaming = !!(lastMsg && 'isStreaming' in lastMsg && lastMsg.isStreaming);
@@ -436,17 +439,21 @@ export const InputAreaLayout: React.FC<InputAreaLayoutProps> = ({
         </div>
       )}
 
-      {/* Mate status line — SDK StreamingStatusLine (#290) */}
+      {/* Mate status line — SDK StreamingStatusLine (#290)
+          Progressive warmup stages drive phase/message while a send is in flight (#278). */}
       <div className="mb-2 px-1">
         <StreamingStatusLine
           phase={
             isActivelyStreaming ? 'generating'
+            : progressiveStage ? progressiveStage.phase
             : !isOnline ? 'connecting'
             : isWorking ? 'preparing'
             : 'idle'
           }
           message={
-            isWorking && !isActivelyStreaming
+            progressiveStage && !isActivelyStreaming
+              ? progressiveStage.label
+              : isWorking && !isActivelyStreaming
               ? `Working on ${activeDelegationCount} task${activeDelegationCount !== 1 ? 's' : ''}...`
               : undefined
           }

--- a/src/hooks/__tests__/useProgressiveStage.test.ts
+++ b/src/hooks/__tests__/useProgressiveStage.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'vitest';
+import { pickStage, DEFAULT_STAGES } from '../useProgressiveStage';
+
+describe('pickStage — time-based synthetic warmup stages (#278)', () => {
+  test('returns connecting at 0ms', () => {
+    expect(pickStage(0).phase).toBe('connecting');
+    expect(pickStage(0).label).toBe('Connecting...');
+  });
+
+  test('stays on connecting below 1s', () => {
+    expect(pickStage(500).label).toBe('Connecting...');
+    expect(pickStage(999).label).toBe('Connecting...');
+  });
+
+  test('transitions to preparing at 1s', () => {
+    expect(pickStage(1_000).phase).toBe('preparing');
+    expect(pickStage(1_000).label).toBe('Preparing...');
+  });
+
+  test('transitions to thinking at 3s', () => {
+    expect(pickStage(3_000).phase).toBe('preparing');
+    expect(pickStage(3_000).label).toBe('Thinking...');
+  });
+
+  test('transitions to still working at 5s', () => {
+    expect(pickStage(5_000).label).toBe('Still working... (complex query)');
+    expect(pickStage(30_000).label).toBe('Still working... (complex query)');
+  });
+
+  test('stages are monotonically ordered by atMs', () => {
+    for (let i = 1; i < DEFAULT_STAGES.length; i++) {
+      expect(DEFAULT_STAGES[i].atMs).toBeGreaterThan(DEFAULT_STAGES[i - 1].atMs);
+    }
+  });
+
+  test('accepts a custom threshold table', () => {
+    const custom = [
+      { atMs: 0, phase: 'connecting' as const, label: 'A' },
+      { atMs: 100, phase: 'preparing' as const, label: 'B' },
+    ];
+    expect(pickStage(50, custom).label).toBe('A');
+    expect(pickStage(100, custom).label).toBe('B');
+  });
+
+  test('returns idle if the threshold table is empty', () => {
+    expect(pickStage(1000, []).phase).toBe('idle');
+    expect(pickStage(1000, []).label).toBe('');
+  });
+});

--- a/src/hooks/useProgressiveStage.ts
+++ b/src/hooks/useProgressiveStage.ts
@@ -1,0 +1,66 @@
+/**
+ * useProgressiveStage — drives the time-based synthetic warmup stages (#278).
+ *
+ * Phase 1: before the backend exposes stage_latency_ms, we reduce perceived
+ * wait by rotating status text based on how long the send has been in flight.
+ * Phase 2 (future): consume real stage events from SSE metadata.
+ */
+
+import { useEffect, useState } from 'react';
+
+export type ProgressiveStage = {
+  /** Matches StreamingStatusLine phase prop. */
+  phase: 'connecting' | 'preparing' | 'generating' | 'idle';
+  /** User-visible label. */
+  label: string;
+};
+
+export interface StageThreshold {
+  /** Elapsed milliseconds at which this stage kicks in. */
+  atMs: number;
+  phase: ProgressiveStage['phase'];
+  label: string;
+}
+
+/** Default thresholds — tuned to feel responsive under normal and cold paths. */
+export const DEFAULT_STAGES: readonly StageThreshold[] = [
+  { atMs: 0,     phase: 'connecting', label: 'Connecting...' },
+  { atMs: 1_000, phase: 'preparing',  label: 'Preparing...' },
+  { atMs: 3_000, phase: 'preparing',  label: 'Thinking...' },
+  { atMs: 5_000, phase: 'preparing',  label: 'Still working... (complex query)' },
+] as const;
+
+/** Pure: pick the stage that applies given elapsed time. */
+export function pickStage(
+  elapsedMs: number,
+  stages: readonly StageThreshold[] = DEFAULT_STAGES,
+): ProgressiveStage {
+  // Walk backwards so the highest-matching threshold wins.
+  for (let i = stages.length - 1; i >= 0; i--) {
+    if (elapsedMs >= stages[i].atMs) {
+      return { phase: stages[i].phase, label: stages[i].label };
+    }
+  }
+  return { phase: 'idle', label: '' };
+}
+
+/**
+ * Hook: returns the current progressive stage while a send is in flight.
+ * - When `sendStartedAt` is null, returns null (no in-flight send).
+ * - Otherwise ticks once per `tickMs` (default 500ms) to recompute elapsed time.
+ */
+export function useProgressiveStage(
+  sendStartedAt: number | null,
+  tickMs: number = 500,
+): ProgressiveStage | null {
+  const [, forceTick] = useState(0);
+
+  useEffect(() => {
+    if (sendStartedAt === null) return;
+    const id = setInterval(() => forceTick((n) => n + 1), tickMs);
+    return () => clearInterval(id);
+  }, [sendStartedAt, tickMs]);
+
+  if (sendStartedAt === null) return null;
+  return pickStage(Date.now() - sendStartedAt);
+}

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -9,6 +9,7 @@ import { useMessageStore } from '../../stores/useMessageStore';
 import { useBranchStore } from '../../stores/useBranchStore';
 import { useUserStore } from '../../stores/useUserStore';
 import { usePerformanceStore } from '../../stores/usePerformanceStore';
+import { useStreamingStore } from '../../stores/useStreamingStore';
 import { logger, LogCategory, createLogger } from '../../utils/logger';
 import { detectPluginTrigger, executePlugin } from '../../plugins';
 import { ArtifactMessage } from '../../types/chatTypes';
@@ -102,6 +103,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
     const timing = new MessageTimingTracker();
     timing.markSent();
+    useStreamingStore.getState().setSendStartedAt(Date.now());
 
     let sessionId = currentSessionId;
 
@@ -235,6 +237,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
         await sendFn({
           onStreamStart: (messageId: string, status?: string) => {
             timing.markStreamStart();
+            useStreamingStore.getState().setSendStartedAt(null);
             // Remove the placeholder — don't finishStreamingMessage (which persists empty content)
             const messages = useMessageStore.getState().messages;
             const lastMsg = messages[messages.length - 1];
@@ -296,6 +299,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
           },
           onError: (error: Error) => {
             logger.error(LogCategory.CHAT_FLOW, 'Message sending failed', { error: error.message });
+            useStreamingStore.getState().setSendStartedAt(null);
             useChatStore.getState().setChatLoading(false);
             useChatStore.getState().setIsTyping(false);
             useChatStore.getState().setExecutingPlan(false);
@@ -342,6 +346,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
     const timing = new MessageTimingTracker();
     timing.markSent();
+    useStreamingStore.getState().setSendStartedAt(Date.now());
 
     const enrichedMetadata = {
       ...metadata,
@@ -374,6 +379,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
       await chatService.sendMultimodalMessage(content, enrichedMetadata, token, {
         onStreamStart: (messageId: string, status?: string) => {
           timing.markStreamStart();
+          useStreamingStore.getState().setSendStartedAt(null);
           useChatStore.getState().startStreamingMessage(messageId, status);
           useChatStore.getState().setExecutingPlan(true);
         },
@@ -397,6 +403,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
         },
         onError: (error: Error) => {
           logger.error(LogCategory.CHAT_FLOW, 'Multimodal message sending failed', { error: error.message });
+          useStreamingStore.getState().setSendStartedAt(null);
           useChatStore.getState().setChatLoading(false);
           useChatStore.getState().setIsTyping(false);
           useChatStore.getState().setExecutingPlan(false);

--- a/src/stores/useStreamingStore.ts
+++ b/src/stores/useStreamingStore.ts
@@ -63,6 +63,9 @@ export interface StreamingStoreState {
   isThinking: boolean;
   /** Accumulated thinking content for the current streaming message */
   thinkingBuffer: string;
+  /** Timestamp (Date.now()) when the current send began, or null if no send in flight.
+   *  Used to drive the progressive warmup status stages (#278). */
+  sendStartedAt: number | null;
 }
 
 export interface StreamingActions {
@@ -82,6 +85,9 @@ export interface StreamingActions {
   startThinking: () => void;
   appendThinkingContent: (delta: string) => void;
   finishThinking: () => void;
+
+  /** Mark the moment the user pressed Send, or null to clear. */
+  setSendStartedAt: (ts: number | null) => void;
 }
 
 export type StreamingStore = StreamingStoreState & StreamingActions;
@@ -100,6 +106,7 @@ export const useStreamingStore = create<StreamingStore>()(
     activeAbortController: null,
     isThinking: false,
     thinkingBuffer: '',
+    sendStartedAt: null,
 
     setIsTyping: (typing) => {
       set({ isTyping: typing });
@@ -396,6 +403,10 @@ export const useStreamingStore = create<StreamingStore>()(
         }
       }
       set({ isThinking: false, thinkingBuffer: '' });
-    }
+    },
+
+    setSendStartedAt: (ts) => {
+      set({ sendStartedAt: ts });
+    },
   }))
 );


### PR DESCRIPTION
## Summary
Phase 1 of #278 — reduce perceived wait during cold starts by rotating the status line text based on elapsed time since send. No backend dependency.

| Elapsed | Phase | Label |
|---|---|---|
| 0-1s | `connecting` | Connecting... |
| 1-3s | `preparing` | Preparing... |
| 3-5s | `preparing` | Thinking... |
| 5s+ | `preparing` | Still working... (complex query) |

## Changes
- **`useStreamingStore`** — new \`sendStartedAt: number \| null\` + \`setSendStartedAt(ts)\`.
- **`src/hooks/useProgressiveStage.ts`** — hook that ticks every 500ms while a send is in flight, returns \`{ phase, label } \| null\`. \`pickStage()\` extracted as a pure predicate.
- **`messageHandlers.ts`** — set timestamp at the top of \`handleSendMessage\`/\`handleSendMultimodal\`; clear it on the first \`onStreamStart\` or on \`onError\` (both paths).
- **`InputAreaLayout.tsx`** — when \`progressiveStage\` is non-null and the message isn't actively streaming, it drives the phase + label of \`StreamingStatusLine\`.

## Acceptance Criteria (Phase 1)
- [x] Time-based synthetic stages visible during wait — driven by 500ms interval in \`useProgressiveStage\`.
- [x] Stages transition smoothly — \`pickStage()\` picks the highest-matching threshold, no flicker.
- [x] Falls back to existing \`isWorking\`/\`!isOnline\` behavior if no send in flight — \`progressiveStage === null\` path untouched.
- [ ] Phase 2 (future): real stage events consumed from SSE metadata — waiting on isA_MCP#526.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit (pickStage) | 8 | ✓ Pass |

Full vitest suite: 464 passed / 9 pre-existing failures / **0 regressions**.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)