### PR TITLE
fix(ui): suppress warmup 404 console noise (#326)

### DIFF
--- a/src/api/__tests__/mateService.warmup.test.ts
+++ b/src/api/__tests__/mateService.warmup.test.ts
@@ -54,16 +54,25 @@ describe('MateService.triggerWarmup', () => {
     service = new MateService();
   });
 
-  test('POSTs to the warmup endpoint with an empty body', async () => {
+  test('POSTs to the warmup endpoint with an empty body and a validateStatus that allows 404 (#326)', async () => {
     getPost().mockResolvedValueOnce({ success: true, data: {}, statusCode: 200 });
 
     await service.triggerWarmup();
 
-    expect(getPost()).toHaveBeenCalledWith('http://mate.test/v1/context/warmup', {});
+    expect(getPost()).toHaveBeenCalledTimes(1);
+    const [url, body, config] = getPost().mock.calls[0];
+    expect(url).toBe('http://mate.test/v1/context/warmup');
+    expect(body).toEqual({});
+    expect(config?.validateStatus).toBeInstanceOf(Function);
+    // Contract: 404 must be treated as a non-error so BaseApiService doesn't log it.
+    expect(config.validateStatus(404)).toBe(true);
+    expect(config.validateStatus(200)).toBe(true);
+    expect(config.validateStatus(500)).toBe(false);
   });
 
   test('resolves silently when backend returns 404 (older Mate, no endpoint)', async () => {
-    getPost().mockResolvedValueOnce({ success: false, statusCode: 404, error: 'Not Found' });
+    // With validateStatus, the mock now resolves rather than throws for 404.
+    getPost().mockResolvedValueOnce({ success: true, statusCode: 404, data: null });
 
     await expect(service.triggerWarmup()).resolves.toBeUndefined();
   });

--- a/src/api/mateService.ts
+++ b/src/api/mateService.ts
@@ -81,19 +81,25 @@ export class MateService {
    *
    * Contract: MUST NOT throw. Older Mate versions without the endpoint
    * return 404 — treated as a no-op. Network errors are swallowed.
+   *
+   * `validateStatus` tells Axios to resolve 404 as a successful response
+   * (carrying statusCode=404) instead of throwing. This keeps
+   * BaseApiService's error logger quiet for a status we expect and handle
+   * explicitly. See #326.
    */
   async triggerWarmup(): Promise<void> {
     try {
       log.info('Warming up Mate backend');
       const response = await this.apiService.post<unknown>(
         GATEWAY_ENDPOINTS.MATE.CONTEXT_WARMUP,
-        {}
+        {},
+        { validateStatus: (status) => status === 404 || status < 400 }
       );
-      if (response.success) return;
       if (response.statusCode === 404) {
         log.info('Mate warmup endpoint not available (404) — skipping');
         return;
       }
+      if (response.success) return;
       log.warn('Mate warmup non-success', { statusCode: response.statusCode, error: response.error });
     } catch (error) {
       log.warn('Mate warmup threw (ignored)', {


### PR DESCRIPTION
## Summary
`MateService.triggerWarmup` already handled a 404 from older Mate versions gracefully, but `BaseApiService` logged the error one layer below — BEFORE the caller could inspect the response — leaving a scary red `POST …/v1/context/warmup 404` every page load.

## Fix
Pass `validateStatus: (status) => status === 404 || status < 400` on the warmup POST. Axios now resolves 404 as a successful response (carrying `statusCode: 404`) instead of throwing, so `BaseApiService.handleRequestError` is never entered and the red ❌ log is gone.

The friendly one-line info ("Mate warmup endpoint not available (404) — skipping") is preserved — reordered before the generic `success` check so it still fires when `statusCode` is 404.

No change to `BaseApiService`; the plumbing for `validateStatus` was already threaded through `post → request → executeAxiosRequest`.

## Acceptance Criteria
- [x] On page load with a Mate that has no `/v1/context/warmup` route, the console shows **at most one** info line noting the endpoint is unavailable.
- [x] No red ❌ error log, no Axios-raw `POST … 404` line.
- [x] `triggerWarmup` still resolves silently (no uncaught rejection).
- [x] Other callers that legitimately 404 are unaffected — this change is per-call-site.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L2 Component (MateService.triggerWarmup) | 4 | ✓ Pass |

New assertions:
- `validateStatus` is passed as a function in the config arg.
- `validateStatus(404) === true`, `validateStatus(200) === true`, `validateStatus(500) === false`.
- 404 mock now returns `{ success: true, statusCode: 404 }` (matching the new Axios behavior) and `triggerWarmup` still resolves silently.

Full vitest suite: **510 passed / 9 pre-existing failures / 0 regressions**.

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)