### PR TITLE
chore(config): remove dead SESSIONS.USER / SESSIONS.ACTIVE declarations

### DIFF
--- a/src/config/__tests__/gatewayIntegration.test.ts
+++ b/src/config/__tests__/gatewayIntegration.test.ts
@@ -61,7 +61,6 @@ describe('Gateway endpoint construction', () => {
   test('SESSIONS endpoints include /api/v1/ paths', () => {
     expect(GATEWAY_ENDPOINTS.SESSIONS.LIST).toContain('/api/v1/sessions');
     expect(GATEWAY_ENDPOINTS.SESSIONS.CREATE).toContain('/api/v1/sessions');
-    expect(GATEWAY_ENDPOINTS.SESSIONS.USER).toContain('/api/v1/sessions/user');
     expect(GATEWAY_ENDPOINTS.SESSIONS.SEARCH).toContain('/api/v1/sessions/search');
   });
 

--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -57,8 +57,6 @@ export const API_PATHS = {
   SESSION: {
     BASE: '/api/v1/sessions',
     HEALTH: '/api/v1/sessions/health',
-    USER: '/api/v1/sessions/user',
-    ACTIVE: '/api/v1/sessions/active',
     SEARCH: '/api/v1/sessions/search'
   },
   

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -301,8 +301,6 @@ export const GATEWAY_ENDPOINTS = {
     GET: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/{sessionId}'),
     UPDATE: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/{sessionId}'),
     DELETE: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/{sessionId}'),
-    USER: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/user'),
-    ACTIVE: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/active'),
     SEARCH: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/search'),
     HEALTH: buildEndpoint(GATEWAY_SERVICES.SESSIONS, '/health'),
   },
@@ -434,8 +432,6 @@ export const LEGACY_TO_GATEWAY_MAP = {
   // 会话服务映射 (原3000端口 → 现在8205通过网关)
   'http://localhost:3000/api/sessions': GATEWAY_ENDPOINTS.SESSIONS.LIST,
   'http://localhost:3000/api/sessions/health': GATEWAY_ENDPOINTS.SESSIONS.HEALTH,
-  'http://localhost:3000/api/sessions/user': GATEWAY_ENDPOINTS.SESSIONS.USER,
-  'http://localhost:3000/api/sessions/active': GATEWAY_ENDPOINTS.SESSIONS.ACTIVE,
   'http://localhost:3000/api/sessions/search': GATEWAY_ENDPOINTS.SESSIONS.SEARCH,
 } as const;
 


### PR DESCRIPTION
## Summary
Dead-code removal. `GATEWAY_ENDPOINTS.SESSIONS.USER`, `SESSIONS.ACTIVE`, and their `API_PATHS.SESSION.USER/ACTIVE` twins were declared in config but have **no runtime consumers** anywhere in \`src\`. A \`grep -r "SESSIONS\\.(USER|ACTIVE)"\` returns only:

- the declarations themselves
- a \`LEGACY_TO_GATEWAY_MAP\` entry keyed on \`http://localhost:3000/api/sessions/user\` (an old URL nothing calls either)
- one test assertion on the path string

The backend \`session_service\` never exposed \`/sessions/user\` or \`/sessions/active\`. The supported shape — and the one several existing hooks already use — is \`GET /api/v1/sessions?user_id=X&active_only=true\`.

## Changes
- \`src/config/gatewayConfig.ts\` — drop 2 \`GATEWAY_ENDPOINTS.SESSIONS\` keys + 2 legacy-map entries
- \`src/config/apiConfig.ts\` — drop 2 \`API_PATHS.SESSION\` keys
- \`src/config/__tests__/gatewayIntegration.test.ts\` — drop the now-meaningless assertion

Part of #312 — xenoISA/isA_user#316 handles the real bug on the backend half (a \`self.db.fetch\` that would have 500'd \`/api/v1/sessions/starred\`).

## Test plan
- [x] \`grep -rn "SESSIONS\\.(USER|ACTIVE)" src/\` returns 0 hits after this change.
- [ ] \`npm test -- gatewayIntegration\` should still pass (I removed the assertion that targeted the removed key; the remaining SESSIONS assertions are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)