### PR TITLE
Build Browser Control panel with HIL approve/reject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@isa/core": "file:../isA_App_SDK/packages/core",
+        "@isa/hooks": "file:../isA_App_SDK/packages/hooks",
         "@isa/transport": "file:../isA_App_SDK/packages/transport",
         "@isa/ui-web": "file:../isA_App_SDK/packages/ui-web",
         "@rudderstack/analytics-js": "^3.23.2",
@@ -47,6 +48,34 @@
         "tsup": "^8.0.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0"
+      }
+    },
+    "../isA_App_SDK/packages/hooks": {
+      "name": "@isa/hooks",
+      "version": "2.0.0",
+      "dependencies": {
+        "@isa/core": "workspace:*"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/react-hooks": "^8.0.1",
+        "@types/react": "^18.0.0",
+        "@types/react-native": "^0.72.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "react": "^18.0.0",
+        "react-native": "^0.72.0",
+        "ts-jest": "^29.4.6",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "@isa/core": "workspace:*",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "../isA_App_SDK/packages/transport": {
@@ -700,6 +729,10 @@
     },
     "node_modules/@isa/core": {
       "resolved": "../isA_App_SDK/packages/core",
+      "link": true
+    },
+    "node_modules/@isa/hooks": {
+      "resolved": "../isA_App_SDK/packages/hooks",
       "link": true
     },
     "node_modules/@isa/transport": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@isa/core": "^0.1.0",
+    "@isa/hooks": "file:../isA_App_SDK/packages/hooks",
     "@isa/transport": "^0.1.0",
     "@isa/theme": "^2.0.0",
     "@isa/ui-web": "^0.1.0",

--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -138,6 +138,8 @@ describe('ChatService', () => {
       onTaskProgress: vi.fn(),
       onHILInterruptDetected: vi.fn(),
       onHILCheckpointCreated: vi.fn(),
+      onBrowserScreenshot: vi.fn(),
+      onBrowserAction: vi.fn(),
       onArtifactCreated: vi.fn(),
       onArtifactUpdated: vi.fn(),
     };
@@ -429,6 +431,97 @@ describe('ChatService', () => {
       const event = { type: 'hil_approval_required', action: 'file_write' };
       await streamEvent(event);
       expect(callbacks.onHILInterruptDetected).toHaveBeenCalledWith(event);
+    });
+
+    test('browser_screenshot → onBrowserScreenshot', async () => {
+      await streamEvent({
+        type: 'browser_screenshot',
+        screenshot_url: 'data:image/png;base64,abc',
+        url: 'https://example.com',
+        tabs: [{ id: 'tab-1', title: 'Example', url: 'https://example.com' }],
+        active_tab_id: 'tab-1',
+      });
+
+      expect(callbacks.onBrowserScreenshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          screenshotUrl: 'data:image/png;base64,abc',
+          currentUrl: 'https://example.com',
+          activeTabId: 'tab-1',
+        }),
+      );
+    });
+
+    test('custom browser_action_pending → onBrowserAction', async () => {
+      await streamEvent({
+        type: 'custom_event',
+        metadata: {
+          custom_type: 'browser_action_pending',
+          custom_data: {
+            id: 'act-1',
+            action_type: 'click',
+            description: 'Click Submit',
+            target: 'button[type=submit]',
+            x: 42,
+            y: 55,
+          },
+        },
+      });
+
+      expect(callbacks.onBrowserAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'act-1',
+          type: 'click',
+          status: 'pending',
+          description: 'Click Submit',
+          target: 'button[type=submit]',
+          x: 42,
+          y: 55,
+        }),
+      );
+    });
+
+    test('custom browser_action preserves SDK adapter action type', async () => {
+      await streamEvent({
+        type: 'custom_event',
+        metadata: {
+          custom_type: 'browser_action',
+          custom_data: {
+            id: 'tc-browser',
+            type: 'navigate',
+            status: 'completed',
+            description: 'Navigation completed',
+            target: 'https://example.com',
+          },
+        },
+      });
+
+      expect(callbacks.onBrowserAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'tc-browser',
+          type: 'navigate',
+          status: 'completed',
+          target: 'https://example.com',
+        }),
+      );
+    });
+
+    test('browser hil_approval_required also creates pending browser action', async () => {
+      const event = {
+        type: 'hil_approval_required',
+        tool_name: 'ComputerUseAgent',
+        action_type: 'navigate',
+        target: 'https://example.com',
+      };
+      await streamEvent(event);
+
+      expect(callbacks.onHILInterruptDetected).toHaveBeenCalledWith(event);
+      expect(callbacks.onBrowserAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'navigate',
+          status: 'pending',
+          target: 'https://example.com',
+        }),
+      );
     });
 
     test('artifact_created → onArtifactCreated', async () => {

--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -24,6 +24,22 @@ export interface MateSSEEvent {
   parameters?: Record<string, unknown>;
   result?: unknown;
   error?: string;
+  id?: string;
+  task_id?: string;
+  title?: string;
+  description?: string;
+  due_at?: string;
+  screenshot?: string;
+  screenshot_url?: string;
+  image_url?: string;
+  url?: string;
+  tabs?: unknown[];
+  active_tab_id?: string;
+  action_type?: string;
+  status?: string;
+  target?: string;
+  x?: number;
+  y?: number;
   // Autonomous event fields
   source?: 'scheduler' | 'trigger' | 'channel';
   job_id?: string;
@@ -122,6 +138,28 @@ export function adaptMateEvent(
         parameters: event.parameters,
       });
 
+      if (/browser|computer[_ -]?use/i.test(toolName)) {
+        results.push({
+          type: 'custom_event' as AGUIEventType,
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          metadata: {
+            custom_type: 'browser_action',
+            custom_data: {
+              id: event.tool_call_id,
+              type: event.parameters?.action || event.parameters?.type || event.action_type || 'wait',
+              status: 'pending',
+              description: event.content || `Approve ${toolName}`,
+              target: event.parameters?.target || event.parameters?.url,
+              x: event.parameters?.x,
+              y: event.parameters?.y,
+              tool_name: toolName,
+            },
+          },
+        });
+      }
+
       if (isMemoryTool && event.result) {
         // Synthesize a memory_recall custom event from the tool result
         const resultData = typeof event.result === 'object' ? event.result as Record<string, unknown> : {};
@@ -145,16 +183,61 @@ export function adaptMateEvent(
     }
 
     case 'tool_result': {
+      const toolName = event.tool_name || 'unknown';
       results.push({
         type: 'tool_call_end',
         thread_id: threadId,
         timestamp: now,
         run_id: context.runId,
-        tool_name: event.tool_name || 'unknown',
+        tool_name: toolName,
         tool_call_id: event.tool_call_id || '',
         result: event.result,
         error: event.error ? { code: 'TOOL_ERROR', message: event.error } : undefined,
       });
+
+      if (/browser|computer[_ -]?use/i.test(toolName)) {
+        const resultData = typeof event.result === 'object' && event.result
+          ? event.result as Record<string, unknown>
+          : {};
+
+        results.push({
+          type: 'custom_event' as AGUIEventType,
+          thread_id: threadId,
+          timestamp: now,
+          run_id: context.runId,
+          metadata: {
+            custom_type: 'browser_action',
+            custom_data: {
+              id: event.tool_call_id,
+              type: resultData.action || resultData.type || 'wait',
+              status: event.error ? 'failed' : 'completed',
+              description: event.content || `${toolName} completed`,
+              target: resultData.target || resultData.url,
+              tool_name: toolName,
+              error: event.error,
+            },
+          },
+        });
+
+        const screenshot = resultData.screenshot || resultData.screenshot_url || resultData.image_url;
+        if (screenshot) {
+          results.push({
+            type: 'custom_event' as AGUIEventType,
+            thread_id: threadId,
+            timestamp: now,
+            run_id: context.runId,
+            metadata: {
+              custom_type: 'browser_screenshot',
+              custom_data: {
+                screenshot,
+                url: resultData.url,
+                tabs: resultData.tabs,
+                active_tab_id: resultData.active_tab_id,
+              },
+            },
+          });
+        }
+      }
       break;
     }
 
@@ -311,6 +394,55 @@ case 'memory_recall': {
       break;
     }
 
+    case 'browser_screenshot':
+    case 'computer_use_screenshot':
+    case 'computer_screenshot':
+    case 'screenshot': {
+      results.push({
+        type: 'custom_event' as AGUIEventType,
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        metadata: {
+          custom_type: 'browser_screenshot',
+          custom_data: {
+            ...event.metadata,
+            screenshot: event.screenshot || event.screenshot_url || event.image_url || event.content,
+            url: event.url || (event.metadata?.url as string | undefined),
+            tabs: event.tabs || event.metadata?.tabs,
+            active_tab_id: event.active_tab_id || (event.metadata?.active_tab_id as string | undefined),
+          },
+        },
+      });
+      break;
+    }
+
+    case 'browser_action':
+    case 'browser_action_pending':
+    case 'computer_use_action':
+    case 'computer_action': {
+      results.push({
+        type: 'custom_event' as AGUIEventType,
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
+        metadata: {
+          custom_type: event.type === 'browser_action_pending' ? 'browser_action_pending' : 'browser_action',
+          custom_data: {
+            ...event.metadata,
+            id: event.id || event.tool_call_id,
+            type: event.action_type || event.metadata?.action_type || 'wait',
+            status: event.status || 'pending',
+            description: event.description || event.content || 'Browser action',
+            target: event.target || event.url || event.metadata?.target,
+            x: event.x,
+            y: event.y,
+          },
+        },
+      });
+      break;
+    }
+
     case 'autonomous_result': {
       // Background autonomous action result from Mate (scheduled tasks, triggers, etc.)
       // Mapped to a custom AGUI event that the autonomousEventService will handle.
@@ -337,7 +469,10 @@ case 'memory_recall': {
     case 'updateDataModel':
     case 'deleteSurface': {
       results.push({
-        type: 'a2ui_surface',
+        type: 'a2ui_surface' as AGUIEventType,
+        thread_id: threadId,
+        timestamp: now,
+        run_id: context.runId,
         data: {
           messageType: event.type,
           payload: event,

--- a/src/api/adapters/__tests__/MateEventAdapter.test.ts
+++ b/src/api/adapters/__tests__/MateEventAdapter.test.ts
@@ -122,6 +122,106 @@ describe('adaptMateEvent — tool events', () => {
     expect(events[0].type).toBe('tool_call_end');
     expect(events[0].error).toEqual({ code: 'TOOL_ERROR', message: 'Timeout after 10s' });
   });
+
+  test('ComputerUseAgent tool_use also emits pending browser action', () => {
+    const event: MateSSEEvent = {
+      type: 'tool_use',
+      tool_name: 'ComputerUseAgent',
+      tool_call_id: 'tc_browser',
+      content: 'Click Submit',
+      parameters: { action: 'click', target: 'button[type=submit]', x: 44, y: 52 },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events[0].type).toBe('tool_call_start');
+    expect(events[1].type).toBe('custom_event');
+    expect(events[1].metadata?.custom_type).toBe('browser_action');
+    expect(events[1].metadata?.custom_data).toMatchObject({
+      id: 'tc_browser',
+      type: 'click',
+      status: 'pending',
+      description: 'Click Submit',
+      target: 'button[type=submit]',
+      x: 44,
+      y: 52,
+    });
+  });
+
+  test('ComputerUseAgent tool_result with screenshot emits browser screenshot', () => {
+    const event: MateSSEEvent = {
+      type: 'tool_result',
+      tool_name: 'ComputerUseAgent',
+      tool_call_id: 'tc_browser',
+      result: {
+        action: 'navigate',
+        url: 'https://example.com',
+        screenshot_url: 'data:image/png;base64,abc',
+      },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events.map((e) => e.type)).toEqual(['tool_call_end', 'custom_event', 'custom_event']);
+    expect(events[1].metadata?.custom_type).toBe('browser_action');
+    expect(events[1].metadata?.custom_data).toMatchObject({
+      id: 'tc_browser',
+      type: 'navigate',
+      status: 'completed',
+      target: 'https://example.com',
+    });
+    expect(events[2].metadata?.custom_type).toBe('browser_screenshot');
+    expect(events[2].metadata?.custom_data).toMatchObject({
+      screenshot: 'data:image/png;base64,abc',
+      url: 'https://example.com',
+    });
+  });
+});
+
+describe('adaptMateEvent — browser control events', () => {
+  const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+
+  test('browser_screenshot maps to browser custom event', () => {
+    const event: MateSSEEvent = {
+      type: 'browser_screenshot',
+      screenshot_url: 'data:image/png;base64,abc',
+      url: 'https://example.com',
+      active_tab_id: 'tab-1',
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('custom_event');
+    expect(events[0].metadata?.custom_type).toBe('browser_screenshot');
+    expect(events[0].metadata?.custom_data).toMatchObject({
+      screenshot: 'data:image/png;base64,abc',
+      url: 'https://example.com',
+      active_tab_id: 'tab-1',
+    });
+  });
+
+  test('browser_action_pending maps to browser action custom event', () => {
+    const event: MateSSEEvent = {
+      type: 'browser_action_pending',
+      id: 'act-1',
+      action_type: 'click',
+      description: 'Click Approve',
+      target: '#approve',
+      x: 20,
+      y: 30,
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata?.custom_type).toBe('browser_action_pending');
+    expect(events[0].metadata?.custom_data).toMatchObject({
+      id: 'act-1',
+      type: 'click',
+      status: 'pending',
+      description: 'Click Approve',
+      target: '#approve',
+      x: 20,
+      y: 30,
+    });
+  });
 });
 
 describe('adaptMateEvent — lifecycle events', () => {

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -64,6 +64,10 @@ export interface ChatServiceCallbacks {
   onHILInterruptDetected?: (hilEvent: any) => void;
   onHILCheckpointCreated?: (checkpoint: any) => void;
   onHILExecutionStatusChanged?: (statusData: any) => void;
+
+  // Browser control callbacks
+  onBrowserScreenshot?: (event: any) => void;
+  onBrowserAction?: (event: any) => void;
   
   // Artifact回调
   onArtifactCreated?: (artifact: any) => void;
@@ -384,6 +388,23 @@ export class ChatService {
       case 'hil_approval_required':
         // 使用现有的HIL interrupt回调处理approval required事件
         callbacks.onHILInterruptDetected?.(event);
+        if (this.isBrowserControlEvent(event)) {
+          callbacks.onBrowserAction?.(this.normalizeBrowserAction({ ...event, status: 'pending' }));
+        }
+        break;
+
+      // Browser control events
+      case 'browser_screenshot':
+      case 'computer_use_screenshot':
+      case 'computer_screenshot':
+        callbacks.onBrowserScreenshot?.(this.normalizeBrowserScreenshot(event));
+        break;
+
+      case 'browser_action':
+      case 'browser_action_pending':
+      case 'computer_use_action':
+      case 'computer_action':
+        callbacks.onBrowserAction?.(this.normalizeBrowserAction(event));
         break;
         
       // 图像生成事件
@@ -441,6 +462,19 @@ export class ChatService {
     const customData = event.metadata?.custom_data || {};
     
     switch (customType) {
+      case 'browser_screenshot':
+      case 'computer_use_screenshot':
+      case 'computer_screenshot':
+        callbacks.onBrowserScreenshot?.(this.normalizeBrowserScreenshot(event));
+        break;
+
+      case 'browser_action':
+      case 'browser_action_pending':
+      case 'computer_use_action':
+      case 'computer_action':
+        callbacks.onBrowserAction?.(this.normalizeBrowserAction(event));
+        break;
+
       case 'content':
         // 处理streaming内容 - 这是关键的修复！
         if (event.metadata?.content || customData.content) {
@@ -526,6 +560,73 @@ export class ChatService {
         log.debug('Custom event', { customType, customData });
         break;
     }
+  }
+
+  private isBrowserControlEvent(event: any): boolean {
+    const data = event?.metadata?.custom_data || event?.metadata || event?.data || {};
+    const haystack = [
+      event?.tool_name,
+      event?.agent_name,
+      event?.type,
+      event?.metadata?.custom_type,
+      data?.tool_name,
+      data?.agent_name,
+      data?.type,
+    ].filter(Boolean).join(' ');
+
+    return /browser|computer[_ -]?use|screenshot|viewport/i.test(haystack);
+  }
+
+  private normalizeBrowserScreenshot(event: any): any {
+    const data = event?.metadata?.custom_data || event?.metadata || event?.data || {};
+    return {
+      ...data,
+      screenshotUrl:
+        event?.screenshotUrl ||
+        event?.screenshot_url ||
+        event?.screenshot ||
+        event?.image_url ||
+        event?.content ||
+        data?.screenshotUrl ||
+        data?.screenshot_url ||
+        data?.screenshot ||
+        data?.image_url,
+      currentUrl: event?.currentUrl || event?.current_url || event?.url || data?.currentUrl || data?.current_url || data?.url,
+      tabs: event?.tabs || data?.tabs,
+      activeTabId: event?.activeTabId || event?.active_tab_id || data?.activeTabId || data?.active_tab_id,
+    };
+  }
+
+  private normalizeBrowserAction(event: any): any {
+    const data = event?.metadata?.custom_data || event?.metadata || event?.data || {};
+    const rawType =
+      event?.action_type ||
+      event?.actionType ||
+      event?.action ||
+      data?.action_type ||
+      data?.actionType ||
+      data?.action ||
+      data?.type;
+    const description =
+      event?.description ||
+      event?.message ||
+      data?.description ||
+      data?.message ||
+      data?.target ||
+      event?.tool_name ||
+      'Browser action requires approval';
+
+    return {
+      ...data,
+      id: event?.id || event?.tool_call_id || data?.id || data?.tool_call_id,
+      type: rawType,
+      status: event?.status || data?.status || 'pending',
+      description,
+      target: event?.target || event?.url || data?.target || data?.url,
+      x: event?.x ?? data?.x,
+      y: event?.y ?? data?.y,
+      durationMs: event?.durationMs || event?.duration_ms || data?.durationMs || data?.duration_ms,
+    };
   }
   
   /**

--- a/src/components/ui/chat/BrowserPanel.tsx
+++ b/src/components/ui/chat/BrowserPanel.tsx
@@ -7,18 +7,17 @@
  * @module
  */
 
-import React, { useState } from 'react';
-// Placeholder until @isa/ui-web dist is rebuilt (#293, #294)
-const BrowserViewport: React.FC<any> = ({ isConnected }) => (
-  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: '#1e1e2e', color: '#6b7280', fontSize: 14, borderRadius: 8 }}>
-    {isConnected ? 'Waiting for screenshot...' : 'Browser Viewport — rebuild @isa/ui-web to activate'}
-  </div>
-);
-const ActionLogPanel: React.FC<any> = ({ actions = [] }) => (
-  <div style={{ padding: 12, color: '#6b7280', fontSize: 13, border: '1px solid #e5e7eb', borderRadius: 8, height: '100%' }}>
-    Action Log — {actions.length} actions
-  </div>
-);
+import React, { useEffect, useState } from 'react';
+import {
+  ActionLogPanel as SDKActionLogPanel,
+  BrowserViewport as SDKBrowserViewport,
+  type BrowserAction,
+  type BrowserTab,
+  type PendingAction,
+} from '@isa/ui-web';
+
+const ActionLogPanel = SDKActionLogPanel as React.ComponentType<any>;
+const BrowserViewport = SDKBrowserViewport as React.ComponentType<any>;
 
 export interface BrowserPanelProps {
   /** Current screenshot */
@@ -30,15 +29,15 @@ export interface BrowserPanelProps {
   /** Current URL */
   currentUrl?: string;
   /** Open tabs */
-  tabs?: Array<{ id: string; title: string; url: string; favicon?: string }>;
+  tabs?: BrowserTab[];
   /** Active tab */
   activeTabId?: string;
   /** Action overlay */
-  actionOverlay?: { type: string; x?: number; y?: number; description: string };
+  actionOverlay?: PendingAction;
   /** Action history */
-  actions?: Array<any>;
+  actions?: BrowserAction[];
   /** Pending action */
-  pendingAction?: any;
+  pendingAction?: BrowserAction | null;
   /** Auto-approve enabled */
   autoApproveEnabled?: boolean;
   /** Callbacks */
@@ -70,6 +69,25 @@ export const BrowserPanel: React.FC<BrowserPanelProps> = ({
   className = '',
 }) => {
   const [viewportHeight, setViewportHeight] = useState(65); // % of panel
+
+  useEffect(() => {
+    if (!pendingAction) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onApprove?.(pendingAction.id);
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onReject?.(pendingAction.id, 'Rejected from keyboard');
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onApprove, onReject, pendingAction]);
 
   return (
     <div
@@ -125,7 +143,7 @@ export const BrowserPanel: React.FC<BrowserPanelProps> = ({
       <div style={{ flex: 1, minHeight: 0 }}>
         <ActionLogPanel
           actions={actions}
-          pendingAction={pendingAction}
+          pendingAction={pendingAction || undefined}
           onApprove={onApprove}
           onReject={onReject}
           autoApproveEnabled={autoApproveEnabled}

--- a/src/components/ui/chat/ChatLayout.tsx
+++ b/src/components/ui/chat/ChatLayout.tsx
@@ -40,6 +40,7 @@ import { ChatContentLayout } from './ChatContentLayout';
 import { InputAreaLayout } from './InputAreaLayout';
 import { SmartWidgetSelector } from '../widgets/SmartWidgetSelector';
 import { THEME_COLORS } from '../../../constants/theme';
+import type { AppMode } from './ModeSwitcher';
 
 // Pure interface - no dependency on stores
 export interface ChatMessage {
@@ -81,6 +82,10 @@ export interface ChatLayoutProps {
   sidebarMode?: 'exclusive' | 'inclusive';
   
   inputSuggestionsContent?: React.ReactNode;
+  modeSwitcherContent?: React.ReactNode;
+  appMode?: AppMode;
+  modePanelContent?: React.ReactNode;
+  modePanelLabel?: string;
   className?: string;
   fullscreen?: boolean;
   onFullscreenToggle?: (fullscreen: boolean) => void;
@@ -161,6 +166,10 @@ export const ChatLayout = memo<ChatLayoutProps>(({
   sidebarMode = 'exclusive',
   
   inputSuggestionsContent,
+  modeSwitcherContent,
+  appMode = 'chat',
+  modePanelContent,
+  modePanelLabel,
   conversationProps = {},
   inputProps = {},
   className = '',
@@ -201,6 +210,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
   onSidebarOpenChange
 }) => {
   const [isFullscreen, setIsFullscreen] = useState(fullscreen);
+  const [modePanelSplit, setModePanelSplit] = useState(40);
   
   // Left sidebar is now handled by ResponsiveSidebar (persistent on desktop, drawer on mobile)
   // so it is removed from the CSS grid. The grid only contains chat + optional right areas.
@@ -209,6 +219,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
   // Determine if the sidebar is open. If sidebarOpen is not provided, fall back to showSidebar legacy prop.
   const isSidebarOpen = sidebarOpen !== undefined ? sidebarOpen : (showSidebar ?? true);
   const handleSidebarOpenChange = onSidebarOpenChange ?? (() => {});
+  const showModePanel = appMode !== 'chat' && Boolean(modePanelContent) && !showRightSidebar;
 
   // Optimized CSS Grid layout configuration (left sidebar removed -- see ResponsiveSidebar below)
   const gridConfig = useMemo(() => {
@@ -217,6 +228,14 @@ export const ChatLayout = memo<ChatLayoutProps>(({
       return {
         templateAreas: '"chat widget"',
         templateColumns: '1fr 1fr',
+        showRightPanel: false,
+      };
+    }
+
+    if (showModePanel) {
+      return {
+        templateAreas: '"chat mode-resizer mode-panel"',
+        templateColumns: `${modePanelSplit}% 6px minmax(0, 1fr)`,
         showRightPanel: false,
       };
     }
@@ -234,7 +253,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
       templateColumns: columns.join(' '),
       showRightPanel: showRightPanel,
     };
-  }, [showRightPanel, showRightSidebar]);
+  }, [modePanelSplit, showModePanel, showRightPanel, showRightSidebar]);
 
   // Right sidebar mode determines overlay vs inline
   const isRightSidebarFullscreen = rightSidebarMode === 'fullscreen';
@@ -249,11 +268,31 @@ export const ChatLayout = memo<ChatLayoutProps>(({
       onFullscreenToggle(newValue);
     }
   }, [isFullscreen, onFullscreenToggle]);
+
+  const startModePanelResize = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const grid = event.currentTarget.parentElement;
+    if (!grid) return;
+
+    const rect = grid.getBoundingClientRect();
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const next = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+      setModePanelSplit(Math.min(Math.max(next, 30), 55));
+    };
+
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, []);
   
   // Layout classes
   const layoutClass = useMemo(() => 
-    `isa-chat-layout ${className} ${isFullscreen ? 'isa-fullscreen' : ''}`,
-    [className, isFullscreen]
+    `isa-chat-layout flex flex-col h-full ${className} ${isFullscreen ? 'isa-fullscreen' : ''} isa-mode-${appMode}`,
+    [appMode, className, isFullscreen]
   );
   
   // Responsive grid styles (removed invalid inline media queries)
@@ -298,7 +337,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
 
   return (
     <div 
-      className={`flex flex-col h-full ${className}`}
+      className={layoutClass}
       style={{
         width: '100%',
         maxWidth: '100%',
@@ -329,7 +368,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
         )}
 
         {/* CSS Grid for chat + optional right panels */}
-        <div style={gridStyles} className="flex-1 overflow-hidden relative z-10 min-w-0">
+        <div style={gridStyles} className="isa-chat-grid flex-1 overflow-hidden relative z-10 min-w-0">
           {/* Center Chat Area */}
           <div
             className="flex flex-col overflow-hidden min-w-0"
@@ -351,6 +390,11 @@ export const ChatLayout = memo<ChatLayoutProps>(({
 
             {/* Input Area */}
             <div className="flex-shrink-0" style={{ borderTop: '1px solid var(--glass-border)' }}>
+              {modeSwitcherContent && (
+                <div className="flex justify-center px-4 pt-3 pb-2">
+                  {modeSwitcherContent}
+                </div>
+              )}
               <InputAreaLayout
                 onSend={onSendMessage}
                 onSendMultimodal={onSendMultimodal}
@@ -368,6 +412,40 @@ export const ChatLayout = memo<ChatLayoutProps>(({
               style={{ borderLeft: '1px solid var(--glass-border)', gridArea: 'widget' }}
             >
               {rightSidebarContent}
+            </div>
+          )}
+
+          {showModePanel && (
+            <div
+              className="isa-mode-resizer"
+              style={{
+                gridArea: 'mode-resizer',
+                cursor: 'col-resize',
+                background: 'var(--glass-border)',
+                opacity: 0.75,
+                borderRadius: '999px',
+                width: '2px',
+                justifySelf: 'center',
+                alignSelf: 'stretch',
+              }}
+              aria-hidden="true"
+              onMouseDown={startModePanelResize}
+            />
+          )}
+
+          {showModePanel && modePanelContent && (
+            <div
+              className="isa-mode-panel glass-tertiary overflow-hidden"
+              style={{
+                borderLeft: '1px solid var(--glass-border)',
+                gridArea: 'mode-panel',
+                minWidth: 0,
+                maxWidth: '100%',
+              }}
+              role="complementary"
+              aria-label={modePanelLabel || `${appMode} panel`}
+            >
+              {modePanelContent}
             </div>
           )}
 
@@ -404,7 +482,7 @@ export const ChatLayout = memo<ChatLayoutProps>(({
           )}
 
           {/* Ultra-Transparent Floating Toggle */}
-          {!showRightSidebar && (
+          {!showRightSidebar && !showModePanel && (
             <div className="fixed right-3 top-1/2 transform -translate-y-1/2 z-30">
               <button
                 onClick={onToggleRightPanel}

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -39,7 +39,11 @@ import React, { useMemo, useCallback, useState, useEffect, useRef } from 'react'
 import { ChatLayout, ChatLayoutProps } from '../components/ui/chat/ChatLayout';
 import { RightPanel } from '../components/ui/chat/RightPanel';
 import { RightSidebarLayout } from '../components/ui/chat/RightSidebarLayout';
+import { BrowserPanel } from '../components/ui/chat/BrowserPanel';
+import { DesignPanel } from '../components/ui/chat/DesignPanel';
+import { ModeSwitcher, type AppMode } from '../components/ui/chat/ModeSwitcher';
 import { AppId } from '../types/appTypes';
+import { useBrowserControl } from '@isa/hooks';
 import { useChat } from '../hooks/useChat';
 import { useChatStore } from '../stores/useChatStore';
 import { useAuth } from '../hooks/useAuth';
@@ -85,6 +89,11 @@ import { createMessageHandlers } from './handlers/messageHandlers';
 // 🆕 Autonomous background message listener (#126)
 import { mateAutonomousListener } from '../api/mateAutonomousListener';
 
+export function shouldActivateBrowseMode(content: string): boolean {
+  return /\b(browser|browse|website|web page|go to|navigate|open url|open website|click)\b/i.test(content)
+    || /(网页|浏览器|打开网站)/.test(content);
+}
+
 interface ChatModuleProps extends Omit<ChatLayoutProps, 'messages' | 'isLoading' | 'isTyping' | 'onSendMessage' | 'onSendMultimodal'> {
   // All ChatLayout props except the data and callback props that we'll provide from business logic
   /** Whether the session sidebar is open (injected by AppLayout) */
@@ -124,6 +133,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // Widget system state (managed internally)
   const [currentWidgetMode, setCurrentWidgetMode] = useState<'half' | 'full' | null>(null);
+  const [appMode, setAppMode] = useState<AppMode>('chat');
 
   // 🆕 HIL (Human-in-the-Loop) 状态管理
   const [hilStatus, setHilStatus] = useState<HILExecutionStatusData | null>(null);
@@ -243,6 +253,104 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     setIsProcessingHilAction,
   }), [currentSession?.id]);
 
+  const browserControl = useBrowserControl();
+  const {
+    currentScreenshot,
+    currentUrl,
+    tabs,
+    activeTabId,
+    actions: browserActions,
+    pendingAction,
+    autoApprove,
+    isConnected,
+    startSession,
+    approveAction,
+    rejectAction,
+    clickAt,
+    switchTab,
+    updateScreenshot,
+    addAction,
+    setAutoApprove,
+  } = browserControl;
+
+  const handleBrowserScreenshot = useCallback((event: any) => {
+    const screenshot =
+      event?.screenshotUrl ||
+      event?.screenshot_url ||
+      event?.screenshot ||
+      event?.image_url ||
+      event?.content ||
+      event?.data?.screenshot;
+
+    if (!screenshot) return;
+
+    const url = event?.currentUrl || event?.current_url || event?.url || event?.data?.url;
+    const tabs = event?.tabs || event?.data?.tabs;
+    updateScreenshot(screenshot, url, Array.isArray(tabs) ? tabs : undefined);
+
+    const activeTabId = event?.activeTabId || event?.active_tab_id || event?.data?.activeTabId;
+    if (activeTabId) {
+      switchTab(activeTabId);
+    }
+
+    setAppMode('browse');
+  }, [switchTab, updateScreenshot]);
+
+  const handleBrowserAction = useCallback((event: any) => {
+    const rawType = String(event?.action_type || event?.actionType || event?.action || event?.type || 'wait');
+    const actionType = ['navigate', 'click', 'type', 'scroll', 'extract', 'screenshot', 'wait'].includes(rawType)
+      ? rawType
+      : 'wait';
+    const status = ['pending', 'approved', 'rejected', 'completed', 'failed'].includes(event?.status)
+      ? event.status
+      : 'pending';
+    const backendActionId = event?.id || event?.tool_call_id || event?.toolCallId;
+
+    addAction({
+      ...(backendActionId && { backendActionId }),
+      type: actionType as any,
+      description: event?.description || event?.message || event?.target || `Browser ${actionType}`,
+      status,
+      target: event?.target || event?.url,
+      durationMs: event?.durationMs || event?.duration_ms,
+      ...(event?.x != null && { x: event.x }),
+      ...(event?.y != null && { y: event.y }),
+    } as any);
+
+    if (autoApprove && status === 'pending') {
+      void hilHandlers.handleHILApprove(backendActionId || `browser-${Date.now()}`);
+    }
+
+    if (status === 'pending') {
+      setAppMode('browse');
+    }
+  }, [addAction, autoApprove, hilHandlers]);
+
+  const handleBrowserApprove = useCallback((actionId: string) => {
+    const action = browserActions.find((item) => item.id === actionId) as any;
+    approveAction(actionId);
+    void hilHandlers.handleHILApprove(action?.backendActionId || actionId);
+  }, [approveAction, browserActions, hilHandlers]);
+
+  const handleBrowserReject = useCallback((actionId: string, reason?: string) => {
+    const action = browserActions.find((item) => item.id === actionId) as any;
+    rejectAction(actionId, reason);
+    void hilHandlers.handleHILReject(action?.backendActionId || actionId, reason);
+  }, [browserActions, hilHandlers, rejectAction]);
+
+  const browserActionOverlay = useMemo(() => {
+    const action = pendingAction as any;
+    if (!action) return undefined;
+
+    const overlayType = ['navigate', 'click', 'type', 'scroll'].includes(action.type) ? action.type : 'click';
+    return {
+      type: overlayType,
+      description: action.description,
+      ...(action.x != null && { x: action.x }),
+      ...(action.y != null && { y: action.y }),
+    };
+  }, [pendingAction]);
+
   // Widget handlers
   const widgetHandlers = useMemo(() => createWidgetHandlers({
     authUserSub: authUser?.sub,
@@ -270,7 +378,65 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     setCurrentApp,
     setShowRightSidebar,
     setHuntSearchResults,
-  }), [authUser?.sub, currentSession?.id, sessionActions, userModule, getChatService, setCurrentApp, setShowRightSidebar, setHuntSearchResults]);
+    onBrowserScreenshot: handleBrowserScreenshot,
+    onBrowserAction: handleBrowserAction,
+  }), [authUser?.sub, currentSession?.id, sessionActions, userModule, getChatService, setCurrentApp, setShowRightSidebar, setHuntSearchResults, handleBrowserScreenshot, handleBrowserAction]);
+
+  const handleSendMessageWithMode = useCallback(async (content: string, metadata?: Record<string, any>) => {
+    if (shouldActivateBrowseMode(content)) {
+      setAppMode('browse');
+      startSession();
+    }
+
+    await messageHandlers.handleSendMessage(content, metadata);
+  }, [messageHandlers, startSession]);
+
+  const modePanelContent = useMemo(() => {
+    if (appMode === 'browse') {
+      return (
+        <BrowserPanel
+          screenshotUrl={currentScreenshot || undefined}
+          isConnected={isConnected || Boolean(currentScreenshot)}
+          isLive={chatInterface.hasStreamingMessage}
+          currentUrl={currentUrl}
+          tabs={tabs}
+          activeTabId={activeTabId || undefined}
+          actionOverlay={browserActionOverlay as any}
+          actions={browserActions as any}
+          pendingAction={pendingAction as any}
+          autoApproveEnabled={autoApprove}
+          onTabSwitch={switchTab}
+          onClickAt={clickAt}
+          onApprove={handleBrowserApprove}
+          onReject={handleBrowserReject}
+          onAutoApproveToggle={setAutoApprove}
+        />
+      );
+    }
+
+    if (appMode === 'design') {
+      return <DesignPanel />;
+    }
+
+    return null;
+  }, [
+    activeTabId,
+    appMode,
+    autoApprove,
+    browserActionOverlay,
+    browserActions,
+    chatInterface.hasStreamingMessage,
+    clickAt,
+    currentScreenshot,
+    currentUrl,
+    handleBrowserApprove,
+    handleBrowserReject,
+    isConnected,
+    pendingAction,
+    setAutoApprove,
+    switchTab,
+    tabs,
+  ]);
 
   // 🆕 初始化Plugin模式监听
   useEffect(() => {
@@ -508,7 +674,7 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
         isLoading={chatInterface.isLoading}
         isTyping={chatInterface.isTyping}
         currentTasks={currentTasks}
-        onSendMessage={messageHandlers.handleSendMessage}
+        onSendMessage={handleSendMessageWithMode}
         onSendMultimodal={messageHandlers.handleSendMultimodal}
         onMessageClick={messageHandlers.handleMessageClick}
         onNewChat={messageHandlers.handleNewChat}
@@ -527,6 +693,17 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
         // Responsive layout: props passed only if ChatLayout supports them
         showHeader={!isMobile} // Hide ChatLayout header on mobile (AppLayout controls desktop header)
+        appMode={appMode}
+        modeSwitcherContent={
+          <ModeSwitcher
+            activeMode={appMode}
+            onModeChange={setAppMode}
+            designAvailable
+            browseAvailable
+          />
+        }
+        modePanelContent={modePanelContent}
+        modePanelLabel={appMode === 'browse' ? 'Browser control panel' : 'Design panel'}
 
         // Right Panel (会话信息管理)
         showRightPanel={showRightPanel}

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -41,6 +41,8 @@ export interface MessageHandlerDeps {
   setCurrentApp: (appId: AppId | null) => void;
   setShowRightSidebar: (show: boolean) => void;
   setHuntSearchResults: (results: any[]) => void;
+  onBrowserScreenshot?: (event: any) => void;
+  onBrowserAction?: (event: any) => void;
 }
 
 export function createMessageHandlers(deps: MessageHandlerDeps) {
@@ -54,6 +56,8 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     setCurrentApp,
     setShowRightSidebar,
     setHuntSearchResults,
+    onBrowserScreenshot,
+    onBrowserAction,
   } = deps;
 
   // Commit message timing to the performance store and log in dev mode (#277).
@@ -303,6 +307,8 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
               useMessageStore.getState().completeDelegation(active.toolCallId, result, error);
             }
           },
+          onBrowserScreenshot,
+          onBrowserAction,
           onError: (error: Error) => {
             logger.error(LogCategory.CHAT_FLOW, 'Message sending failed', { error: error.message });
             useStreamingStore.getState().setSendStartedAt(null);
@@ -407,6 +413,8 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
           commitMessageTiming(timing);
           consumeCreditsAfterSend('multimodal_send');
         },
+        onBrowserScreenshot,
+        onBrowserAction,
         onError: (error: Error) => {
           logger.error(LogCategory.CHAT_FLOW, 'Multimodal message sending failed', { error: error.message });
           useStreamingStore.getState().setSendStartedAt(null);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -979,6 +979,31 @@ div.input-area-container .suggestions-panel {
   .isa-chat-layout .flex {
     gap: 8px !important;
   }
+
+  .isa-chat-layout.isa-mode-browse .isa-chat-grid,
+  .isa-chat-layout.isa-mode-design .isa-chat-grid {
+    display: block !important;
+  }
+
+  .isa-chat-layout .isa-mode-resizer {
+    display: none !important;
+  }
+
+  .isa-chat-layout .isa-mode-panel {
+    position: fixed !important;
+    left: max(10px, var(--sal, 0px)) !important;
+    right: max(10px, var(--sar, 0px)) !important;
+    bottom: max(10px, var(--sab, 0px)) !important;
+    height: min(58vh, 520px) !important;
+    z-index: 45 !important;
+    border-radius: 20px !important;
+    border: 1px solid var(--glass-border) !important;
+    background: var(--glass-primary) !important;
+    backdrop-filter: blur(22px) saturate(120%) !important;
+    -webkit-backdrop-filter: blur(22px) saturate(120%) !important;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32) !important;
+    overflow: hidden !important;
+  }
   
   /* Hide sidebars on mobile by default - show them as overlays */
   .isa-chat-sidebar {


### PR DESCRIPTION
## Summary
- Add Browse/Design mode switching to the chat layout with a resizable browser-control panel.
- Wire SDK BrowserViewport/ActionLogPanel through @isa/hooks useBrowserControl, including approve/reject keyboard shortcuts.
- Normalize browser/computer-use stream events from AGUI and Mate into screenshot/action callbacks.
- Preserve backend HIL action IDs while keeping local panel action status updates.

## Tests
- npm test -- src/api/__tests__/chatService.test.ts src/api/adapters/__tests__/MateEventAdapter.test.ts -t "browser|ComputerUseAgent|custom browser" (8 passed)
- ./node_modules/.bin/tsc --noEmit --pretty false (fails on existing desktop/SDK/repo type debt; filtered diagnostics for #286-touched files returned no matches)

Fixes #286