### PR TITLE
fix(api): unwrap calendar envelope & attach auth header to projects

### DIFF
--- a/src/api/adapters/CalendarAdapter.ts
+++ b/src/api/adapters/CalendarAdapter.ts
@@ -40,7 +40,8 @@ export async function getEvents(userId: string, start: string, end: string): Pro
     start_date: start,
     end_date: end,
   });
-  return apiFetch(`/events?${params.toString()}`);
+  const res = await apiFetch<CalendarEvent[] | { events: CalendarEvent[] }>(`/events?${params.toString()}`);
+  return Array.isArray(res) ? res : (res?.events ?? []);
 }
 
 export async function getTodayEvents(userId: string): Promise<CalendarEvent[]> {
@@ -59,7 +60,8 @@ export async function deleteEvent(id: string): Promise<void> {
 }
 
 export async function getProviders(): Promise<CalendarProvider[]> {
-  return apiFetch('/providers');
+  const res = await apiFetch<CalendarProvider[] | { providers: CalendarProvider[] }>('/providers');
+  return Array.isArray(res) ? res : (res?.providers ?? []);
 }
 
 export async function connectProvider(type: CalendarProvider['type']): Promise<{ authUrl: string }> {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -3,7 +3,7 @@
  * Connects to isA_user project CRUD API (#258)
  */
 import { useState, useEffect, useCallback } from 'react';
-import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { GATEWAY_ENDPOINTS, getAuthHeaders } from '../config/gatewayConfig';
 
 export interface Project {
   id: string;
@@ -26,6 +26,7 @@ export function useProjects() {
     try {
       const res = await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', '/projects'), {
         credentials: 'include',
+        headers: getAuthHeaders(),
       });
       if (res.ok) {
         const data = await res.json();
@@ -52,7 +53,7 @@ export function useProjects() {
     try {
       const res = await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', '/projects'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
         credentials: 'include',
         body: JSON.stringify({ name, description }),
       });
@@ -70,6 +71,7 @@ export function useProjects() {
       await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', `/projects/${id}`), {
         method: 'DELETE',
         credentials: 'include',
+        headers: getAuthHeaders(),
       });
       setProjects(prev => prev.filter(p => p.id !== id));
       if (activeProjectId === id) setActiveProjectId(null);


### PR DESCRIPTION
## Summary
- `CalendarAdapter.getEvents`/`getProviders` now unwrap the backend's `{events|providers, total, page, page_size}` envelope, so `AlertModule.tsx:30`'s for-of loop no longer throws `TypeError: todayEvents is not iterable`. Without this, every authenticated load trips the fatal "Application Initialization Failed" boundary.
- `useProjects` fetch/create/delete now attach `getAuthHeaders()`, fixing 401s against `/api/v1/projects` in JWT-localStorage dev mode. (HttpOnly cookie mode remained correct because `credentials: 'include'` is preserved.)

Fixes #330
Fixes #331

## Test plan
- [x] Reproduced the init crash as Alice (`alice@example.com / test123456`), applied patch, reloaded — crash overlay gone, authed welcome renders (screenshot `pw-03-after-calendar-fix.png`).
- [x] Before: `GET /api/v1/projects → 401 Unauthorized` in DevTools network tab. After: 401 is gone; request now reaches `project_service` (and surfaces the separate xenoISA/isA_user#314 backend bug — unblocked but not in scope here).
- [ ] Please run the existing component/unit tests for `CalendarAdapter` and `useProjects` in CI to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)