### PR TITLE
Frontend cost badge and audit drawer

### DIFF
--- a/src/api/ObservabilityService.ts
+++ b/src/api/ObservabilityService.ts
@@ -2,11 +2,9 @@
  * ObservabilityService — client for the isA_Mate /v1/observability/*
  * capability router (xenoISA/isA_Mate#406 / #426). Powers the cost
  * badge + audit drawer surfaces.
- *
- * TODO: Replace with `import { ObservabilityClient } from '@isa/transport'`
- * once xenoISA/isA_App_SDK#311 publishes.
  */
 
+import { HttpClient, ObservabilityClient } from '@isa/transport';
 import { logger, LogCategory } from '../utils/logger';
 import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
 import { authTokenStore } from '../stores/authTokenStore';
@@ -18,6 +16,15 @@ import type {
 } from './types/observability';
 
 export class ObservabilityService {
+  private createClient(operation?: string): ObservabilityClient {
+    return new ObservabilityClient(
+      new HttpClient({
+        baseURL: GATEWAY_ENDPOINTS.MATE.BASE,
+        headers: this.getHeaders(operation),
+      }),
+    );
+  }
+
   private getHeaders(operation?: string): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     const token = authTokenStore.getToken();
@@ -33,41 +40,12 @@ export class ObservabilityService {
   }
 
   async getMetrics(filter: MetricsFilter = {}): Promise<ExecutionMetrics> {
-    const qs = new URLSearchParams();
-    if (filter.since) qs.set('since', toISO(filter.since));
-    if (filter.until) qs.set('until', toISO(filter.until));
-    if (filter.agent_id) qs.set('agent_id', filter.agent_id);
-    if (filter.session_id) qs.set('session_id', filter.session_id);
-    const path = qs.toString()
-      ? `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS}?${qs.toString()}`
-      : GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.METRICS;
-    const resp = await fetch(path, {
-      method: 'GET',
-      headers: this.getHeaders('getMetrics'),
-    });
-    if (!resp.ok) throw new Error(`getMetrics failed: ${resp.status} ${resp.statusText}`);
-    return resp.json();
+    return this.createClient('getMetrics').getMetrics(filter);
   }
 
   async getAudit(filter: AuditFilter = {}): Promise<AuditListResponse> {
-    const qs = new URLSearchParams();
-    if (filter.action) qs.set('action', filter.action);
-    if (filter.since) qs.set('since', toISO(filter.since));
-    if (filter.until) qs.set('until', toISO(filter.until));
-    if (filter.session_id) qs.set('session_id', filter.session_id);
-    qs.set('limit', String(filter.limit ?? 100));
-    if (filter.cursor) qs.set('cursor', filter.cursor);
-    const resp = await fetch(
-      `${GATEWAY_ENDPOINTS.MATE.OBSERVABILITY.AUDIT}?${qs.toString()}`,
-      { method: 'GET', headers: this.getHeaders('getAudit') },
-    );
-    if (!resp.ok) throw new Error(`getAudit failed: ${resp.status} ${resp.statusText}`);
-    return resp.json();
+    return this.createClient('getAudit').getAudit(filter);
   }
-}
-
-function toISO(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : value;
 }
 
 export const observabilityService = new ObservabilityService();

--- a/src/api/__tests__/ObservabilityService.test.ts
+++ b/src/api/__tests__/ObservabilityService.test.ts
@@ -4,6 +4,7 @@ import { ObservabilityService } from '../ObservabilityService';
 vi.mock('../../config/gatewayConfig', () => ({
   GATEWAY_ENDPOINTS: {
     MATE: {
+      BASE: 'http://localhost:18789',
       OBSERVABILITY: {
         METRICS: 'http://localhost:18789/v1/observability/metrics',
         AUDIT: 'http://localhost:18789/v1/observability/audit',

--- a/src/api/types/observability.ts
+++ b/src/api/types/observability.ts
@@ -1,9 +1,6 @@
 /**
  * Types for the isA_Mate /v1/observability/* capability router
  * (xenoISA/isA_Mate#406 / #426).
- *
- * TODO: Replace with `import { ... } from '@isa/transport'` once
- * @isa/transport publishes ObservabilityClient.
  */
 
 export interface TokenUsage {

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -117,6 +117,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ className = '', children }
           availableApps={appData.availableApps}
           onMenuClick={toggleSidebar}
           sidebarOpen={sidebarOpen}
+          isAuthenticated={isAuthenticated}
         />
       </div>
 

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -22,6 +22,8 @@ interface AppHeaderProps {
   onMenuClick?: () => void;
   /** Whether sidebar drawer is currently open */
   sidebarOpen?: boolean;
+  /** Whether the user is authenticated; cost/audit calls require auth */
+  isAuthenticated?: boolean;
   // TaskStatusIndicator props
   streamingStatus?: string;
   lastSSEEvent?: any;
@@ -54,6 +56,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   onTaskControl,
   onMenuClick,
   sidebarOpen,
+  isAuthenticated = false,
 }) => {
   const currentSessionId = useCurrentSessionId();
   const [auditDrawerOpen, setAuditDrawerOpen] = useState(false);
@@ -130,10 +133,12 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 
       <div className="flex-1" />
 
-      <CostBadge
-        sessionId={currentSessionId}
-        onClick={() => setAuditDrawerOpen(true)}
-      />
+      {isAuthenticated && (
+        <CostBadge
+          sessionId={currentSessionId}
+          onClick={() => setAuditDrawerOpen(true)}
+        />
+      )}
 
       {/* Task status — always visible */}
       <TaskStatusIndicator
@@ -175,7 +180,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       )}
     </header>
     <AuditDrawer
-      open={auditDrawerOpen}
+      open={auditDrawerOpen && isAuthenticated}
       sessionId={currentSessionId}
       onClose={() => setAuditDrawerOpen(false)}
     />

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -3,9 +3,12 @@ import { CalendarToolbar } from './CalendarToolbar';
 import { TaskToolbar } from './TaskToolbar';
 import { NotificationToolbar } from './NotificationToolbar';
 import { TaskStatusIndicator } from './header/TaskStatusIndicator';
+import { CostBadge } from './header/CostBadge';
+import { AuditDrawer } from './drawers/AuditDrawer';
 import { ThemeToggle } from './theme/ThemeToggle';
 import { MatePresenceIndicator } from './chat/MatePresenceIndicator';
 import { docsLinks } from '../../config/surfaceConfig';
+import { useCurrentSessionId } from '../../stores/useSessionStore';
 
 interface AppHeaderProps {
   currentApp: string | null;
@@ -52,6 +55,9 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   onMenuClick,
   sidebarOpen,
 }) => {
+  const currentSessionId = useCurrentSessionId();
+  const [auditDrawerOpen, setAuditDrawerOpen] = useState(false);
+
   // Logo element — clean, no gradient
   const logo = (
     <div className="size-9 rounded-lg flex items-center justify-center bg-white/10 border border-white/10">
@@ -94,6 +100,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   }, [overflowOpen]);
 
   return (
+    <>
     <header className="flex items-center gap-3 px-3 md:px-4 h-full bg-transparent">
       {/* Hamburger on mobile */}
       {isMobile && onMenuClick && (
@@ -122,6 +129,11 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       <MatePresenceIndicator className="ml-1" />
 
       <div className="flex-1" />
+
+      <CostBadge
+        sessionId={currentSessionId}
+        onClick={() => setAuditDrawerOpen(true)}
+      />
 
       {/* Task status — always visible */}
       <TaskStatusIndicator
@@ -162,5 +174,11 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
         </>
       )}
     </header>
+    <AuditDrawer
+      open={auditDrawerOpen}
+      sessionId={currentSessionId}
+      onClose={() => setAuditDrawerOpen(false)}
+    />
+    </>
   );
 };

--- a/src/components/ui/drawers/AuditDrawer.tsx
+++ b/src/components/ui/drawers/AuditDrawer.tsx
@@ -1,0 +1,251 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { observabilityService } from '../../../api/ObservabilityService';
+import type { ObservabilityAuditEntry } from '../../../api/types/observability';
+import {
+  OBSERVABILITY_REFRESH_EVENT,
+  type ObservabilityRefreshDetail,
+} from '../../../utils/observabilityEvents';
+import { formatUsd } from '../header/CostBadge';
+
+export type AuditActionFilter = 'all' | 'hil' | 'tool' | 'cost' | 'trigger';
+
+export const AUDIT_FILTERS: Array<{ value: AuditActionFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'hil', label: 'HIL' },
+  { value: 'tool', label: 'Tools' },
+  { value: 'cost', label: 'Cost' },
+  { value: 'trigger', label: 'Triggers' },
+];
+
+export interface AuditDrawerProps {
+  open: boolean;
+  sessionId?: string;
+  onClose: () => void;
+}
+
+export function getAuditCategory(entry: ObservabilityAuditEntry): AuditActionFilter {
+  const metadata = entry.metadata || {};
+  const haystack = [
+    entry.action,
+    metadata.type,
+    metadata.tool_name,
+    metadata.trigger_id,
+    metadata.source,
+  ].filter(Boolean).join(' ').toLowerCase();
+
+  if (/hil|human|interrupt|approval|reject/.test(haystack)) return 'hil';
+  if (/tool|browser|computer|mcp/.test(haystack)) return 'tool';
+  if (/cost|billing|credit|model|llm|token/.test(haystack) || (entry.cost_usd ?? 0) > 0) return 'cost';
+  if (/trigger|proactive|scheduler|schedule|autonomous/.test(haystack)) return 'trigger';
+  return 'all';
+}
+
+export function filterAuditEntries(
+  entries: ObservabilityAuditEntry[],
+  filter: AuditActionFilter,
+): ObservabilityAuditEntry[] {
+  if (filter === 'all') return entries;
+  return entries.filter((entry) => getAuditCategory(entry) === filter);
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function summarizeMetadata(entry: ObservabilityAuditEntry): string {
+  const metadata = entry.metadata || {};
+  const summary =
+    metadata.tool_name ||
+    metadata.model ||
+    metadata.trigger_id ||
+    metadata.interrupt_id ||
+    metadata.reason;
+
+  return typeof summary === 'string' ? summary : '';
+}
+
+export const AuditDrawer: React.FC<AuditDrawerProps> = ({
+  open,
+  sessionId,
+  onClose,
+}) => {
+  const [entries, setEntries] = useState<ObservabilityAuditEntry[]>([]);
+  const [filter, setFilter] = useState<AuditActionFilter>('all');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAudit = useCallback(async () => {
+    if (!open || !sessionId) return;
+
+    setLoading(true);
+    try {
+      const response = await observabilityService.getAudit({
+        session_id: sessionId,
+        limit: 100,
+      });
+      setEntries(response.entries);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Audit unavailable');
+    } finally {
+      setLoading(false);
+    }
+  }, [open, sessionId]);
+
+  useEffect(() => {
+    if (!open) return;
+    void fetchAudit();
+  }, [fetchAudit, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<ObservabilityRefreshDetail>).detail;
+      if (detail?.sessionId && detail.sessionId !== sessionId) return;
+      void fetchAudit();
+    };
+
+    window.addEventListener(OBSERVABILITY_REFRESH_EVENT, onRefresh);
+    return () => window.removeEventListener(OBSERVABILITY_REFRESH_EVENT, onRefresh);
+  }, [fetchAudit, open, sessionId]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose, open]);
+
+  const visibleEntries = useMemo(
+    () => filterAuditEntries(entries, filter),
+    [entries, filter],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        aria-label="Close audit drawer overlay"
+        className="absolute inset-0 bg-black/45"
+        onClick={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Session audit drawer"
+        className="absolute inset-y-0 right-0 flex w-full flex-col overflow-hidden border-l border-white/10 bg-slate-950/95 text-white shadow-2xl backdrop-blur-xl sm:max-w-md"
+      >
+        <div className="border-b border-white/10 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.18em] text-emerald-200/60">Session audit</p>
+              <h2 className="mt-1 text-lg font-semibold">Recent actions</h2>
+              <p className="mt-1 text-xs text-white/45">{sessionId || 'No active session'}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex size-8 items-center justify-center rounded-lg text-white/60 hover:bg-white/10 hover:text-white"
+              aria-label="Close audit drawer"
+            >
+              x
+            </button>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {AUDIT_FILTERS.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                onClick={() => setFilter(item.value)}
+                className={[
+                  'rounded-full border px-3 py-1 text-xs transition-colors',
+                  filter === item.value
+                    ? 'border-emerald-300/70 bg-emerald-300/15 text-emerald-50'
+                    : 'border-white/10 bg-white/5 text-white/60 hover:bg-white/10',
+                ].join(' ')}
+              >
+                {item.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => void fetchAudit()}
+              className="ml-auto rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/60 hover:bg-white/10"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading && entries.length === 0 && (
+            <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+              Loading audit events...
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-3 rounded-xl border border-red-300/20 bg-red-400/10 p-3 text-sm text-red-100">
+              {error}
+            </div>
+          )}
+
+          {!loading && visibleEntries.length === 0 && (
+            <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+              No audit entries for this filter.
+            </div>
+          )}
+
+          <div className="space-y-3">
+            {visibleEntries.map((entry, index) => {
+              const metadataSummary = summarizeMetadata(entry);
+
+              return (
+                <article
+                  key={`${entry.timestamp}-${entry.action}-${index}`}
+                  className="rounded-2xl border border-white/10 bg-white/[0.04] p-3"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-white/70">
+                      {getAuditCategory(entry)}
+                    </span>
+                    <span className="text-xs text-white/40">{formatTimestamp(entry.timestamp)}</span>
+                  </div>
+                  <div className="mt-2 flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-medium text-white">{entry.action}</h3>
+                      {metadataSummary && (
+                        <p className="mt-1 truncate text-xs text-white/50">{metadataSummary}</p>
+                      )}
+                    </div>
+                    {entry.cost_usd != null && (
+                      <span className="shrink-0 text-xs font-semibold text-emerald-100">
+                        {formatUsd(entry.cost_usd)}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between text-xs text-white/40">
+                    <span>{entry.result}</span>
+                    <span>{entry.user_id}</span>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default AuditDrawer;

--- a/src/components/ui/drawers/__tests__/AuditDrawer.test.ts
+++ b/src/components/ui/drawers/__tests__/AuditDrawer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import {
+  filterAuditEntries,
+  getAuditCategory,
+  type AuditActionFilter,
+} from '../AuditDrawer';
+import type { ObservabilityAuditEntry } from '../../../../api/types/observability';
+
+function entry(action: string, metadata: Record<string, unknown> = {}, cost_usd: number | null = null): ObservabilityAuditEntry {
+  return {
+    timestamp: '2026-04-23T00:00:00.000Z',
+    action,
+    user_id: 'user-1',
+    result: 'success',
+    cost_usd,
+    session_id: 'session-1',
+    metadata,
+  };
+}
+
+describe('AuditDrawer helpers', () => {
+  test.each<Array<[string, ObservabilityAuditEntry, AuditActionFilter]>>([
+    ['approval', entry('hil_approval_required'), 'hil'],
+    ['tool', entry('tool_call_end', { tool_name: 'browser' }), 'tool'],
+    ['cost', entry('model_completed', {}, 0.002), 'cost'],
+    ['trigger', entry('proactive_trigger_run'), 'trigger'],
+  ])('categorizes %s entries', (_name, auditEntry, expected) => {
+    expect(getAuditCategory(auditEntry)).toBe(expected);
+  });
+
+  test('filters entries by category', () => {
+    const entries = [
+      entry('hil_interrupt_detected'),
+      entry('tool_call_end', { tool_name: 'search' }),
+      entry('billing_update', {}, 0.01),
+    ];
+
+    expect(filterAuditEntries(entries, 'all')).toHaveLength(3);
+    expect(filterAuditEntries(entries, 'hil')).toEqual([entries[0]]);
+    expect(filterAuditEntries(entries, 'tool')).toEqual([entries[1]]);
+    expect(filterAuditEntries(entries, 'cost')).toEqual([entries[2]]);
+  });
+});

--- a/src/components/ui/header/CostBadge.tsx
+++ b/src/components/ui/header/CostBadge.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { observabilityService } from '../../../api/ObservabilityService';
+import type { ExecutionMetrics } from '../../../api/types/observability';
+import {
+  OBSERVABILITY_REFRESH_EVENT,
+  type ObservabilityRefreshDetail,
+} from '../../../utils/observabilityEvents';
+
+export interface CostBadgeProps {
+  sessionId?: string;
+  onClick?: () => void;
+  className?: string;
+}
+
+export function totalTokens(metrics: ExecutionMetrics | null): number {
+  if (!metrics) return 0;
+  return (metrics.tokens_used?.input ?? 0) + (metrics.tokens_used?.output ?? 0);
+}
+
+export function formatUsd(value: number | null | undefined): string {
+  const amount = value ?? 0;
+  if (amount > 0 && amount < 0.01) return `$${amount.toFixed(4)}`;
+  return `$${amount.toFixed(2)}`;
+}
+
+export function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M tok`;
+  if (value >= 10_000) return `${Math.round(value / 1_000)}k tok`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k tok`;
+  return `${value} tok`;
+}
+
+export const CostBadge: React.FC<CostBadgeProps> = ({
+  sessionId,
+  onClick,
+  className = '',
+}) => {
+  const [metrics, setMetrics] = useState<ExecutionMetrics | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pulse, setPulse] = useState(false);
+  const pulseTimerRef = useRef<number | null>(null);
+
+  const fetchMetrics = useCallback(async () => {
+    if (!sessionId) {
+      setMetrics(null);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const next = await observabilityService.getMetrics({ session_id: sessionId });
+      setMetrics(next);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Metrics unavailable');
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void fetchMetrics();
+    const timer = window.setInterval(() => {
+      void fetchMetrics();
+    }, 5000);
+    return () => window.clearInterval(timer);
+  }, [fetchMetrics]);
+
+  useEffect(() => {
+    const onRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<ObservabilityRefreshDetail>).detail;
+      if (detail?.sessionId && detail.sessionId !== sessionId) return;
+
+      setPulse(true);
+      if (pulseTimerRef.current) window.clearTimeout(pulseTimerRef.current);
+      pulseTimerRef.current = window.setTimeout(() => setPulse(false), 450);
+      void fetchMetrics();
+    };
+
+    window.addEventListener(OBSERVABILITY_REFRESH_EVENT, onRefresh);
+    return () => {
+      window.removeEventListener(OBSERVABILITY_REFRESH_EVENT, onRefresh);
+      if (pulseTimerRef.current) window.clearTimeout(pulseTimerRef.current);
+    };
+  }, [fetchMetrics, sessionId]);
+
+  const tokens = useMemo(() => totalTokens(metrics), [metrics]);
+  const title = error
+    ? `Session cost unavailable: ${error}`
+    : 'Open session audit drawer';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!sessionId}
+      title={title}
+      aria-label="Open session cost and audit drawer"
+      className={[
+        'inline-flex h-8 items-center gap-2 rounded-lg border px-2.5 text-xs font-medium transition-all',
+        'border-emerald-300/25 bg-emerald-400/10 text-emerald-50 hover:bg-emerald-400/20',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/70',
+        pulse ? 'scale-[1.03] shadow-[0_0_24px_rgba(52,211,153,0.28)]' : '',
+        !sessionId ? 'cursor-not-allowed opacity-50' : '',
+        className,
+      ].join(' ')}
+    >
+      <span className="size-1.5 rounded-full bg-emerald-300 shadow-[0_0_10px_rgba(110,231,183,0.85)]" />
+      <span>{loading && !metrics ? 'Syncing' : formatUsd(metrics?.cost_usd)}</span>
+      <span className="hidden sm:inline text-emerald-100/70">
+        {formatTokenCount(tokens)}
+      </span>
+    </button>
+  );
+};
+
+export default CostBadge;

--- a/src/components/ui/header/__tests__/CostBadge.test.ts
+++ b/src/components/ui/header/__tests__/CostBadge.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+import { formatTokenCount, formatUsd, totalTokens } from '../CostBadge';
+
+describe('CostBadge helpers', () => {
+  test('formats USD with extra precision for sub-cent costs', () => {
+    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(0.0042)).toBe('$0.0042');
+    expect(formatUsd(1.25)).toBe('$1.25');
+  });
+
+  test('formats token counts compactly', () => {
+    expect(formatTokenCount(850)).toBe('850 tok');
+    expect(formatTokenCount(1250)).toBe('1.3k tok');
+    expect(formatTokenCount(12000)).toBe('12k tok');
+    expect(formatTokenCount(1_250_000)).toBe('1.3M tok');
+  });
+
+  test('totals input and output tokens', () => {
+    expect(totalTokens({
+      nodes_executed: 0,
+      tool_calls: 0,
+      model_calls: 0,
+      tokens_used: { input: 120, output: 80 },
+      cost_usd: 0.01,
+      window_start: null,
+      window_end: null,
+    })).toBe(200);
+  });
+});

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -17,6 +17,7 @@ import { AppId } from '../../types/appTypes';
 import { CreditConsumption } from '../../types/userTypes';
 import { isDelegationTool } from '../../constants/delegationTeams';
 import { MessageTimingTracker, formatTimingLog } from '../../utils/messageTiming';
+import { emitObservabilityRefresh } from '../../utils/observabilityEvents';
 
 const log = createLogger('ChatModule:Message');
 
@@ -59,6 +60,10 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     onBrowserScreenshot,
     onBrowserAction,
   } = deps;
+
+  const refreshObservability = (reason: string) => {
+    emitObservabilityRefresh({ sessionId: currentSessionId, reason });
+  };
 
   // Commit message timing to the performance store and log in dev mode (#277).
   const commitMessageTiming = (tracker: MessageTimingTracker) => {
@@ -277,6 +282,7 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
             commitMessageTiming(timing);
             consumeCreditsAfterSend('message_send');
+            refreshObservability('stream_complete');
 
             // Artifact edit-to-version: if this was an artifact edit, create new version (#256)
             if (typeof window !== 'undefined' && (window as any).__pendingArtifactEdit) {
@@ -306,7 +312,10 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
             if (active) {
               useMessageStore.getState().completeDelegation(active.toolCallId, result, error);
             }
+            refreshObservability('tool_completed');
           },
+          onLLMCompleted: () => refreshObservability('llm_completed'),
+          onBillingUpdate: () => refreshObservability('billing_update'),
           onBrowserScreenshot,
           onBrowserAction,
           onError: (error: Error) => {
@@ -412,7 +421,11 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
           commitMessageTiming(timing);
           consumeCreditsAfterSend('multimodal_send');
+          refreshObservability('multimodal_stream_complete');
         },
+        onToolCompleted: () => refreshObservability('multimodal_tool_completed'),
+        onLLMCompleted: () => refreshObservability('multimodal_llm_completed'),
+        onBillingUpdate: () => refreshObservability('multimodal_billing_update'),
         onBrowserScreenshot,
         onBrowserAction,
         onError: (error: Error) => {

--- a/src/utils/observabilityEvents.ts
+++ b/src/utils/observabilityEvents.ts
@@ -1,0 +1,14 @@
+export const OBSERVABILITY_REFRESH_EVENT = 'isa:observability-refresh';
+
+export interface ObservabilityRefreshDetail {
+  sessionId?: string;
+  reason?: string;
+}
+
+export function emitObservabilityRefresh(detail: ObservabilityRefreshDetail = {}): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<ObservabilityRefreshDetail>(
+    OBSERVABILITY_REFRESH_EVENT,
+    { detail },
+  ));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       '@/types': path.resolve(__dirname, 'src/types'),
       '@/stores': path.resolve(__dirname, 'src/stores'),
       '@/services': path.resolve(__dirname, 'src/services'),
+      '@isa/transport': path.resolve(__dirname, '../isA_App_SDK/packages/transport/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add a session-scoped cost badge to the app header with live token/USD metrics.
- Add a mobile-friendly audit drawer filtered to the current session with HIL/tool/cost/trigger filters.
- Route observability through @isa/transport ObservabilityClient and dispatch refresh events from chat model/tool/billing completions.
- Add focused service/helper tests and align Vitest resolution with the SDK source path used by tsconfig.

## Tests
- npm test -- src/api/__tests__/ObservabilityService.test.ts src/components/ui/header/__tests__/CostBadge.test.ts src/components/ui/drawers/__tests__/AuditDrawer.test.ts (13 passed)
- npm test -- src/api/__tests__/ObservabilityService.test.ts src/api/__tests__/storageService.test.ts (23 passed)
- ./node_modules/.bin/tsc --noEmit --pretty false (full repo still fails on existing desktop/SDK/repo type debt; filtered diagnostics for #304-touched files returned no matches)

Fixes #304