### PR TITLE
fix(core): align SDK package source resolution

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@isa/ui-web', '@isa/core', '@isa/theme', '@isa/transport'],
+  transpilePackages: ['@isa/ui-web', '@isa/core', '@isa/theme', '@isa/transport', '@isa/hooks'],
   // Produce a standalone build for Docker deployment
   output: 'standalone',
   env: {

--- a/src/config/__tests__/sdkResolution.test.ts
+++ b/src/config/__tests__/sdkResolution.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import tsconfig from '../../../tsconfig.json';
+import nextConfig from '../../../next.config.js';
+
+describe('SDK package resolution config', () => {
+  test('typescript paths resolve SDK packages to source entrypoints', () => {
+    const paths = tsconfig.compilerOptions.paths;
+
+    expect(paths['@isa/core']).toEqual(['../isA_App_SDK/packages/core/src/index.ts']);
+    expect(paths['@isa/transport']).toEqual(['../isA_App_SDK/packages/transport/src/index.ts']);
+    expect(paths['@isa/ui-web']).toEqual(['../isA_App_SDK/packages/ui-web/src/index.ts']);
+    expect(paths['@isa/theme']).toEqual(['../isA_App_SDK/packages/theme/src/index.ts']);
+    expect(paths['@isa/hooks']).toEqual(['../isA_App_SDK/packages/hooks/src/index.ts']);
+  });
+
+  test('next transpiles the same direct SDK packages the app imports', () => {
+    expect(nextConfig.transpilePackages).toEqual(
+      expect.arrayContaining([
+        '@isa/core',
+        '@isa/transport',
+        '@isa/ui-web',
+        '@isa/theme',
+        '@isa/hooks',
+      ]),
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
@@ -24,7 +25,12 @@
       "@/utils/*": ["./src/utils/*"],
       "@/types/*": ["./src/types/*"],
       "@/stores/*": ["./src/stores/*"],
-      "@/services/*": ["./src/services/*"]
+      "@/services/*": ["./src/services/*"],
+      "@isa/core": ["../isA_App_SDK/packages/core/src/index.ts"],
+      "@isa/transport": ["../isA_App_SDK/packages/transport/src/index.ts"],
+      "@isa/ui-web": ["../isA_App_SDK/packages/ui-web/src/index.ts"],
+      "@isa/theme": ["../isA_App_SDK/packages/theme/src/index.ts"],
+      "@isa/hooks": ["../isA_App_SDK/packages/hooks/src/index.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
This aligns TypeScript and Next.js SDK package resolution so direct imports like `@isa/transport` resolve to the App SDK source entrypoints instead of broken package `dist` metadata.
It also keeps the Next transpilation list in sync with the SDK packages the app imports directly.

## Changes
- add TypeScript path mappings for direct `@isa/*` SDK imports used by the app
- add a regression test covering SDK path mappings and Next transpile package alignment
- include `@isa/hooks` in `transpilePackages` so runtime transpilation matches the configured SDK package set

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | `npm test -- src/config/__tests__/sdkResolution.test.ts` (2 tests) | Pass |
| L2 Component | N/A | N/A |
| L3 Integration | N/A | N/A |
| L4 API | N/A | N/A |
| L5 Smoke | N/A | N/A |

## Verification
- `npx tsc --noEmit --project tsconfig.json --traceResolution` now resolves `@isa/core`, `@isa/transport`, `@isa/theme`, `@isa/ui-web`, and `@isa/hooks` to `../isA_App_SDK/packages/*/src/index.ts`.
- Full project `tsc` still reports unrelated pre-existing type errors elsewhere in the repo, but the direct SDK package `Cannot find module` resolution failures are no longer present.

## Related Issues
Fixes #171