### PR TITLE
fix(ui): share Mate /health poller across consumers — not one per hook call

### DIFF
--- a/src/hooks/useMatePresence.ts
+++ b/src/hooks/useMatePresence.ts
@@ -4,14 +4,18 @@
  * ============================================================================
  *
  * Returns live online/offline status, active channels, and working state.
- * Polls every 30 seconds. Handles Mate-offline gracefully.
+ *
+ * All consumers share a single module-level poller (one /health request
+ * every 30s regardless of how many components call this hook). Previously
+ * each component spun up its own setInterval, which multiplied the poll
+ * rate by the number of mounted consumers (5+).
  *
  * (Note: a frontend-initiated warmup was tried in #276 but removed —
  * Mate pre-warms its RuntimeContextHelper at process startup on the
  * server side, so the frontend has no useful role in warmup.)
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { getMateService } from '../api/mateService';
 import { useMessageStore } from '../stores/useMessageStore';
 import type { MateHealthResponse } from '../types/mateTypes';
@@ -27,69 +31,109 @@ export interface MatePresenceState {
   error: string | null;
 }
 
-export function useMatePresence(): MatePresenceState {
-  const [state, setState] = useState<MatePresenceState>({
-    isOnline: false,
-    status: 'offline',
-    channels: [],
-    isWorking: false,
-    lastChecked: null,
-    error: null,
-  });
+const INITIAL_STATE: MatePresenceState = {
+  isOnline: false,
+  status: 'offline',
+  channels: [],
+  isWorking: false,
+  lastChecked: null,
+  error: null,
+};
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+// ----------------------------------------------------------------------------
+// Module-level shared poller — one interval, one in-flight request, N subscribers.
+// ----------------------------------------------------------------------------
 
-  const poll = useCallback(async () => {
+type Listener = (state: MatePresenceState) => void;
+
+let currentState: MatePresenceState = INITIAL_STATE;
+const listeners = new Set<Listener>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let delegationUnsub: (() => void) | null = null;
+let inFlight: Promise<void> | null = null;
+
+function emit(next: MatePresenceState) {
+  currentState = next;
+  listeners.forEach((l) => l(next));
+}
+
+async function poll() {
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
     try {
       const health = await getMateService().healthCheck();
       const activeDelegations = useMessageStore.getState().activeDelegations;
       const working = activeDelegations.some(
         (d) => d.status === 'delegating' || d.status === 'working'
       );
-
-      setState((prev) => ({
-        ...prev,
+      emit({
         isOnline: true,
         status: health.status,
         channels: health.channels ?? [],
         isWorking: working,
         lastChecked: new Date(),
         error: null,
-      }));
+      });
     } catch (err) {
-      setState((prev) => ({
-        ...prev,
+      emit({
+        ...currentState,
         isOnline: false,
         status: 'offline',
         channels: [],
         lastChecked: new Date(),
         error: err instanceof Error ? err.message : String(err),
-      }));
+      });
+    } finally {
+      inFlight = null;
     }
-  }, []);
+  })();
+  return inFlight;
+}
 
-  useEffect(() => {
-    // Initial poll
-    poll();
-
-    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [poll]);
-
-  // Also subscribe to delegation changes so isWorking updates immediately
-  useEffect(() => {
-    const unsub = useMessageStore.subscribe(
-      (s) => s.activeDelegations,
-      (delegations) => {
-        const working = delegations.some(
-          (d) => d.status === 'delegating' || d.status === 'working'
-        );
-        setState((prev) => ({ ...prev, isWorking: working }));
+function startPolling() {
+  if (intervalId !== null) return;
+  void poll();
+  intervalId = setInterval(() => void poll(), POLL_INTERVAL_MS);
+  delegationUnsub = useMessageStore.subscribe(
+    (s) => s.activeDelegations,
+    (delegations) => {
+      const working = delegations.some(
+        (d) => d.status === 'delegating' || d.status === 'working'
+      );
+      if (working !== currentState.isWorking) {
+        emit({ ...currentState, isWorking: working });
       }
-    );
-    return unsub;
+    }
+  );
+}
+
+function stopPolling() {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+  if (delegationUnsub) {
+    delegationUnsub();
+    delegationUnsub = null;
+  }
+}
+
+export function useMatePresence(): MatePresenceState {
+  const [state, setState] = useState<MatePresenceState>(currentState);
+
+  useEffect(() => {
+    listeners.add(setState);
+    if (listeners.size === 1) {
+      startPolling();
+    } else {
+      setState(currentState);
+    }
+    return () => {
+      listeners.delete(setState);
+      if (listeners.size === 0) {
+        stopPolling();
+      }
+    };
   }, []);
 
   return state;


### PR DESCRIPTION
## Summary
\`useMatePresence\` is consumed by 4 components (\`SidePanelIdle\`, \`InputAreaLayout\`, \`SidePanelChannels\`, \`MatePresenceIndicator\`). Each instance spun up its own \`useState\` + \`setInterval\`, so with the /app page open every consumer was hitting \`GET http://localhost:18789/health\` every 30s independently. That's roughly 8 requests/min / ~500/hr against Mate per open tab — what #334 observed as "200+ health calls" was the accumulated tally over a long Playwright session with multiple consumers mounted.

Hoisted the poller to module scope: one \`setInterval\`, one in-flight \`Promise\`, N subscribers. The first consumer to mount starts the poller; the last one to unmount stops it. Hook surface (\`MatePresenceState\`) and return type are unchanged, so callers don't need to touch anything.

Fixes #334

## Test plan
- [x] Reading the diff: \`listeners.size === 1\` guard starts polling exactly once; \`=== 0\` on unmount stops cleanly.
- [x] Inflight Promise deduplication (\`if (inFlight) return inFlight\`) prevents a burst of requests if multiple consumers mount in the same tick.
- [ ] Open /app, observe network tab — should see exactly one /health hit per 30s regardless of which panels are visible.
- [ ] Verify SPI store subscription still routes \`isWorking\` updates through (the store \`subscribe\` was moved from per-hook to module-scope).

## Notes on React 18 strict mode
\`listeners.size\` transitions 0→1→0→1 during strict-mode's double-mount in dev. That briefly tears down and restarts the interval, which is fine — at worst we immediately fire one poll (desired behavior on cold mount anyway). No duplicate intervals survive past the dev double-mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)