### PR TITLE
fix(core): restore optimistic credit rollback

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -302,8 +302,16 @@ export const useUser = (): UseUserReturn => {
       const consumptionResult = await authenticatedUserService.consumeCredits(auth0_id, consumption);
       
       // Update user with remaining credits from result
-      if (externalUser) {
-        const updatedExternalUser = { ...externalUser, credits: consumptionResult.remaining_credits };
+      const currentStoreUser = useUserStore.getState().externalUser ?? externalUser;
+      const currentDisplayedCredits = currentStoreUser?.credits;
+
+      if (currentStoreUser) {
+        const updatedExternalUser = {
+          ...currentStoreUser,
+          credits: currentDisplayedCredits === undefined
+            ? consumptionResult.remaining_credits
+            : Math.min(currentDisplayedCredits, consumptionResult.remaining_credits),
+        };
         setExternalUser(updatedExternalUser);
         logger.info(LogCategory.USER_AUTH, 'Credits consumed successfully', { 
           auth0_id, 

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -70,15 +70,21 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
   // optimistic UI update first, then backend consume. Revert on backend failure.
   const consumeCreditsAfterSend = (reason: string, amount = 1) => {
     const consumption: CreditConsumption = { amount, reason };
-    useUserStore.getState().consumeCreditsOptimistic(consumption);
-    userModule.consumeUserCredits(consumption).catch((error) => {
-      logger.error(LogCategory.USER_AUTH, 'Backend credit consumption failed, reverting optimistic update', {
-        reason,
-        amount,
-        error: error instanceof Error ? error.message : String(error),
+    const pendingId = useUserStore.getState().consumeCreditsOptimistic(consumption);
+
+    userModule.consumeUserCredits(consumption)
+      .then(() => {
+        useUserStore.getState().confirmCreditConsumption(pendingId);
+      })
+      .catch((error) => {
+        logger.error(LogCategory.USER_AUTH, 'Backend credit consumption failed, reverting optimistic update', {
+          reason,
+          amount,
+          pendingId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        useUserStore.getState().revertCreditsOptimistic(pendingId);
       });
-      useUserStore.getState().revertCreditsOptimistic();
-    });
   };
 
   const handleNewChat = () => {

--- a/src/stores/__tests__/useUserStore.test.ts
+++ b/src/stores/__tests__/useUserStore.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { ExternalUser } from '../../types/userTypes';
+import { useUserStore } from '../useUserStore';
+
+const createUser = (credits: number): ExternalUser => ({
+  auth0_id: 'auth0|user-1',
+  email: 'user@example.com',
+  name: 'Test User',
+  credits,
+  credits_total: 100,
+  plan: 'pro',
+  is_active: true,
+});
+
+describe('useUserStore optimistic credit consumption', () => {
+  beforeEach(() => {
+    useUserStore.getState().clearUserState();
+  });
+
+  test('restores credits when an optimistic deduction is reverted', () => {
+    useUserStore.getState().setExternalUser(createUser(10));
+
+    const pendingId = useUserStore.getState().consumeCreditsOptimistic({
+      amount: 2,
+      reason: 'chat.send',
+    });
+
+    expect(useUserStore.getState().externalUser?.credits).toBe(8);
+
+    useUserStore.getState().revertCreditsOptimistic(pendingId);
+
+    expect(useUserStore.getState().externalUser?.credits).toBe(10);
+  });
+
+  test('keeps the deducted credits after backend confirmation and clears the pending rollback', () => {
+    useUserStore.getState().setExternalUser(createUser(10));
+
+    const pendingId = useUserStore.getState().consumeCreditsOptimistic({
+      amount: 2,
+      reason: 'chat.send',
+    });
+
+    useUserStore.getState().confirmCreditConsumption(pendingId);
+    useUserStore.getState().revertCreditsOptimistic(pendingId);
+
+    expect(useUserStore.getState().externalUser?.credits).toBe(8);
+  });
+
+  test('tracks multiple in-flight deductions independently', () => {
+    useUserStore.getState().setExternalUser(createUser(10));
+
+    const firstPendingId = useUserStore.getState().consumeCreditsOptimistic({
+      amount: 1,
+      reason: 'chat.first',
+    });
+    const secondPendingId = useUserStore.getState().consumeCreditsOptimistic({
+      amount: 1,
+      reason: 'chat.second',
+    });
+
+    expect(firstPendingId).not.toBe(secondPendingId);
+    expect(useUserStore.getState().externalUser?.credits).toBe(8);
+
+    useUserStore.getState().confirmCreditConsumption(firstPendingId);
+    useUserStore.getState().revertCreditsOptimistic(secondPendingId);
+
+    expect(useUserStore.getState().externalUser?.credits).toBe(9);
+  });
+});

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -53,6 +53,11 @@ export interface UserStore {
   externalUser: ExternalUser | null;
   subscription: ExternalSubscription | null;
   role: UserRole;
+  _nextOptimisticCreditId: number;
+  _pendingCreditConsumptions: Array<{
+    id: string;
+    amount: number;
+  }>;
 
   // Loading States
   isLoading: boolean;
@@ -82,8 +87,9 @@ export interface UserStore {
 
   // Actions - Credits Management
   updateCredits: (credits: number, source?: 'api' | 'billing' | 'manual') => void;
-  consumeCreditsOptimistic: (consumption: CreditConsumption) => void;
-  revertCreditsOptimistic: () => void;
+  consumeCreditsOptimistic: (consumption: CreditConsumption) => string | null;
+  confirmCreditConsumption: (pendingId: string | null | undefined) => void;
+  revertCreditsOptimistic: (pendingId: string | null | undefined) => void;
 }
 
 // ================================================================================
@@ -95,6 +101,8 @@ const initialState = {
   externalUser: null,
   subscription: null,
   role: 'user' as UserRole,
+  _nextOptimisticCreditId: 0,
+  _pendingCreditConsumptions: [],
 
   // Loading States
   isLoading: false,
@@ -298,30 +306,95 @@ export const useUserStore = create<UserStore>()(
     
     consumeCreditsOptimistic: (consumption: CreditConsumption) => {
       const currentUser = get().externalUser;
-      if (currentUser) {
-        const newCredits = Math.max(0, currentUser.credits - consumption.amount);
-        
-        logger.info(LogCategory.USER_AUTH, 'Optimistic credits consumption', { 
-          auth0_id: currentUser.auth0_id,
-          consumption: consumption.amount,
-          reason: consumption.reason,
-          oldCredits: currentUser.credits,
-          newCredits 
-        });
-        
-        set({ 
-          externalUser: { 
-            ...currentUser, 
-            credits: newCredits 
-          }
-        });
+      if (!currentUser) {
+        log.warn('Cannot consume credits optimistically - no current user');
+        return null;
       }
+
+      const nextId = get()._nextOptimisticCreditId + 1;
+      const pendingId = `credit-pending-${nextId}`;
+      const newCredits = Math.max(0, currentUser.credits - consumption.amount);
+
+      logger.info(LogCategory.USER_AUTH, 'Optimistic credits consumption', { 
+        auth0_id: currentUser.auth0_id,
+        pendingId,
+        consumption: consumption.amount,
+        reason: consumption.reason,
+        oldCredits: currentUser.credits,
+        newCredits 
+      });
+
+      set((state) => ({
+        _nextOptimisticCreditId: nextId,
+        _pendingCreditConsumptions: [
+          ...state._pendingCreditConsumptions,
+          { id: pendingId, amount: consumption.amount },
+        ],
+        externalUser: { 
+          ...currentUser, 
+          credits: newCredits 
+        }
+      }));
+
+      return pendingId;
+    },
+
+    confirmCreditConsumption: (pendingId: string | null | undefined) => {
+      if (!pendingId) {
+        return;
+      }
+
+      const pending = get()._pendingCreditConsumptions.find((entry) => entry.id === pendingId);
+      if (!pending) {
+        logger.warn(LogCategory.USER_AUTH, 'Credit optimistic confirm requested for unknown pending entry', {
+          pendingId,
+        });
+        return;
+      }
+
+      logger.info(LogCategory.USER_AUTH, 'Confirmed optimistic credit consumption', {
+        pendingId,
+        amount: pending.amount,
+      });
+
+      set((state) => ({
+        _pendingCreditConsumptions: state._pendingCreditConsumptions.filter(
+          (entry) => entry.id !== pendingId,
+        ),
+      }));
     },
     
-    revertCreditsOptimistic: () => {
-      // This would need to store original credits value
-      // For now, just log the revert attempt
-      logger.warn(LogCategory.USER_AUTH, 'Credits optimistic revert requested - implement if needed');
+    revertCreditsOptimistic: (pendingId: string | null | undefined) => {
+      if (!pendingId) {
+        return;
+      }
+
+      const currentUser = get().externalUser;
+      const pending = get()._pendingCreditConsumptions.find((entry) => entry.id === pendingId);
+
+      if (!currentUser || !pending) {
+        logger.warn(LogCategory.USER_AUTH, 'Credit optimistic revert requested for unknown pending entry', {
+          pendingId,
+          hasUser: !!currentUser,
+        });
+        return;
+      }
+
+      logger.warn(LogCategory.USER_AUTH, 'Reverting optimistic credit consumption', {
+        pendingId,
+        amount: pending.amount,
+        currentCredits: currentUser.credits,
+      });
+
+      set((state) => ({
+        _pendingCreditConsumptions: state._pendingCreditConsumptions.filter(
+          (entry) => entry.id !== pendingId,
+        ),
+        externalUser: {
+          ...currentUser,
+          credits: currentUser.credits + pending.amount,
+        },
+      }));
     },
   }))
 );


### PR DESCRIPTION
## Summary
This restores optimistic credit rollback for failed backend credit consumption calls.
It tracks individual in-flight deductions so a failed consume restores only the matching optimistic change, while successful consumes clear their pending rollback state.

## Changes
- add pending optimistic credit tracking and per-consumption IDs in the user store
- confirm successful backend credit consumption instead of leaving stale rollback state behind
- revert only the matching optimistic deduction on backend failure
- add regression tests for revert, confirm, and double-deduct behavior

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | `npm test -- src/stores/__tests__/useUserStore.test.ts` (3 tests) | Pass |
| L2 Component | N/A | N/A |
| L3 Integration | N/A | N/A |
| L4 API | N/A | N/A |
| L5 Smoke | N/A | N/A |

## Notes
- `npm test` still reports unrelated pre-existing failures in `chatService`, `MateEventAdapter`, `config`/`gatewayIntegration`, and a missing `RealAPIEventMapping` module.

## Related Issues
Fixes #316