### PR TITLE
fix(api): align frontend contracts with backend account_service + calendar_service

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -262,19 +262,33 @@ function setupIPC(): void {
   ipcMain.on('updater:check-now', () => checkForUpdates());
   ipcMain.on('updater:quit-and-install', () => quitAndInstall());
 
-  // Calendar IPC (#230)
-  ipcMain.handle('calendar:get-today', async () => {
+  // Calendar IPC (#230) — renderer must pass its current auth0_id (backend requires user_id).
+  ipcMain.handle('calendar:get-today', async (_e, userId: string) => {
     const win = getMainWindow();
-    if (!win) return [];
+    if (!win || !userId) return [];
+    const userIdLiteral = JSON.stringify(userId);
     return win.webContents.executeJavaScript(
-      `fetch((window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/calendar/events?start=' + new Date(new Date().setHours(0,0,0,0)).toISOString() + '&end=' + new Date(new Date().setHours(23,59,59,999)).toISOString(), { credentials: 'include' }).then(r => r.json()).catch(() => [])`
+      `(() => {
+        const base = (window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/calendar/events';
+        const params = new URLSearchParams({
+          user_id: ${userIdLiteral},
+          start_date: new Date(new Date().setHours(0,0,0,0)).toISOString(),
+          end_date: new Date(new Date().setHours(23,59,59,999)).toISOString(),
+        });
+        return fetch(base + '?' + params.toString(), { credentials: 'include' }).then(r => r.json()).catch(() => []);
+      })()`
     );
   });
-  ipcMain.handle('calendar:get-tasks', async () => {
+  ipcMain.handle('calendar:get-tasks', async (_e, userId: string) => {
     const win = getMainWindow();
-    if (!win) return [];
+    if (!win || !userId) return [];
+    const userIdLiteral = JSON.stringify(userId);
     return win.webContents.executeJavaScript(
-      `fetch((window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/tasks?status=pending&limit=10', { credentials: 'include' }).then(r => r.json()).catch(() => [])`
+      `(() => {
+        const base = (window.__NEXT_DATA__?.runtimeConfig?.GATEWAY_URL || 'http://localhost:9080') + '/api/v1/tasks';
+        const params = new URLSearchParams({ user_id: ${userIdLiteral}, status: 'pending', limit: '10' });
+        return fetch(base + '?' + params.toString(), { credentials: 'include' }).then(r => r.json()).catch(() => []);
+      })()`
     );
   });
 }

--- a/src/api/adapters/CalendarAdapter.ts
+++ b/src/api/adapters/CalendarAdapter.ts
@@ -34,15 +34,20 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export async function getEvents(start: string, end: string): Promise<CalendarEvent[]> {
-  return apiFetch(`/events?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+export async function getEvents(userId: string, start: string, end: string): Promise<CalendarEvent[]> {
+  const params = new URLSearchParams({
+    user_id: userId,
+    start_date: start,
+    end_date: end,
+  });
+  return apiFetch(`/events?${params.toString()}`);
 }
 
-export async function getTodayEvents(): Promise<CalendarEvent[]> {
+export async function getTodayEvents(userId: string): Promise<CalendarEvent[]> {
   const now = new Date();
   const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
   const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).toISOString();
-  return getEvents(start, end);
+  return getEvents(userId, start, end);
 }
 
 export async function createEvent(event: Omit<CalendarEvent, 'id'>): Promise<CalendarEvent> {

--- a/src/api/adapters/__tests__/CalendarAdapter.test.ts
+++ b/src/api/adapters/__tests__/CalendarAdapter.test.ts
@@ -39,22 +39,24 @@ describe('CalendarAdapter', () => {
   // getEvents
   // ---------------------------------------------------------------------------
   describe('getEvents', () => {
-    test('constructs URL with encoded start/end query params', async () => {
+    test('sends user_id, start_date, end_date as query params (backend contract)', async () => {
       const events = [{ id: 'e1', title: 'Standup' }];
       globalThis.fetch = mockFetchOk(events);
 
-      const result = await getEvents('2026-04-16T00:00:00Z', '2026-04-17T00:00:00Z');
+      const result = await getEvents('user-42', '2026-04-16T00:00:00Z', '2026-04-17T00:00:00Z');
 
       expect(result).toEqual(events);
       const url = (globalThis.fetch as any).mock.calls[0][0] as string;
-      expect(url).toContain(`${BASE}/events?start=`);
-      expect(url).toContain(encodeURIComponent('2026-04-16T00:00:00Z'));
-      expect(url).toContain(encodeURIComponent('2026-04-17T00:00:00Z'));
+      expect(url.startsWith(`${BASE}/events?`)).toBe(true);
+      const qs = new URLSearchParams(url.split('?')[1]);
+      expect(qs.get('user_id')).toBe('user-42');
+      expect(qs.get('start_date')).toBe('2026-04-16T00:00:00Z');
+      expect(qs.get('end_date')).toBe('2026-04-17T00:00:00Z');
     });
 
     test('sends credentials include and content-type header', async () => {
       globalThis.fetch = mockFetchOk([]);
-      await getEvents('a', 'b');
+      await getEvents('user-42', 'a', 'b');
 
       const opts = (globalThis.fetch as any).mock.calls[0][1];
       expect(opts.credentials).toBe('include');
@@ -63,7 +65,7 @@ describe('CalendarAdapter', () => {
 
     test('throws on non-200 response', async () => {
       globalThis.fetch = mockFetchError(500);
-      await expect(getEvents('a', 'b')).rejects.toThrow('Calendar API error: 500');
+      await expect(getEvents('user-42', 'a', 'b')).rejects.toThrow('Calendar API error: 500');
     });
   });
 
@@ -71,15 +73,16 @@ describe('CalendarAdapter', () => {
   // getTodayEvents
   // ---------------------------------------------------------------------------
   describe('getTodayEvents', () => {
-    test('calls getEvents with today start/end', async () => {
+    test('calls getEvents with current userId and today window', async () => {
       globalThis.fetch = mockFetchOk([]);
-      await getTodayEvents();
+      await getTodayEvents('user-42');
 
       const url = (globalThis.fetch as any).mock.calls[0][0] as string;
-      // Should contain today's date (ISO format)
-      const now = new Date();
-      const yearStr = String(now.getFullYear());
-      expect(url).toContain(yearStr);
+      const qs = new URLSearchParams(url.split('?')[1]);
+      expect(qs.get('user_id')).toBe('user-42');
+      const yearStr = String(new Date().getFullYear());
+      expect(qs.get('start_date')).toContain(yearStr);
+      expect(qs.get('end_date')).toContain(yearStr);
     });
   });
 

--- a/src/api/userService.ts
+++ b/src/api/userService.ts
@@ -84,7 +84,7 @@ export class UserService {
         email: userData.email,
         name: userData.name,
       };
-      const response = await this.apiService.post<ExternalUser>('/api/v1/users/ensure', payload);
+      const response = await this.apiService.post<ExternalUser>('/api/v1/accounts/ensure', payload);
 
       if (!response.success) {
         throw new Error(response.error || 'Failed to ensure user exists');

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import type { CalendarEvent, CalendarProvider } from '../api/adapters/CalendarAdapter';
 import * as CalendarAdapter from '../api/adapters/CalendarAdapter';
+import { useUserStore } from './useUserStore';
+
+function requireUserId(): string | null {
+  return useUserStore.getState().externalUser?.auth0_id ?? null;
+}
 
 interface CalendarState {
   events: CalendarEvent[];
@@ -22,18 +27,28 @@ export const useCalendarStore = create<CalendarState>((set) => ({
   isLoading: false,
   error: null,
   fetchTodayEvents: async () => {
+    const userId = requireUserId();
+    if (!userId) {
+      set({ error: 'Not authenticated: calendar fetch requires a logged-in user', isLoading: false });
+      return;
+    }
     set({ isLoading: true, error: null });
     try {
-      const todayEvents = await CalendarAdapter.getTodayEvents();
+      const todayEvents = await CalendarAdapter.getTodayEvents(userId);
       set({ todayEvents, isLoading: false });
     } catch (err: any) {
       set({ error: err.message, isLoading: false });
     }
   },
   fetchEvents: async (start, end) => {
+    const userId = requireUserId();
+    if (!userId) {
+      set({ error: 'Not authenticated: calendar fetch requires a logged-in user', isLoading: false });
+      return;
+    }
     set({ isLoading: true, error: null });
     try {
-      const events = await CalendarAdapter.getEvents(start, end);
+      const events = await CalendarAdapter.getEvents(userId, start, end);
       set({ events, isLoading: false });
     } catch (err: any) {
       set({ error: err.message, isLoading: false });


### PR DESCRIPTION
## Summary

Two frontend→backend contract mismatches were blocking the app at login and on the calendar widget. Aligning the frontend to the backend's canonical paths/params (the resources are `accounts` and `calendar/events` with `user_id`/`start_date`/`end_date`).

Fixes #321, fixes #322.

## Changes

| File | Change |
|---|---|
| `src/api/userService.ts` | `/api/v1/users/ensure` → `/api/v1/accounts/ensure` |
| `src/api/adapters/CalendarAdapter.ts` | `getEvents(userId, start, end)` + `getTodayEvents(userId)`, sending `user_id` / `start_date` / `end_date` via `URLSearchParams` |
| `src/stores/useCalendarStore.ts` | reads `auth0_id` from `useUserStore` and passes it through; bails early with an auth error if there's no logged-in user |
| `desktop/src/main.ts` | calendar IPC handlers now accept `userId` from the renderer and use the corrected query contract |
| `src/api/adapters/__tests__/CalendarAdapter.test.ts` | updated assertions to verify the new param names |

## Test plan

- [x] `vitest run src/api/adapters/__tests__/CalendarAdapter.test.ts` → **13/13 pass**
- [x] `npx tsc --noEmit` → no new errors introduced by this diff (only the pre-existing `Cannot find module 'electron'` in `desktop/` and implicit-any `_e` warnings on other IPC handlers, which pre-date this change)
- [ ] Reviewer — manual check: log in → `UserModule` initializes without 404; open calendar widget → no 422 in devtools; events show up for the logged-in user

## Notes

- Desktop calendar IPC (`calendar:get-today` / `calendar:get-tasks`) is currently not invoked from any renderer code — this fix corrects the contract in place so the future wiring from issue #230 won't hit the same 422.
- Left `/api/v1/users/me` (other callers in `userService.ts`) alone — they're not in scope of #321/#322 and I haven't verified whether they hit the same mismatch.