### PR TITLE
Create useCalendar hook for component consumption

### DIFF
--- a/src/hooks/__tests__/useCalendar.test.tsx
+++ b/src/hooks/__tests__/useCalendar.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  calendarActionsSelector,
+  calendarDateHelpersEqual,
+  calendarDateHelpersSelector,
+  calendarStateSelector,
+} from '../useCalendar';
+import { useCalendarStore, type CalendarEvent } from '../../stores/useCalendarStore';
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: 'evt-1',
+    title: 'Standup',
+    startTime: '2026-04-23T09:00:00.000Z',
+    endTime: '2026-04-23T09:30:00.000Z',
+    allDay: false,
+    ...overrides,
+  };
+}
+
+describe('useCalendar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T08:00:00.000Z'));
+    useCalendarStore.setState({
+      events: [],
+      todayEvents: [],
+      providers: [],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('selects calendar state and CRUD actions for component consumption', () => {
+    const event = makeEvent();
+    useCalendarStore.setState({
+      events: [event],
+      isLoading: true,
+      error: 'sync failed',
+    });
+
+    const store = useCalendarStore.getState();
+    const calendar = {
+      ...calendarStateSelector(store),
+      ...calendarActionsSelector(store),
+    };
+
+    expect(calendar.events).toEqual([event]);
+    expect(calendar.loading).toBe(true);
+    expect(calendar.isLoading).toBe(true);
+    expect(calendar.error).toBe('sync failed');
+    expect(calendar.createEvent).toBe(store.createEvent);
+    expect(calendar.updateEvent).toBe(store.updateEvent);
+    expect(calendar.deleteEvent).toBe(store.deleteEvent);
+  });
+
+  test('selects date helper event groups from the calendar store', () => {
+    const today = makeEvent({ id: 'today' });
+    const fetchedToday = makeEvent({ id: 'fetched-today', title: 'Fetched today' });
+    const tomorrow = makeEvent({
+      id: 'tomorrow',
+      startTime: '2026-04-24T09:00:00.000Z',
+      endTime: '2026-04-24T09:30:00.000Z',
+    });
+    const later = makeEvent({
+      id: 'later',
+      startTime: '2026-05-03T09:00:00.000Z',
+      endTime: '2026-05-03T09:30:00.000Z',
+    });
+
+    useCalendarStore.setState({
+      events: [later, today, tomorrow],
+      todayEvents: [fetchedToday],
+    });
+
+    const calendar = calendarDateHelpersSelector(useCalendarStore.getState());
+
+    expect(calendar.todayEvents.map((event) => event.id)).toEqual(['fetched-today', 'today']);
+    expect(calendar.weekEvents.map((event) => event.id)).toEqual(['today', 'tomorrow']);
+    expect(calendar.upcomingEvents.map((event) => event.id)).toEqual(['today', 'tomorrow', 'later']);
+  });
+
+  test('keeps equivalent helper selections equal to avoid unnecessary hook updates', () => {
+    const today = makeEvent({ id: 'today' });
+    const state = {
+      ...useCalendarStore.getState(),
+      events: [today],
+      todayEvents: [],
+    };
+
+    const first = calendarDateHelpersSelector(state);
+    const second = calendarDateHelpersSelector(state);
+
+    expect(first).not.toBe(second);
+    expect(calendarDateHelpersEqual(first, second)).toBe(true);
+    expect(calendarDateHelpersEqual(first, { ...second, upcomingEvents: [] })).toBe(false);
+  });
+});

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import {
+  selectTodayEvents,
+  selectUpcomingEvents,
+  selectWeekEvents,
+  useCalendarStore,
+  type CalendarEvent,
+  type CalendarState,
+} from '../stores/useCalendarStore';
+
+export type CalendarActions = Pick<
+  CalendarState,
+  | 'fetchTodayEvents'
+  | 'fetchEvents'
+  | 'fetchProviders'
+  | 'createEvent'
+  | 'updateEvent'
+  | 'deleteEvent'
+  | 'addEvent'
+  | 'removeEvent'
+>;
+
+export interface CalendarSnapshot {
+  events: CalendarEvent[];
+  providers: CalendarState['providers'];
+  loading: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface CalendarDateHelpers {
+  todayEvents: CalendarEvent[];
+  weekEvents: CalendarEvent[];
+  upcomingEvents: CalendarEvent[];
+}
+
+export interface UseCalendarReturn extends CalendarSnapshot, CalendarDateHelpers, CalendarActions {
+  actions: CalendarActions;
+}
+
+export const calendarStateSelector = (state: CalendarState): CalendarSnapshot => ({
+  events: state.events,
+  providers: state.providers,
+  loading: state.isLoading,
+  isLoading: state.isLoading,
+  error: state.error,
+});
+
+export const calendarActionsSelector = (state: CalendarState): CalendarActions => ({
+  fetchTodayEvents: state.fetchTodayEvents,
+  fetchEvents: state.fetchEvents,
+  fetchProviders: state.fetchProviders,
+  createEvent: state.createEvent,
+  updateEvent: state.updateEvent,
+  deleteEvent: state.deleteEvent,
+  addEvent: state.addEvent,
+  removeEvent: state.removeEvent,
+});
+
+function uniqueById(events: CalendarEvent[]): CalendarEvent[] {
+  const seen = new Set<string>();
+  return events.filter((event) => {
+    if (seen.has(event.id)) return false;
+    seen.add(event.id);
+    return true;
+  });
+}
+
+export const calendarDateHelpersSelector = (state: CalendarState): CalendarDateHelpers => ({
+  todayEvents: uniqueById([...state.todayEvents, ...selectTodayEvents(state)]),
+  weekEvents: selectWeekEvents(state),
+  upcomingEvents: selectUpcomingEvents(state),
+});
+
+function sameEventList(left: CalendarEvent[], right: CalendarEvent[]): boolean {
+  return left.length === right.length && left.every((event, index) => Object.is(event, right[index]));
+}
+
+export function calendarDateHelpersEqual(
+  left: CalendarDateHelpers,
+  right: CalendarDateHelpers,
+): boolean {
+  return (
+    sameEventList(left.todayEvents, right.todayEvents) &&
+    sameEventList(left.weekEvents, right.weekEvents) &&
+    sameEventList(left.upcomingEvents, right.upcomingEvents)
+  );
+}
+
+function calendarSnapshotEqual(left: CalendarSnapshot, right: CalendarSnapshot): boolean {
+  return (
+    Object.is(left.events, right.events) &&
+    Object.is(left.providers, right.providers) &&
+    left.loading === right.loading &&
+    left.isLoading === right.isLoading &&
+    left.error === right.error
+  );
+}
+
+function calendarActionsEqual(left: CalendarActions, right: CalendarActions): boolean {
+  return (
+    Object.is(left.fetchTodayEvents, right.fetchTodayEvents) &&
+    Object.is(left.fetchEvents, right.fetchEvents) &&
+    Object.is(left.fetchProviders, right.fetchProviders) &&
+    Object.is(left.createEvent, right.createEvent) &&
+    Object.is(left.updateEvent, right.updateEvent) &&
+    Object.is(left.deleteEvent, right.deleteEvent) &&
+    Object.is(left.addEvent, right.addEvent) &&
+    Object.is(left.removeEvent, right.removeEvent)
+  );
+}
+
+export function useCalendar(): UseCalendarReturn {
+  const snapshot = useCalendarStore(calendarStateSelector, calendarSnapshotEqual);
+  const dateHelpers = useCalendarStore(calendarDateHelpersSelector, calendarDateHelpersEqual);
+  const actions = useCalendarStore(calendarActionsSelector, calendarActionsEqual);
+
+  return useMemo(
+    () => ({
+      ...snapshot,
+      ...dateHelpers,
+      ...actions,
+      actions,
+    }),
+    [snapshot, dateHelpers, actions],
+  );
+}

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
 import {
   CalendarService,
   type CalendarEvent as SDKCalendarEvent,
@@ -28,8 +28,8 @@ export interface CalendarEvent {
   metadata?: Record<string, any>;
 }
 
-type CalendarEventDraft = Omit<CalendarEvent, 'id'>;
-type CalendarEventPatch = Partial<CalendarEventDraft>;
+export type CalendarEventDraft = Omit<CalendarEvent, 'id'>;
+export type CalendarEventPatch = Partial<CalendarEventDraft>;
 
 export interface CalendarState {
   events: CalendarEvent[];
@@ -150,7 +150,7 @@ export const selectUpcomingEvents = (state: CalendarState): CalendarEvent[] => {
     .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 };
 
-export const useCalendarStore = create<CalendarState>((set) => ({
+const createCalendarState: StateCreator<CalendarState> = (set, get) => ({
   events: [],
   todayEvents: [],
   providers: [],
@@ -205,7 +205,7 @@ export const useCalendarStore = create<CalendarState>((set) => ({
     }
 
     const pending = optimisticEvent(event);
-    const previous = useCalendarStore.getState();
+    const previous = get();
     set((state) => ({
       error: null,
       events: [...state.events, pending],
@@ -236,7 +236,7 @@ export const useCalendarStore = create<CalendarState>((set) => ({
       throw new Error(message);
     }
 
-    const previous = useCalendarStore.getState();
+    const previous = get();
     set((s) => ({
       error: null,
       events: patchEvent(s.events, id, updates),
@@ -267,7 +267,7 @@ export const useCalendarStore = create<CalendarState>((set) => ({
       throw new Error(message);
     }
 
-    const previous = useCalendarStore.getState();
+    const previous = get();
     set((s) => ({
       error: null,
       events: removeEvent(s.events, id),
@@ -286,9 +286,11 @@ export const useCalendarStore = create<CalendarState>((set) => ({
     }
   },
   addEvent: async (event) => {
-    return useCalendarStore.getState().createEvent(event);
+    return get().createEvent(event);
   },
   removeEvent: async (id) => {
-    return useCalendarStore.getState().deleteEvent(id);
+    return get().deleteEvent(id);
   },
-}));
+});
+
+export const useCalendarStore = create<CalendarState>(createCalendarState);


### PR DESCRIPTION
## Summary
- Add src/hooks/useCalendar.ts as a component-facing wrapper over useCalendarStore.
- Expose events, loading/error state, providers, CRUD/fetch actions, and today/week/upcoming helper groups.
- Add selector equality checks to avoid unnecessary hook updates and make calendar store action aliases typed without self-referencing the store initializer.

## Tests
- npm test -- src/hooks/__tests__/useCalendar.test.tsx src/stores/__tests__/useCalendarStore.test.ts
- npm test -- src/hooks/__tests__/useCalendar.test.tsx src/stores/__tests__/useCalendarStore.test.ts src/api/__tests__/calendarService.test.ts src/api/adapters/__tests__/CalendarAdapter.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false 2>&1 | rg "src/hooks/useCalendar|src/stores/useCalendarStore|src/components/ui/calendar/CalendarSyncSettings|src/modules/AlertModule" (no matching errors; full tsc still has unrelated existing repo errors)

Fixes #159