### PR TITLE
feat(data): sync calendar store with SDK

### DIFF
--- a/src/stores/__tests__/useCalendarStore.test.ts
+++ b/src/stores/__tests__/useCalendarStore.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const {
+  mockGetTodayEvents,
+  mockGetEventsByDateRange,
+  mockCreateEvent,
+  mockUpdateEvent,
+  mockDeleteEvent,
+  mockGetProviders,
+} = vi.hoisted(() => ({
+  mockGetTodayEvents: vi.fn(),
+  mockGetEventsByDateRange: vi.fn(),
+  mockCreateEvent: vi.fn(),
+  mockUpdateEvent: vi.fn(),
+  mockDeleteEvent: vi.fn(),
+  mockGetProviders: vi.fn(),
+}));
+
+vi.mock('../../api/calendarService', () => ({
+  CalendarService: vi.fn().mockImplementation(() => ({
+    getTodayEvents: mockGetTodayEvents,
+    getEventsByDateRange: mockGetEventsByDateRange,
+    createEvent: mockCreateEvent,
+    updateEvent: mockUpdateEvent,
+    deleteEvent: mockDeleteEvent,
+  })),
+}));
+
+vi.mock('../../api/adapters/CalendarAdapter', () => ({
+  getProviders: mockGetProviders,
+}));
+
+import {
+  selectTodayEvents,
+  selectUpcomingEvents,
+  selectWeekEvents,
+  useCalendarStore,
+} from '../useCalendarStore';
+import { useUserStore } from '../useUserStore';
+
+function makeSdkEvent(overrides: Record<string, any> = {}) {
+  return {
+    event_id: 'evt-1',
+    user_id: 'user-1',
+    title: 'Standup',
+    description: 'Daily sync',
+    start_time: new Date('2026-04-23T09:00:00Z'),
+    end_time: new Date('2026-04-23T09:30:00Z'),
+    all_day: false,
+    timezone: 'UTC',
+    category: 'work',
+    recurrence_type: 'none',
+    reminders: [15],
+    sync_provider: 'local',
+    is_shared: false,
+    shared_with: [],
+    created_at: new Date('2026-04-20T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeStoreEvent(overrides: Record<string, any> = {}) {
+  return {
+    id: 'evt-1',
+    title: 'Standup',
+    description: 'Daily sync',
+    startTime: '2026-04-23T09:00:00.000Z',
+    endTime: '2026-04-23T09:30:00.000Z',
+    allDay: false,
+    provider: 'local',
+    reminders: [15],
+    metadata: undefined,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useCalendarStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCalendarStore.setState({
+      events: [],
+      todayEvents: [],
+      providers: [],
+      isLoading: false,
+      error: null,
+    });
+    useUserStore.getState().clearUserState();
+    useUserStore.getState().setExternalUser({ auth0_id: 'user-1' } as any);
+  });
+
+  test('fetches today events from the SDK-backed calendar service', async () => {
+    mockGetTodayEvents.mockResolvedValue([makeSdkEvent()]);
+
+    await useCalendarStore.getState().fetchTodayEvents();
+
+    expect(mockGetTodayEvents).toHaveBeenCalledWith('user-1');
+    expect(useCalendarStore.getState().todayEvents).toEqual([makeStoreEvent()]);
+    expect(useCalendarStore.getState().isLoading).toBe(false);
+    expect(useCalendarStore.getState().error).toBeNull();
+  });
+
+  test('blocks SDK fetches when no user is authenticated', async () => {
+    useUserStore.getState().clearUserState();
+
+    await useCalendarStore.getState().fetchEvents('2026-04-23T00:00:00Z', '2026-04-24T00:00:00Z');
+
+    expect(mockGetEventsByDateRange).not.toHaveBeenCalled();
+    expect(useCalendarStore.getState().error).toContain('Not authenticated');
+  });
+
+  test('fetches events for a custom date range', async () => {
+    mockGetEventsByDateRange.mockResolvedValue([
+      makeSdkEvent({ event_id: 'evt-custom', title: 'Custom range' }),
+    ]);
+
+    await useCalendarStore.getState().fetchEvents('2026-04-23T00:00:00Z', '2026-04-24T00:00:00Z');
+
+    expect(mockGetEventsByDateRange).toHaveBeenCalledWith(
+      'user-1',
+      new Date('2026-04-23T00:00:00Z'),
+      new Date('2026-04-24T00:00:00Z'),
+    );
+    expect(useCalendarStore.getState().events[0].id).toBe('evt-custom');
+  });
+
+  test('creates events optimistically and replaces the temporary event with SDK response', async () => {
+    const pending = deferred<any>();
+    mockCreateEvent.mockReturnValue(pending.promise);
+
+    const createPromise = useCalendarStore.getState().createEvent({
+      title: 'Planning',
+      startTime: '2026-04-23T10:00:00Z',
+      endTime: '2026-04-23T11:00:00Z',
+    });
+
+    expect(useCalendarStore.getState().events[0].id).toMatch(/^optimistic-/);
+    expect(useCalendarStore.getState().todayEvents[0].title).toBe('Planning');
+
+    pending.resolve(makeSdkEvent({ event_id: 'evt-created', title: 'Planning' }));
+    const created = await createPromise;
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        title: 'Planning',
+        start_time: '2026-04-23T10:00:00Z',
+        end_time: '2026-04-23T11:00:00Z',
+      }),
+    );
+    expect(created.id).toBe('evt-created');
+    expect(useCalendarStore.getState().events[0].id).toBe('evt-created');
+    expect(useCalendarStore.getState().todayEvents[0].id).toBe('evt-created');
+  });
+
+  test('rolls back optimistic create when SDK create fails', async () => {
+    mockCreateEvent.mockRejectedValue(new Error('create failed'));
+
+    await expect(
+      useCalendarStore.getState().createEvent({
+        title: 'Broken',
+        startTime: '2026-04-23T10:00:00Z',
+        endTime: '2026-04-23T11:00:00Z',
+      }),
+    ).rejects.toThrow('create failed');
+
+    expect(useCalendarStore.getState().events).toEqual([]);
+    expect(useCalendarStore.getState().todayEvents).toEqual([]);
+    expect(useCalendarStore.getState().error).toBe('create failed');
+  });
+
+  test('updates events optimistically and keeps SDK response', async () => {
+    useCalendarStore.setState({
+      events: [makeStoreEvent()],
+      todayEvents: [makeStoreEvent()],
+    });
+    mockUpdateEvent.mockResolvedValue(makeSdkEvent({ event_id: 'evt-1', title: 'Updated' }));
+
+    const updated = await useCalendarStore.getState().updateEvent('evt-1', { title: 'Updated' });
+
+    expect(mockUpdateEvent).toHaveBeenCalledWith('evt-1', 'user-1', { title: 'Updated' });
+    expect(updated.title).toBe('Updated');
+    expect(useCalendarStore.getState().events[0].title).toBe('Updated');
+    expect(useCalendarStore.getState().todayEvents[0].title).toBe('Updated');
+  });
+
+  test('rolls back optimistic update when SDK update fails', async () => {
+    useCalendarStore.setState({
+      events: [makeStoreEvent()],
+      todayEvents: [makeStoreEvent()],
+    });
+    mockUpdateEvent.mockRejectedValue(new Error('update failed'));
+
+    await expect(useCalendarStore.getState().updateEvent('evt-1', { title: 'Broken' })).rejects.toThrow(
+      'update failed',
+    );
+
+    expect(useCalendarStore.getState().events[0].title).toBe('Standup');
+    expect(useCalendarStore.getState().todayEvents[0].title).toBe('Standup');
+    expect(useCalendarStore.getState().error).toBe('update failed');
+  });
+
+  test('deletes events optimistically', async () => {
+    useCalendarStore.setState({
+      events: [makeStoreEvent()],
+      todayEvents: [makeStoreEvent()],
+    });
+    mockDeleteEvent.mockResolvedValue({ success: true, message: 'deleted' });
+
+    await useCalendarStore.getState().deleteEvent('evt-1');
+
+    expect(mockDeleteEvent).toHaveBeenCalledWith('evt-1', 'user-1');
+    expect(useCalendarStore.getState().events).toEqual([]);
+    expect(useCalendarStore.getState().todayEvents).toEqual([]);
+  });
+
+  test('rolls back optimistic delete when SDK delete fails', async () => {
+    useCalendarStore.setState({
+      events: [makeStoreEvent()],
+      todayEvents: [makeStoreEvent()],
+    });
+    mockDeleteEvent.mockRejectedValue(new Error('delete failed'));
+
+    await expect(useCalendarStore.getState().deleteEvent('evt-1')).rejects.toThrow('delete failed');
+
+    expect(useCalendarStore.getState().events).toHaveLength(1);
+    expect(useCalendarStore.getState().todayEvents).toHaveLength(1);
+    expect(useCalendarStore.getState().error).toBe('delete failed');
+  });
+
+  test('keeps provider fetching through the existing provider adapter', async () => {
+    mockGetProviders.mockResolvedValue([{ id: 'google', type: 'google', name: 'Google', connected: true }]);
+
+    await useCalendarStore.getState().fetchProviders();
+
+    expect(mockGetProviders).toHaveBeenCalled();
+    expect(useCalendarStore.getState().providers).toHaveLength(1);
+  });
+
+  test('exports date filtering selectors', () => {
+    const state = {
+      ...useCalendarStore.getState(),
+      events: [
+        makeStoreEvent({ id: 'today', startTime: new Date().toISOString() }),
+        makeStoreEvent({
+          id: 'next-week',
+          startTime: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        makeStoreEvent({
+          id: 'tomorrow',
+          startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    };
+
+    expect(selectTodayEvents(state).map((event) => event.id)).toEqual(['today']);
+    expect(selectWeekEvents(state).map((event) => event.id)).toEqual(['today', 'tomorrow']);
+    expect(selectUpcomingEvents(state).map((event) => event.id)).toEqual(['today', 'tomorrow', 'next-week']);
+  });
+});

--- a/src/stores/__tests__/useCalendarStore.test.ts
+++ b/src/stores/__tests__/useCalendarStore.test.ts
@@ -250,7 +250,11 @@ describe('useCalendarStore', () => {
     const state = {
       ...useCalendarStore.getState(),
       events: [
-        makeStoreEvent({ id: 'today', startTime: new Date().toISOString() }),
+        makeStoreEvent({
+          id: 'today',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        }),
         makeStoreEvent({
           id: 'next-week',
           startTime: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,13 +1,37 @@
 import { create } from 'zustand';
-import type { CalendarEvent, CalendarProvider } from '../api/adapters/CalendarAdapter';
+import {
+  CalendarService,
+  type CalendarEvent as SDKCalendarEvent,
+  type CreateEventRequest,
+  type UpdateEventRequest,
+} from '../api/calendarService';
+import type { CalendarProvider } from '../api/adapters/CalendarAdapter';
 import * as CalendarAdapter from '../api/adapters/CalendarAdapter';
 import { useUserStore } from './useUserStore';
 
+const calendarService = new CalendarService();
+
 function requireUserId(): string | null {
-  return useUserStore.getState().externalUser?.auth0_id ?? null;
+  const externalUser = useUserStore.getState().externalUser as Record<string, any> | null;
+  return externalUser?.auth0_id || externalUser?.sub || externalUser?.user_id || externalUser?.id || null;
 }
 
-interface CalendarState {
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  description?: string;
+  startTime: string;
+  endTime: string;
+  allDay?: boolean;
+  provider?: string;
+  reminders?: number[];
+  metadata?: Record<string, any>;
+}
+
+type CalendarEventDraft = Omit<CalendarEvent, 'id'>;
+type CalendarEventPatch = Partial<CalendarEventDraft>;
+
+export interface CalendarState {
   events: CalendarEvent[];
   todayEvents: CalendarEvent[];
   providers: CalendarProvider[];
@@ -16,9 +40,115 @@ interface CalendarState {
   fetchTodayEvents: () => Promise<void>;
   fetchEvents: (start: string, end: string) => Promise<void>;
   fetchProviders: () => Promise<void>;
-  addEvent: (event: Omit<CalendarEvent, 'id'>) => Promise<CalendarEvent>;
+  createEvent: (event: CalendarEventDraft) => Promise<CalendarEvent>;
+  updateEvent: (id: string, updates: CalendarEventPatch) => Promise<CalendarEvent>;
+  deleteEvent: (id: string) => Promise<void>;
+  addEvent: (event: CalendarEventDraft) => Promise<CalendarEvent>;
   removeEvent: (id: string) => Promise<void>;
 }
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function toISO(value: Date | string | undefined): string {
+  if (!value) return new Date().toISOString();
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function fromSDKEvent(event: SDKCalendarEvent): CalendarEvent {
+  return {
+    id: event.event_id,
+    title: event.title,
+    description: event.description,
+    startTime: toISO(event.start_time),
+    endTime: toISO(event.end_time),
+    allDay: event.all_day,
+    provider: event.sync_provider,
+    reminders: event.reminders,
+    metadata: event.metadata,
+  };
+}
+
+function toCreateRequest(userId: string, event: CalendarEventDraft): CreateEventRequest {
+  return {
+    user_id: userId,
+    title: event.title,
+    description: event.description,
+    start_time: event.startTime,
+    end_time: event.endTime,
+    all_day: event.allDay,
+    reminders: event.reminders,
+    metadata: event.metadata,
+  };
+}
+
+function toUpdateRequest(updates: CalendarEventPatch): UpdateEventRequest {
+  return {
+    title: updates.title,
+    description: updates.description,
+    start_time: updates.startTime,
+    end_time: updates.endTime,
+    all_day: updates.allDay,
+    reminders: updates.reminders,
+  };
+}
+
+function optimisticEvent(event: CalendarEventDraft): CalendarEvent {
+  return {
+    id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    allDay: false,
+    reminders: [],
+    ...event,
+  };
+}
+
+function replaceEvent(events: CalendarEvent[], id: string, next: CalendarEvent): CalendarEvent[] {
+  return events.map((event) => (event.id === id ? next : event));
+}
+
+function patchEvent(events: CalendarEvent[], id: string, updates: CalendarEventPatch): CalendarEvent[] {
+  return events.map((event) => (event.id === id ? { ...event, ...updates } : event));
+}
+
+function removeEvent(events: CalendarEvent[], id: string): CalendarEvent[] {
+  return events.filter((event) => event.id !== id);
+}
+
+function startOfLocalDay(date: Date): Date {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+function isInRange(event: CalendarEvent, start: Date, end: Date): boolean {
+  const time = new Date(event.startTime).getTime();
+  return time >= start.getTime() && time < end.getTime();
+}
+
+function isToday(event: CalendarEvent): boolean {
+  const start = startOfLocalDay(new Date());
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return isInRange(event, start, end);
+}
+
+export const selectTodayEvents = (state: CalendarState): CalendarEvent[] =>
+  state.events.filter(isToday);
+
+export const selectWeekEvents = (state: CalendarState): CalendarEvent[] => {
+  const start = startOfLocalDay(new Date());
+  const end = new Date(start);
+  end.setDate(end.getDate() + 7);
+  return state.events.filter((event) => isInRange(event, start, end));
+};
+
+export const selectUpcomingEvents = (state: CalendarState): CalendarEvent[] => {
+  const now = Date.now();
+  return [...state.events]
+    .filter((event) => new Date(event.endTime).getTime() >= now)
+    .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+};
 
 export const useCalendarStore = create<CalendarState>((set) => ({
   events: [],
@@ -34,10 +164,10 @@ export const useCalendarStore = create<CalendarState>((set) => ({
     }
     set({ isLoading: true, error: null });
     try {
-      const todayEvents = await CalendarAdapter.getTodayEvents(userId);
+      const todayEvents = (await calendarService.getTodayEvents(userId)).map(fromSDKEvent);
       set({ todayEvents, isLoading: false });
     } catch (err: any) {
-      set({ error: err.message, isLoading: false });
+      set({ error: errorMessage(err), isLoading: false });
     }
   },
   fetchEvents: async (start, end) => {
@@ -48,10 +178,14 @@ export const useCalendarStore = create<CalendarState>((set) => ({
     }
     set({ isLoading: true, error: null });
     try {
-      const events = await CalendarAdapter.getEvents(userId, start, end);
+      const events = (await calendarService.getEventsByDateRange(
+        userId,
+        new Date(start),
+        new Date(end),
+      )).map(fromSDKEvent);
       set({ events, isLoading: false });
     } catch (err: any) {
-      set({ error: err.message, isLoading: false });
+      set({ error: errorMessage(err), isLoading: false });
     }
   },
   fetchProviders: async () => {
@@ -59,19 +193,102 @@ export const useCalendarStore = create<CalendarState>((set) => ({
       const providers = await CalendarAdapter.getProviders();
       set({ providers });
     } catch (err: any) {
-      set({ error: err.message });
+      set({ error: errorMessage(err) });
+    }
+  },
+  createEvent: async (event) => {
+    const userId = requireUserId();
+    if (!userId) {
+      const message = 'Not authenticated: calendar create requires a logged-in user';
+      set({ error: message, isLoading: false });
+      throw new Error(message);
+    }
+
+    const pending = optimisticEvent(event);
+    const previous = useCalendarStore.getState();
+    set((state) => ({
+      error: null,
+      events: [...state.events, pending],
+      todayEvents: isToday(pending) ? [...state.todayEvents, pending] : state.todayEvents,
+    }));
+
+    try {
+      const created = fromSDKEvent(await calendarService.createEvent(toCreateRequest(userId, event)));
+      set((state) => ({
+        events: replaceEvent(state.events, pending.id, created),
+        todayEvents: replaceEvent(state.todayEvents, pending.id, created),
+      }));
+      return created;
+    } catch (err) {
+      set({
+        events: previous.events,
+        todayEvents: previous.todayEvents,
+        error: errorMessage(err),
+      });
+      throw err;
+    }
+  },
+  updateEvent: async (id, updates) => {
+    const userId = requireUserId();
+    if (!userId) {
+      const message = 'Not authenticated: calendar update requires a logged-in user';
+      set({ error: message, isLoading: false });
+      throw new Error(message);
+    }
+
+    const previous = useCalendarStore.getState();
+    set((s) => ({
+      error: null,
+      events: patchEvent(s.events, id, updates),
+      todayEvents: patchEvent(s.todayEvents, id, updates),
+    }));
+
+    try {
+      const updated = fromSDKEvent(await calendarService.updateEvent(id, userId, toUpdateRequest(updates)));
+      set((s) => ({
+        events: replaceEvent(s.events, id, updated),
+        todayEvents: replaceEvent(s.todayEvents, id, updated),
+      }));
+      return updated;
+    } catch (err) {
+      set({
+        events: previous.events,
+        todayEvents: previous.todayEvents,
+        error: errorMessage(err),
+      });
+      throw err;
+    }
+  },
+  deleteEvent: async (id) => {
+    const userId = requireUserId();
+    if (!userId) {
+      const message = 'Not authenticated: calendar delete requires a logged-in user';
+      set({ error: message, isLoading: false });
+      throw new Error(message);
+    }
+
+    const previous = useCalendarStore.getState();
+    set((s) => ({
+      error: null,
+      events: removeEvent(s.events, id),
+      todayEvents: removeEvent(s.todayEvents, id),
+    }));
+
+    try {
+      await calendarService.deleteEvent(id, userId);
+    } catch (err) {
+      set({
+        events: previous.events,
+        todayEvents: previous.todayEvents,
+        error: errorMessage(err),
+      });
+      throw err;
     }
   },
   addEvent: async (event) => {
-    const created = await CalendarAdapter.createEvent(event);
-    set((s) => ({ todayEvents: [...s.todayEvents, created], events: [...s.events, created] }));
-    return created;
+    return useCalendarStore.getState().createEvent(event);
   },
   removeEvent: async (id) => {
-    await CalendarAdapter.deleteEvent(id);
-    set((s) => ({
-      todayEvents: s.todayEvents.filter((e) => e.id !== id),
-      events: s.events.filter((e) => e.id !== id),
-    }));
+    return useCalendarStore.getState().deleteEvent(id);
   },
 }));


### PR DESCRIPTION
## Summary
- Move useCalendarStore event reads/writes onto the SDK-backed CalendarService added in #338.
- Add optimistic create/update/delete with rollback on SDK failures.
- Add date filtering selectors for today, week, and upcoming events while keeping provider sync on the existing provider adapter.
- Preserve addEvent/removeEvent aliases for current call sites.

## Tests
- npm test -- src/stores/__tests__/useCalendarStore.test.ts
- npm test -- src/stores/__tests__/useCalendarStore.test.ts src/api/__tests__/calendarService.test.ts src/api/adapters/__tests__/CalendarAdapter.test.ts

Fixes #158
Related to #156