### PR TITLE
feat(ui): populate ArtifactRendererRegistry with defaults + Dream renderer (#255)

### DIFF
--- a/src/components/ui/chat/ArtifactPanel.tsx
+++ b/src/components/ui/chat/ArtifactPanel.tsx
@@ -10,7 +10,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import type { ArtifactNode } from '../../../types/artifactTypes';
 import { getActiveVersion, getVersionCount } from '../../../types/artifactTypes';
 import { useArtifactManager } from '../../../stores/useArtifactManager';
-import { getRenderer, hasRenderer } from './ArtifactRendererRegistry';
+import { RenderArtifact } from './renderers';
 
 // Lazy-load A2UI renderer — only imported when an artifact has a2uiState
 let A2UIRendererModule: typeof import('./A2UISurfacePanel') | null = null;
@@ -374,19 +374,17 @@ export const ArtifactPanel: React.FC<ArtifactPanelInternalProps> = ({
                 surfaceEvents={surfaceEvents}
                 onUserAction={onUserAction}
               />
-            ) : (() => {
-              // Use ArtifactRendererRegistry for content-type dispatch (#255)
-              const Renderer = getRenderer(artifact.contentType);
-              return (
-                <Renderer
-                  content={activeVersion.content}
-                  language={activeVersion.language}
-                  title={artifact.title}
-                  a2uiState={activeVersion.a2uiState}
-                  metadata={artifact.metadata}
-                />
-              );
-            })()}
+            ) : (
+              // ArtifactRendererRegistry dispatch with widget + content fallback chain (#255)
+              <RenderArtifact
+                widgetType={artifact.widgetType}
+                content={activeVersion.content}
+                contentType={artifact.contentType}
+                language={activeVersion.language}
+                layout="inspect"
+                metadata={artifact.metadata}
+              />
+            )}
           </div>
         )}
 

--- a/src/components/ui/chat/renderers/CodeRenderer.tsx
+++ b/src/components/ui/chat/renderers/CodeRenderer.tsx
@@ -1,0 +1,9 @@
+/** Default code renderer — monospace block with language class hint (#255). */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+export const CodeRenderer: ArtifactRenderer = ({ content, language }) => (
+  <pre className="p-4 text-[13px] font-mono leading-relaxed text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-[#111111] rounded-lg overflow-x-auto">
+    <code className={language ? `language-${language}` : undefined}>{content}</code>
+  </pre>
+);

--- a/src/components/ui/chat/renderers/DataRenderer.tsx
+++ b/src/components/ui/chat/renderers/DataRenderer.tsx
@@ -1,0 +1,17 @@
+/** Default data renderer — JSON pretty-print with graceful fallback (#255). */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+export const DataRenderer: ArtifactRenderer = ({ content }) => {
+  let formatted = content;
+  try {
+    formatted = JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    // Not valid JSON — render as-is.
+  }
+  return (
+    <pre className="p-4 text-[12px] font-mono leading-relaxed text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-[#111111] rounded-lg overflow-x-auto">
+      <code>{formatted}</code>
+    </pre>
+  );
+};

--- a/src/components/ui/chat/renderers/DreamRenderer.tsx
+++ b/src/components/ui/chat/renderers/DreamRenderer.tsx
@@ -1,0 +1,48 @@
+/** Widget-specific renderer for Dream image artifacts (#255).
+ *  Dream artifacts are image URLs; the renderer adds a framed gallery
+ *  treatment distinct from the generic ImageRenderer so gallery context
+ *  is visually explicit. Content may be a single URL or a JSON array
+ *  of URLs. */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+function parseImageUrls(content: string): string[] {
+  const trimmed = content.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((s) => typeof s === 'string');
+      }
+    } catch {
+      // Fall through to single-url treatment.
+    }
+  }
+  return [trimmed];
+}
+
+export const DreamRenderer: ArtifactRenderer = ({ content, metadata }) => {
+  const urls = parseImageUrls(content);
+  const prompt = (metadata?.prompt as string | undefined) ?? undefined;
+
+  if (urls.length === 0) {
+    return <div className="text-sm text-gray-500">No images</div>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {prompt && (
+        <div className="text-xs text-gray-500 italic line-clamp-2" title={prompt}>
+          {prompt}
+        </div>
+      )}
+      <div className={`grid gap-3 ${urls.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+        {urls.map((url, i) => (
+          <div key={`${url}-${i}`} className="rounded-lg overflow-hidden bg-gray-50 dark:bg-[#111111] ring-1 ring-gray-200/60 dark:ring-white/10">
+            <img src={url} alt={`Dream image ${i + 1}`} className="w-full h-auto" loading="lazy" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/chat/renderers/HtmlRenderer.tsx
+++ b/src/components/ui/chat/renderers/HtmlRenderer.tsx
@@ -1,0 +1,14 @@
+/** Default HTML renderer — iframe-sandboxed to prevent XSS (#255).
+ *  Content is rendered in an isolated iframe with no scripts/same-origin
+ *  capability so untrusted markup can't access the parent page. */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+export const HtmlRenderer: ArtifactRenderer = ({ content }) => (
+  <iframe
+    srcDoc={content}
+    sandbox=""
+    title="Artifact HTML"
+    className="w-full min-h-[200px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white"
+  />
+);

--- a/src/components/ui/chat/renderers/ImageRenderer.tsx
+++ b/src/components/ui/chat/renderers/ImageRenderer.tsx
@@ -1,0 +1,10 @@
+/** Default image renderer — responsive img tag (#255). */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+export const ImageRenderer: ArtifactRenderer = ({ content, metadata }) => {
+  const alt = (metadata?.alt as string | undefined) ?? 'Artifact image';
+  return (
+    <img src={content} alt={alt} className="max-w-full rounded-lg" loading="lazy" />
+  );
+};

--- a/src/components/ui/chat/renderers/TextRenderer.tsx
+++ b/src/components/ui/chat/renderers/TextRenderer.tsx
@@ -1,0 +1,9 @@
+/** Default text renderer — whitespace-preserving prose (#255). */
+import React from 'react';
+import type { ArtifactRenderer } from '../../../../systems/ArtifactRendererRegistry';
+
+export const TextRenderer: ArtifactRenderer = ({ content }) => (
+  <div className="text-[15px] leading-[1.6] text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+    {content}
+  </div>
+);

--- a/src/components/ui/chat/renderers/index.tsx
+++ b/src/components/ui/chat/renderers/index.tsx
@@ -1,0 +1,74 @@
+/** Registrations + fallback wrapper for the artifact renderer registry (#255).
+ *
+ *  Side-effecting: importing this module registers the default renderers
+ *  (text/code/image/data/html + alias 'svg') and one widget-specific
+ *  renderer (Dream → image gallery). Import once from the app root.
+ */
+import React from 'react';
+import {
+  registerArtifactRenderer,
+  getArtifactRenderer,
+  type ArtifactRendererProps,
+  type ArtifactRenderer,
+} from '../../../../systems/ArtifactRendererRegistry';
+import { TextRenderer } from './TextRenderer';
+import { CodeRenderer } from './CodeRenderer';
+import { ImageRenderer } from './ImageRenderer';
+import { DataRenderer } from './DataRenderer';
+import { HtmlRenderer } from './HtmlRenderer';
+import { DreamRenderer } from './DreamRenderer';
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerDefaultRenderers(): void {
+  // Content-type defaults
+  registerArtifactRenderer('text', TextRenderer);
+  registerArtifactRenderer('code', CodeRenderer);
+  registerArtifactRenderer('image', ImageRenderer);
+  registerArtifactRenderer('data', DataRenderer);
+  registerArtifactRenderer('html', HtmlRenderer);
+
+  // Aliases to the closest default
+  registerArtifactRenderer('svg', HtmlRenderer);
+  registerArtifactRenderer('chart', DataRenderer);
+  registerArtifactRenderer('analysis', TextRenderer);
+  registerArtifactRenderer('search_results', DataRenderer);
+  registerArtifactRenderer('form', HtmlRenderer);
+  registerArtifactRenderer('dashboard', HtmlRenderer);
+
+  // Widget-specific renderers
+  registerArtifactRenderer('dream', DreamRenderer);
+}
+
+// Register on module load — importing this file once wires the registry.
+registerDefaultRenderers();
+
+// ---------------------------------------------------------------------------
+// FallbackRenderer — safety net for unknown types
+// ---------------------------------------------------------------------------
+
+export const FallbackRenderer: ArtifactRenderer = ({ content, contentType }) => (
+  <div className="p-4 text-sm text-gray-500 dark:text-gray-400">
+    <div className="text-xs uppercase tracking-wide mb-2">
+      Unsupported type: {String(contentType ?? 'unknown')}
+    </div>
+    <div className="font-mono text-xs whitespace-pre-wrap break-all line-clamp-8">
+      {content}
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// RenderArtifact — component wrapper that resolves + renders with fallback
+// ---------------------------------------------------------------------------
+
+export interface RenderArtifactProps extends ArtifactRendererProps {
+  widgetType?: string;
+}
+
+export const RenderArtifact: React.FC<RenderArtifactProps> = ({ widgetType, ...props }) => {
+  const Renderer = getArtifactRenderer(widgetType, props.contentType) ?? FallbackRenderer;
+  return <Renderer {...props} />;
+};

--- a/src/modules/AppModule.tsx
+++ b/src/modules/AppModule.tsx
@@ -45,6 +45,8 @@ import { CommandPalette } from '../components/ui/chat/CommandPalette';
 import { SettingsModal } from '../components/ui/settings/SettingsModal';
 import { ArtifactCanvas } from '../components/ui/chat/ArtifactCanvas';
 import { ArtifactSheet } from '../components/ui/chat/ArtifactSheet';
+// Side-effect import: registers default + widget-specific artifact renderers (#255)
+import '../components/ui/chat/renderers';
 import { KeyboardShortcutsOverlay } from '../components/ui/settings/KeyboardShortcutsOverlay';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 

--- a/src/systems/__tests__/ArtifactRendererRegistry.test.ts
+++ b/src/systems/__tests__/ArtifactRendererRegistry.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import React from 'react';
+import {
+  registerArtifactRenderer,
+  getArtifactRenderer,
+  getRegisteredRenderers,
+  clearRegistry,
+} from '../ArtifactRendererRegistry';
+
+const StubRenderer = () => null;
+
+describe('ArtifactRendererRegistry — fallback chain', () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  test('returns null when nothing is registered', () => {
+    expect(getArtifactRenderer('dream', 'image')).toBeNull();
+    expect(getArtifactRenderer(undefined, undefined)).toBeNull();
+  });
+
+  test('widget:content wins over widget alone', () => {
+    const Widget = () => null;
+    const WidgetContent = () => null;
+    registerArtifactRenderer('dream', Widget);
+    registerArtifactRenderer('dream:image', WidgetContent);
+    expect(getArtifactRenderer('dream', 'image')).toBe(WidgetContent);
+  });
+
+  test('widget wins over contentType-only', () => {
+    const ContentOnly = () => null;
+    const Widget = () => null;
+    registerArtifactRenderer('image', ContentOnly);
+    registerArtifactRenderer('dream', Widget);
+    expect(getArtifactRenderer('dream', 'image')).toBe(Widget);
+  });
+
+  test('contentType is used when no widget match', () => {
+    const ContentOnly = () => null;
+    registerArtifactRenderer('image', ContentOnly);
+    expect(getArtifactRenderer('unknown_widget', 'image')).toBe(ContentOnly);
+  });
+
+  test('returns null when neither widget nor content matches', () => {
+    registerArtifactRenderer('dream', StubRenderer);
+    expect(getArtifactRenderer('hunt', 'image')).toBeNull();
+  });
+
+  test('getRegisteredRenderers returns all keys', () => {
+    registerArtifactRenderer('a', StubRenderer);
+    registerArtifactRenderer('b', StubRenderer);
+    registerArtifactRenderer('c:d', StubRenderer);
+    expect(getRegisteredRenderers().sort()).toEqual(['a', 'b', 'c:d']);
+  });
+
+  test('register overwrites an existing key', () => {
+    const First = () => null;
+    const Second = () => null;
+    registerArtifactRenderer('text', First);
+    registerArtifactRenderer('text', Second);
+    expect(getArtifactRenderer(undefined, 'text')).toBe(Second);
+  });
+});
+
+describe('Default renderer registration (side-effect import)', () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  test('registerDefaultRenderers populates all advertised types', async () => {
+    const { registerDefaultRenderers } = await import('../../components/ui/chat/renderers');
+    registerDefaultRenderers();
+
+    const required = ['text', 'code', 'image', 'data', 'html', 'dream', 'svg', 'chart', 'analysis', 'search_results'];
+    for (const key of required) {
+      expect(getArtifactRenderer(undefined, key as any)).not.toBeNull();
+    }
+  });
+
+  test('DreamRenderer wins for widgetType=dream regardless of contentType', async () => {
+    const { registerDefaultRenderers } = await import('../../components/ui/chat/renderers');
+    registerDefaultRenderers();
+
+    const renderer = getArtifactRenderer('dream', 'image');
+    expect(renderer).not.toBeNull();
+    expect(renderer?.name).toBe('DreamRenderer');
+  });
+});


### PR DESCRIPTION
## Summary
Finishes #255. The registry file at `src/systems/ArtifactRendererRegistry.ts` has existed since an earlier epic but shipped with zero renderers — callers relied on hardcoded branching, and a stale *different-API* duplicate sat untracked at `src/components/ui/chat/ArtifactRendererRegistry.ts`.

This PR populates the registry, deletes the stale duplicate, and migrates one call site.

## Changes
- **Delete**: `src/components/ui/chat/ArtifactRendererRegistry.ts` (stale duplicate with incompatible API).
- **Add**: `src/components/ui/chat/renderers/` directory — 5 default content renderers + 1 widget-specific renderer.
  - `TextRenderer`, `CodeRenderer`, `ImageRenderer`, `DataRenderer`, `HtmlRenderer`.
  - `DreamRenderer` (image gallery, matches `widgetType === 'dream'`).
  - Aliases registered: `svg → HtmlRenderer`, `chart → DataRenderer`, `analysis → TextRenderer`, `search_results → DataRenderer`, `form/dashboard → HtmlRenderer`.
- **Add**: `RenderArtifact` wrapper — resolves via `getArtifactRenderer(widgetType, contentType)`, falls back to a clearly-labelled `FallbackRenderer` for unknown types (meets the "prevents crashes" AC).
- **Wire**: `AppModule.tsx` imports the renderers barrel once as a side-effect, triggering registrations at app start.
- **Migrate**: `ArtifactPanel.tsx` — replace the stale `getRenderer/hasRenderer` call with `<RenderArtifact />`, now threading `widgetType` through the fallback chain.

## Security note
`HtmlRenderer` uses `<iframe srcDoc sandbox="">` — the empty sandbox attribute disables scripts, same-origin access, forms, and everything else. Even if an agent emits malicious HTML, it cannot escape the iframe.

## Acceptance Criteria
- [x] Registry with register/get/fallback — existed; now populated.
- [x] Default renderers for 5 content types — text, code, image, data, html.
- [x] At least 1 custom widget renderer — `DreamRenderer`.
- [x] Fallback renderer prevents crashes — `FallbackRenderer` exported + used by `RenderArtifact`.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit (registry fallback chain) | 7 | ✓ Pass |
| L2 Component (default registration) | 2 | ✓ Pass |

Full vitest suite: **479 passed / 9 pre-existing failures / 0 regressions**.

## Remaining scope (out of this PR)
- `ArtifactSheet` and `ArtifactPeekCard` still use their local branching — can be migrated incrementally. Registry works for both; migrating them is pure cleanup.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)