### PR TITLE
feat(ui): triggers settings panel with dry-run (#303)

### DIFF
--- a/src/components/ui/settings/SettingsModal.tsx
+++ b/src/components/ui/settings/SettingsModal.tsx
@@ -9,8 +9,9 @@ import { MemoryManager } from './MemoryManager';
 import { SkillBuilder } from './SkillBuilder';
 import { ConnectorMarketplace } from './ConnectorMarketplace';
 import { CalendarSyncSettings } from '../calendar/CalendarSyncSettings';
+import { TriggersPanel } from './TriggersPanel';
 
-type SettingsTab = 'general' | 'appearance' | 'project' | 'memory' | 'skills' | 'calendar' | 'integrations';
+type SettingsTab = 'general' | 'appearance' | 'project' | 'memory' | 'skills' | 'triggers' | 'calendar' | 'integrations';
 
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
@@ -18,6 +19,7 @@ const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'project', label: 'Project' },
   { id: 'memory', label: 'Memory' },
   { id: 'skills', label: 'Skills' },
+  { id: 'triggers', label: 'Triggers' },
   { id: 'calendar', label: 'Calendar' },
   { id: 'integrations', label: 'Integrations' },
 ];
@@ -76,6 +78,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) =
           {activeTab === 'project' && <ProjectSettings />}
           {activeTab === 'memory' && <MemoryManager />}
           {activeTab === 'skills' && <SkillBuilder />}
+          {activeTab === 'triggers' && <TriggersPanel />}
           {activeTab === 'calendar' && <CalendarSyncSettings />}
           {activeTab === 'integrations' && <ConnectorMarketplace />}
         </div>

--- a/src/components/ui/settings/TriggersPanel.tsx
+++ b/src/components/ui/settings/TriggersPanel.tsx
@@ -1,0 +1,506 @@
+/**
+ * TriggersPanel — CRUD UI for proactive triggers (#303).
+ *
+ * Backed by ProactiveService. Lists triggers, lets users create/edit/delete,
+ * and dry-run against a mock event to preview `{ would_fire, reason }`
+ * without side effects.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { proactiveService } from '../../../api/ProactiveService';
+import type {
+  Trigger,
+  TriggerInput,
+  TriggerType,
+  TriggerTestResult,
+} from '../../../api/types/proactive';
+import { validateTriggerInput, type TriggerFormErrors } from '../../../utils/triggerValidation';
+
+type DraftTrigger = Partial<TriggerInput> & { condition?: Record<string, unknown> };
+
+const TYPE_OPTIONS: { value: TriggerType; label: string; hint: string }[] = [
+  { value: 'cron',      label: 'Cron',      hint: 'Runs on a schedule (e.g. "0 9 * * 1-5")' },
+  { value: 'threshold', label: 'Threshold', hint: 'Runs when a metric crosses a bound' },
+  { value: 'webhook',   label: 'Webhook',   hint: 'Runs when an external webhook hits a path' },
+  { value: 'event',     label: 'Event',     hint: 'Runs on an arbitrary backend event' },
+];
+
+function emptyDraft(type: TriggerType = 'cron'): DraftTrigger {
+  return {
+    type,
+    name: '',
+    action_prompt: '',
+    enabled: true,
+    condition: type === 'cron'      ? { cron: '0 9 * * *' }
+             : type === 'threshold' ? { metric: '', above: 0 }
+             : type === 'webhook'   ? { path: '' }
+                                    : {},
+  };
+}
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—';
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+// ---------------------------------------------------------------------------
+// Panel
+// ---------------------------------------------------------------------------
+
+export const TriggersPanel: React.FC = () => {
+  const [triggers, setTriggers] = useState<Trigger[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Trigger | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [dryRuns, setDryRuns] = useState<Record<string, TriggerTestResult | { error: string }>>({});
+
+  const loadTriggers = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await proactiveService.listTriggers({ limit: 100 });
+      setTriggers(res.triggers);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadTriggers(); }, [loadTriggers]);
+
+  const handleCreate = useCallback(async (input: TriggerInput) => {
+    const created = await proactiveService.createTrigger(input);
+    setTriggers((prev) => [created, ...prev]);
+    setCreating(false);
+  }, []);
+
+  const handleUpdate = useCallback(async (id: string, input: TriggerInput) => {
+    const updated = await proactiveService.updateTrigger(id, {
+      name: input.name,
+      action_prompt: input.action_prompt,
+      condition: input.condition,
+      enabled: input.enabled,
+    });
+    setTriggers((prev) => prev.map((t) => (t.id === id ? updated : t)));
+    setEditing(null);
+  }, []);
+
+  const handleDelete = useCallback(async (id: string) => {
+    const snapshot = triggers;
+    // Optimistic remove
+    setTriggers((prev) => prev.filter((t) => t.id !== id));
+    try {
+      await proactiveService.deleteTrigger(id);
+    } catch (err) {
+      setTriggers(snapshot); // revert
+      setLoadError(err instanceof Error ? err.message : String(err));
+    }
+  }, [triggers]);
+
+  const handleDryRun = useCallback(async (trigger: Trigger) => {
+    try {
+      const result = await proactiveService.testTrigger(trigger.id, {
+        mock_event: {},
+        apply_rate_limit: false,
+      });
+      setDryRuns((prev) => ({ ...prev, [trigger.id]: result }));
+    } catch (err) {
+      setDryRuns((prev) => ({
+        ...prev,
+        [trigger.id]: { error: err instanceof Error ? err.message : String(err) },
+      }));
+    }
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Triggers</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Proactive rules that let Mate start conversations on your behalf.
+          </p>
+        </div>
+        <button
+          onClick={() => { setCreating(true); setEditing(null); }}
+          disabled={creating || !!editing}
+          className="px-3 py-2 rounded-lg bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          + New trigger
+        </button>
+      </header>
+
+      {loadError && (
+        <div className="text-sm px-3 py-2 rounded-md bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200/60 dark:border-red-800/40">
+          Failed to load: {loadError}
+        </div>
+      )}
+
+      {creating && (
+        <TriggerForm
+          initial={emptyDraft()}
+          submitLabel="Create"
+          onSubmit={(draft) => handleCreate(draft as TriggerInput)}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+
+      {loading && triggers.length === 0 && !loadError ? (
+        <div className="text-sm text-gray-500">Loading triggers…</div>
+      ) : triggers.length === 0 && !creating ? (
+        <div className="text-sm text-gray-500 dark:text-gray-400 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg px-4 py-8 text-center">
+          No triggers yet. Create one to have Mate reach out automatically.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {triggers.map((trigger) => (
+            <li key={trigger.id}>
+              {editing?.id === trigger.id ? (
+                <TriggerForm
+                  initial={trigger}
+                  submitLabel="Save"
+                  onSubmit={(draft) => handleUpdate(trigger.id, draft as TriggerInput)}
+                  onCancel={() => setEditing(null)}
+                />
+              ) : (
+                <TriggerCard
+                  trigger={trigger}
+                  dryRun={dryRuns[trigger.id]}
+                  onEdit={() => { setEditing(trigger); setCreating(false); }}
+                  onDelete={() => handleDelete(trigger.id)}
+                  onDryRun={() => handleDryRun(trigger)}
+                />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// TriggerCard — one row in the list
+// ---------------------------------------------------------------------------
+
+interface TriggerCardProps {
+  trigger: Trigger;
+  dryRun: TriggerTestResult | { error: string } | undefined;
+  onEdit: () => void;
+  onDelete: () => void;
+  onDryRun: () => void;
+}
+
+const TriggerCard: React.FC<TriggerCardProps> = ({ trigger, dryRun, onEdit, onDelete, onDryRun }) => {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const typeLabel = TYPE_OPTIONS.find((o) => o.value === trigger.type)?.label ?? trigger.type;
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3 bg-white dark:bg-gray-900/40">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">{trigger.name}</span>
+            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded">
+              {typeLabel}
+            </span>
+            {!trigger.enabled && (
+              <span className="px-1.5 py-0.5 text-[10px] font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 rounded">
+                Paused
+              </span>
+            )}
+          </div>
+          <div className="mt-1 text-xs text-gray-500 dark:text-gray-400 line-clamp-2" title={trigger.action_prompt}>
+            {trigger.action_prompt}
+          </div>
+          <div className="mt-2 flex gap-4 text-[11px] text-gray-500 dark:text-gray-500">
+            <span><span className="text-gray-400">Next fire:</span> {formatTimestamp(trigger.next_fire)}</span>
+            <span>
+              <span className="text-gray-400">Last result:</span>{' '}
+              {trigger.last_result ? 'ran' : 'none'}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <button
+            onClick={onDryRun}
+            className="px-2 py-1 text-xs rounded-md border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            title="Preview fire condition without side effects"
+          >
+            Dry-run
+          </button>
+          <button
+            onClick={onEdit}
+            className="px-2 py-1 text-xs rounded-md border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            Edit
+          </button>
+          {confirmDelete ? (
+            <button
+              onClick={() => { setConfirmDelete(false); onDelete(); }}
+              className="px-2 py-1 text-xs rounded-md bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800/50"
+            >
+              Confirm
+            </button>
+          ) : (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              className="px-2 py-1 text-xs rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-red-600 transition-colors"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {dryRun && <TriggerDryRunResult result={dryRun} />}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// TriggerForm — create + edit
+// ---------------------------------------------------------------------------
+
+interface TriggerFormProps {
+  initial: DraftTrigger | Trigger;
+  submitLabel: string;
+  onSubmit: (draft: TriggerInput) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+const TriggerForm: React.FC<TriggerFormProps> = ({ initial, submitLabel, onSubmit, onCancel }) => {
+  const [draft, setDraft] = useState<DraftTrigger>(() => ({
+    type: initial.type,
+    name: initial.name,
+    action_prompt: initial.action_prompt,
+    enabled: initial.enabled ?? true,
+    condition: initial.condition ?? {},
+  }));
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const errors: TriggerFormErrors = useMemo(() => validateTriggerInput(draft), [draft]);
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const setType = (type: TriggerType) => setDraft((prev) => ({ ...prev, type, condition: emptyDraft(type).condition }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (hasErrors) return;
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(draft as TriggerInput);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3 bg-gray-50 dark:bg-gray-900/40"
+      aria-label={submitLabel === 'Create' ? 'Create trigger' : 'Edit trigger'}
+    >
+      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+        Type
+        <select
+          value={draft.type}
+          onChange={(e) => setType(e.target.value as TriggerType)}
+          className="mt-1 block w-full px-2 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+        >
+          {TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+        <span className="mt-1 block text-[11px] text-gray-500">{TYPE_OPTIONS.find((o) => o.value === draft.type)?.hint}</span>
+      </label>
+
+      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+        Name
+        <input
+          type="text"
+          value={draft.name ?? ''}
+          onChange={(e) => setDraft((prev) => ({ ...prev, name: e.target.value }))}
+          className="mt-1 block w-full px-2 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+          placeholder="e.g. Morning brief"
+        />
+        {errors.name && <span className="mt-1 block text-[11px] text-red-600">{errors.name}</span>}
+      </label>
+
+      <ConditionFields type={draft.type!} condition={draft.condition ?? {}} onChange={(c) => setDraft((prev) => ({ ...prev, condition: c }))} error={errors.condition} />
+
+      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+        Action prompt
+        <textarea
+          value={draft.action_prompt ?? ''}
+          onChange={(e) => setDraft((prev) => ({ ...prev, action_prompt: e.target.value }))}
+          rows={3}
+          className="mt-1 block w-full px-2 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+          placeholder="What should Mate do when this fires?"
+        />
+        {errors.action_prompt && <span className="mt-1 block text-[11px] text-red-600">{errors.action_prompt}</span>}
+      </label>
+
+      <label className="flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300">
+        <input
+          type="checkbox"
+          checked={draft.enabled ?? true}
+          onChange={(e) => setDraft((prev) => ({ ...prev, enabled: e.target.checked }))}
+        />
+        Enabled
+      </label>
+
+      {submitError && (
+        <div className="text-xs text-red-600" role="alert">{submitError}</div>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={hasErrors || submitting}
+          className="px-3 py-1.5 text-sm font-medium rounded-md bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ConditionFields — type-specific inputs
+// ---------------------------------------------------------------------------
+
+interface ConditionFieldsProps {
+  type: TriggerType;
+  condition: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  error: string | undefined;
+}
+
+const ConditionFields: React.FC<ConditionFieldsProps> = ({ type, condition, onChange, error }) => {
+  const inputClass = "mt-1 block w-full px-2 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono";
+
+  return (
+    <div className="space-y-2">
+      {type === 'cron' && (
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+          Cron expression
+          <input
+            type="text"
+            value={(condition.cron as string | undefined) ?? ''}
+            onChange={(e) => onChange({ ...condition, cron: e.target.value })}
+            className={inputClass}
+            placeholder="0 9 * * 1-5"
+          />
+        </label>
+      )}
+      {type === 'threshold' && (
+        <>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+            Metric
+            <input
+              type="text"
+              value={(condition.metric as string | undefined) ?? ''}
+              onChange={(e) => onChange({ ...condition, metric: e.target.value })}
+              className={inputClass}
+              placeholder="cpu_percent"
+            />
+          </label>
+          <div className="flex gap-2">
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 flex-1">
+              Above
+              <input
+                type="number"
+                value={(condition.above as number | undefined) ?? ''}
+                onChange={(e) => onChange({ ...condition, above: e.target.value === '' ? undefined : Number(e.target.value) })}
+                className={inputClass}
+              />
+            </label>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 flex-1">
+              Below
+              <input
+                type="number"
+                value={(condition.below as number | undefined) ?? ''}
+                onChange={(e) => onChange({ ...condition, below: e.target.value === '' ? undefined : Number(e.target.value) })}
+                className={inputClass}
+              />
+            </label>
+          </div>
+        </>
+      )}
+      {type === 'webhook' && (
+        <>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+            Path
+            <input
+              type="text"
+              value={(condition.path as string | undefined) ?? ''}
+              onChange={(e) => onChange({ ...condition, path: e.target.value })}
+              className={inputClass}
+              placeholder="/hooks/my-hook"
+            />
+          </label>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+            Secret (optional)
+            <input
+              type="password"
+              value={(condition.secret as string | undefined) ?? ''}
+              onChange={(e) => onChange({ ...condition, secret: e.target.value || undefined })}
+              className={inputClass}
+            />
+          </label>
+        </>
+      )}
+      {type === 'event' && (
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+          Event condition (JSON)
+          <textarea
+            rows={3}
+            value={JSON.stringify(condition, null, 2)}
+            onChange={(e) => {
+              try { onChange(JSON.parse(e.target.value || '{}')); } catch { /* ignore until valid */ }
+            }}
+            className={inputClass}
+          />
+        </label>
+      )}
+      {error && <span className="text-[11px] text-red-600">{error}</span>}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// TriggerDryRunResult — inline banner
+// ---------------------------------------------------------------------------
+
+const TriggerDryRunResult: React.FC<{ result: TriggerTestResult | { error: string } }> = ({ result }) => {
+  if ('error' in result) {
+    return (
+      <div className="text-xs px-3 py-2 rounded-md bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200/60 dark:border-red-800/40" role="alert">
+        Dry-run failed: {result.error}
+      </div>
+    );
+  }
+  const palette = result.would_fire
+    ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 border-green-200/60 dark:border-green-800/40'
+    : 'bg-gray-50 dark:bg-gray-800/40 text-gray-600 dark:text-gray-400 border-gray-200/60 dark:border-gray-700/50';
+  return (
+    <div className={`text-xs px-3 py-2 rounded-md border ${palette}`} role="status">
+      <div className="font-medium">{result.would_fire ? 'Would fire' : 'Would NOT fire'}</div>
+      <div className="mt-0.5">{result.reason}</div>
+    </div>
+  );
+};

--- a/src/utils/__tests__/triggerValidation.test.ts
+++ b/src/utils/__tests__/triggerValidation.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from 'vitest';
+import {
+  isValidCronExpression,
+  isValidThresholdCondition,
+  isValidWebhookCondition,
+  validateTriggerInput,
+} from '../triggerValidation';
+
+describe('isValidCronExpression', () => {
+  test.each([
+    '0 9 * * *',
+    '*/15 * * * *',
+    '0 9 * * 1-5',
+    '0,30 * * * *',
+    '0 0 1 1 *',
+  ])('accepts %s', (expr) => {
+    expect(isValidCronExpression(expr)).toBe(true);
+  });
+
+  test.each([
+    ['', 'empty'],
+    ['0 9 * *', 'four fields'],
+    ['0 9 * * * *', 'six fields'],
+    ['? 9 * * *', 'invalid char ?'],
+    ['abc 9 * * *', 'non-numeric'],
+    ['   ', 'whitespace only'],
+  ])('rejects %s (%s)', (expr) => {
+    expect(isValidCronExpression(expr)).toBe(false);
+  });
+});
+
+describe('isValidThresholdCondition', () => {
+  test('accepts metric + above', () => {
+    expect(isValidThresholdCondition({ metric: 'cpu', above: 80 })).toBe(true);
+  });
+
+  test('accepts metric + below', () => {
+    expect(isValidThresholdCondition({ metric: 'disk_free_gb', below: 5 })).toBe(true);
+  });
+
+  test('accepts metric + both', () => {
+    expect(isValidThresholdCondition({ metric: 'temp', above: 100, below: 0 })).toBe(true);
+  });
+
+  test('rejects missing metric', () => {
+    expect(isValidThresholdCondition({ above: 80 })).toBe(false);
+  });
+
+  test('rejects empty metric', () => {
+    expect(isValidThresholdCondition({ metric: '', above: 80 })).toBe(false);
+  });
+
+  test('rejects when neither above nor below present', () => {
+    expect(isValidThresholdCondition({ metric: 'cpu' })).toBe(false);
+  });
+
+  test('rejects non-object', () => {
+    expect(isValidThresholdCondition(null)).toBe(false);
+    expect(isValidThresholdCondition('cpu>80')).toBe(false);
+  });
+
+  test('rejects non-finite bounds', () => {
+    expect(isValidThresholdCondition({ metric: 'cpu', above: NaN })).toBe(false);
+    expect(isValidThresholdCondition({ metric: 'cpu', above: Infinity })).toBe(false);
+  });
+});
+
+describe('isValidWebhookCondition', () => {
+  test('accepts path-only', () => {
+    expect(isValidWebhookCondition({ path: '/hooks/my-hook' })).toBe(true);
+  });
+
+  test('accepts path + secret', () => {
+    expect(isValidWebhookCondition({ path: '/hooks/x', secret: 's3cr3t' })).toBe(true);
+  });
+
+  test('rejects empty path', () => {
+    expect(isValidWebhookCondition({ path: '' })).toBe(false);
+  });
+
+  test('rejects missing path', () => {
+    expect(isValidWebhookCondition({ secret: 'x' })).toBe(false);
+  });
+
+  test('rejects non-string secret', () => {
+    expect(isValidWebhookCondition({ path: '/x', secret: 42 })).toBe(false);
+  });
+});
+
+describe('validateTriggerInput', () => {
+  test('valid cron returns no errors', () => {
+    expect(validateTriggerInput({
+      type: 'cron',
+      name: 'Morning brief',
+      action_prompt: 'Summarize overnight activity',
+      condition: { cron: '0 9 * * *' },
+    })).toEqual({});
+  });
+
+  test('flags missing name', () => {
+    const errs = validateTriggerInput({
+      type: 'cron',
+      name: '',
+      action_prompt: 'x',
+      condition: { cron: '0 9 * * *' },
+    });
+    expect(errs.name).toBeDefined();
+  });
+
+  test('flags missing action_prompt', () => {
+    const errs = validateTriggerInput({
+      type: 'cron',
+      name: 'x',
+      action_prompt: '',
+      condition: { cron: '0 9 * * *' },
+    });
+    expect(errs.action_prompt).toBeDefined();
+  });
+
+  test('flags invalid cron', () => {
+    const errs = validateTriggerInput({
+      type: 'cron',
+      name: 'x',
+      action_prompt: 'y',
+      condition: { cron: 'not a cron' },
+    });
+    expect(errs.condition).toMatch(/cron/i);
+  });
+
+  test('flags unknown type', () => {
+    const errs = validateTriggerInput({
+      // @ts-expect-error — intentionally invalid
+      type: 'garbage',
+      name: 'x',
+      action_prompt: 'y',
+      condition: {},
+    });
+    expect(errs.condition).toMatch(/unknown/i);
+  });
+
+  test('threshold trigger validates condition shape', () => {
+    expect(validateTriggerInput({
+      type: 'threshold',
+      name: 'x',
+      action_prompt: 'y',
+      condition: { metric: 'cpu', above: 80 },
+    })).toEqual({});
+
+    expect(validateTriggerInput({
+      type: 'threshold',
+      name: 'x',
+      action_prompt: 'y',
+      condition: { metric: 'cpu' },
+    }).condition).toBeDefined();
+  });
+
+  test('flags overlong name', () => {
+    const errs = validateTriggerInput({
+      type: 'cron',
+      name: 'x'.repeat(121),
+      action_prompt: 'y',
+      condition: { cron: '0 9 * * *' },
+    });
+    expect(errs.name).toMatch(/120/);
+  });
+});

--- a/src/utils/triggerValidation.ts
+++ b/src/utils/triggerValidation.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure validators for proactive trigger forms (#303).
+ *
+ * Kept UI-free so they're trivially unit-testable. Returns a structured
+ * error record (field → message) instead of throwing so the form can
+ * render field-level messages.
+ */
+
+import type { TriggerInput, TriggerType } from '../api/types/proactive';
+
+export type TriggerFormErrors = Partial<Record<'name' | 'action_prompt' | 'condition', string>>;
+
+/**
+ * Validate a 5-field cron expression. Not exhaustive — checks the basic
+ * shape: 5 space-separated fields, each non-empty, no obviously-invalid
+ * characters. Full cron semantics are the backend's responsibility.
+ */
+export function isValidCronExpression(expr: string): boolean {
+  const trimmed = expr.trim();
+  if (!trimmed) return false;
+  const fields = trimmed.split(/\s+/);
+  if (fields.length !== 5) return false;
+  // Each field must contain only digits, *, /, -, ,, or whitespace-bounded.
+  const fieldRe = /^[0-9*/,\-]+$/;
+  return fields.every((f) => fieldRe.test(f));
+}
+
+/**
+ * Validate a threshold condition — requires `metric` (string) and `above`
+ * OR `below` (finite number). Both can be present (range).
+ */
+export function isValidThresholdCondition(condition: unknown): boolean {
+  if (!condition || typeof condition !== 'object') return false;
+  const c = condition as Record<string, unknown>;
+  if (typeof c.metric !== 'string' || !c.metric.trim()) return false;
+  const above = c.above;
+  const below = c.below;
+  const hasAbove = typeof above === 'number' && Number.isFinite(above);
+  const hasBelow = typeof below === 'number' && Number.isFinite(below);
+  return hasAbove || hasBelow;
+}
+
+/**
+ * Validate a webhook condition — requires a non-empty `path` string.
+ * Optional `secret` must be a string if present.
+ */
+export function isValidWebhookCondition(condition: unknown): boolean {
+  if (!condition || typeof condition !== 'object') return false;
+  const c = condition as Record<string, unknown>;
+  if (typeof c.path !== 'string' || !c.path.trim()) return false;
+  if (c.secret !== undefined && typeof c.secret !== 'string') return false;
+  return true;
+}
+
+/**
+ * Validate a full trigger input object. Returns field-level errors —
+ * empty object means valid.
+ */
+export function validateTriggerInput(input: Partial<TriggerInput>): TriggerFormErrors {
+  const errors: TriggerFormErrors = {};
+
+  if (!input.name || !input.name.trim()) {
+    errors.name = 'Name is required';
+  } else if (input.name.length > 120) {
+    errors.name = 'Name must be 120 characters or fewer';
+  }
+
+  if (!input.action_prompt || !input.action_prompt.trim()) {
+    errors.action_prompt = 'Action prompt is required';
+  }
+
+  // Condition shape depends on type
+  const type = input.type as TriggerType | undefined;
+  if (type === 'cron') {
+    const cron = (input.condition?.cron as string | undefined) ?? '';
+    if (!isValidCronExpression(cron)) {
+      errors.condition = 'Cron expression must be 5 fields (e.g. "0 9 * * 1-5")';
+    }
+  } else if (type === 'threshold') {
+    if (!isValidThresholdCondition(input.condition)) {
+      errors.condition = 'Threshold needs a metric and at least one of above/below';
+    }
+  } else if (type === 'webhook') {
+    if (!isValidWebhookCondition(input.condition)) {
+      errors.condition = 'Webhook needs a non-empty path';
+    }
+  } else if (type === 'event') {
+    // Event triggers are opaque — backend validates.
+    if (!input.condition || typeof input.condition !== 'object') {
+      errors.condition = 'Event condition is required';
+    }
+  } else {
+    errors.condition = 'Unknown trigger type';
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary
Adds a Triggers tab to `SettingsModal` for CRUD against `/v1/proactive/triggers` plus a per-trigger dry-run button. Proactive trigger *display* (chat surface) was already working — this fills in the missing *management* UI.

## Design pivot
Original plan was a standalone `pages/settings/triggers.tsx` route. After inspecting the codebase, the repo convention is `SettingsModal` with left-nav tabs (Appearance, Memory, Skills, etc.) — no standalone settings routes exist. Integrating as a modal tab is smaller, more consistent, and discoverable from the same entry point as all other settings. Updated the design comment on the issue accordingly.

## Changes
- **`src/utils/triggerValidation.ts`** — pure validators: 5-field cron regex, threshold shape (metric + above|below), webhook path, full `TriggerInput` validator with field-level error messages.
- **`src/components/ui/settings/TriggersPanel.tsx`** — list + create + edit + delete + dry-run, fully self-contained (no new props added to `SettingsModal`). Type-discriminated `ConditionFields` component for cron/threshold/webhook/event inputs. Optimistic delete with revert on error. Inline `TriggerDryRunResult` banner (green "would fire" / gray "would not" / red error).
- **`src/components/ui/settings/SettingsModal.tsx`** — new `'triggers'` tab between Skills and Calendar.

## Acceptance Criteria
- [x] User can create/edit/delete cron, webhook, and threshold triggers from settings.
- [x] Trigger fires show up as proactive messages in current chat thread — **already wired** (`MessageList.tsx:735-751` routes `isAutonomous` → `AutonomousActivityCard` / `ScheduleResultCard`).
- [x] Dry-run button shows `{ would_fire, reason }` without side effects — `proactiveService.testTrigger(id, { mock_event: {}, apply_rate_limit: false })`.
- [x] Triggers panel lists `next_fire` and `last_result`.
- [x] Design follows "companion, not dashboard" — integrated into SettingsModal (same modal as Memory, Skills, etc.), not a separate dashboard page.

## Deferred (follow-up)
- Trigger-origin badge on AutonomousActivityCard (surfaces "from trigger X" on fired messages). Nice-to-have, not in AC.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit (trigger validators) | 31 | ✓ Pass |

Full vitest suite: **509 passed / 9 pre-existing failures / 0 regressions**.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)