### PR TITLE
Add design system onboarding

### DIFF
--- a/src/api/__tests__/designSystemProfileService.test.ts
+++ b/src/api/__tests__/designSystemProfileService.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  DESIGN_SYSTEM_PROFILE_STORAGE_KEY,
+  buildDesignSystemProfile,
+  loadDesignSystemProfile,
+  normalizeDesignTokens,
+  saveDesignSystemProfile,
+  shouldShowDesignSystemOnboarding,
+} from '../designSystemProfileService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_ENDPOINTS: {
+    ACCOUNTS: {
+      ME: 'http://gateway.test/api/v1/accounts/me',
+    },
+  },
+}));
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/authCookieHelper', () => ({
+  getCredentialsMode: () => 'include',
+}));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+describe('designSystemProfileService', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    vi.stubGlobal('fetch', vi.fn());
+    vi.setSystemTime(new Date('2026-04-23T08:00:00.000Z'));
+    localStorageMock.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('normalizes Creative brand extraction tokens into app design tokens', () => {
+    const tokens = normalizeDesignTokens({
+      colors: { primary: '#101828', secondary: '#667085', accent: '#f97316' },
+      fonts: { heading: 'Fraunces', body: 'DM Sans' },
+      borderRadius: '18px',
+    });
+
+    expect(tokens.colors.primary).toBe('#101828');
+    expect(tokens.colors.secondary).toBe('#667085');
+    expect(tokens.colors.accent).toBe('#f97316');
+    expect(tokens.typography.heading).toBe('Fraunces');
+    expect(tokens.typography.body).toBe('DM Sans');
+    expect(tokens.radii.lg).toBe('18px');
+  });
+
+  test('builds a completed URL-sourced profile from extracted tokens', () => {
+    const profile = buildDesignSystemProfile({
+      source: 'url',
+      sourceValue: 'https://example.com',
+      tokens: normalizeDesignTokens({ colors: ['#111111', '#eeeeee', '#ff6600'] }),
+    });
+
+    expect(profile.source).toBe('url');
+    expect(profile.sourceValue).toBe('https://example.com');
+    expect(profile.completedAt).toBe('2026-04-23T08:00:00.000Z');
+    expect(profile.tokens.colors.primary).toBe('#111111');
+    expect(profile.tokens.colors.secondary).toBe('#eeeeee');
+    expect(profile.tokens.colors.accent).toBe('#ff6600');
+  });
+
+  test('shows onboarding only on first Design mode entry', () => {
+    expect(shouldShowDesignSystemOnboarding('chat', null, false)).toBe(false);
+    expect(shouldShowDesignSystemOnboarding('design', null, false)).toBe(true);
+    expect(
+      shouldShowDesignSystemOnboarding(
+        'design',
+        buildDesignSystemProfile({ source: 'defaults', skipped: true }),
+        false,
+      ),
+    ).toBe(false);
+    expect(shouldShowDesignSystemOnboarding('design', null, true)).toBe(false);
+  });
+
+  test('saves locally and attempts to sync profile into isA_user preferences', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ preferences: { theme: 'dark' } }),
+      } as Response);
+    const profile = buildDesignSystemProfile({ source: 'manual' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        preferences: { theme: 'dark', design_system_profile: profile },
+      }),
+    } as Response);
+
+    const result = await saveDesignSystemProfile(profile);
+
+    expect(result).toEqual({ local: true, remote: true });
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      DESIGN_SYSTEM_PROFILE_STORAGE_KEY,
+      JSON.stringify(profile),
+    );
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://gateway.test/api/v1/accounts/me',
+      expect.objectContaining({
+        method: 'PATCH',
+        credentials: 'include',
+        body: JSON.stringify({
+          preferences: {
+            theme: 'dark',
+            design_system_profile: profile,
+          },
+        }),
+      }),
+    );
+  });
+
+  test('loads local profile before making a network request', async () => {
+    const profile = buildDesignSystemProfile({ source: 'manual' });
+    localStorageMock.setItem(DESIGN_SYSTEM_PROFILE_STORAGE_KEY, JSON.stringify(profile));
+
+    await expect(loadDesignSystemProfile()).resolves.toEqual(profile);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/designSystemProfileService.ts
+++ b/src/api/designSystemProfileService.ts
@@ -1,0 +1,372 @@
+import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import { getCredentialsMode } from '../utils/authCookieHelper';
+
+export const DESIGN_SYSTEM_PROFILE_STORAGE_KEY = 'isa_design_system_profile';
+
+export type DesignSystemSource = 'url' | 'manual' | 'defaults';
+export type AppModeForDesignOnboarding = 'chat' | 'design' | 'browse';
+
+export interface DesignSystemTokens {
+  colors: {
+    primary: string;
+    secondary: string;
+    accent: string;
+    background: string;
+    surface: string;
+    text: string;
+  };
+  typography: {
+    heading: string;
+    body: string;
+  };
+  spacing: {
+    xs: string;
+    sm: string;
+    md: string;
+    lg: string;
+    xl: string;
+  };
+  radii: {
+    sm: string;
+    md: string;
+    lg: string;
+    xl: string;
+  };
+}
+
+export interface DesignSystemProfile {
+  id: string;
+  source: DesignSystemSource;
+  sourceValue?: string;
+  tokens: DesignSystemTokens;
+  completedAt: string;
+  screenshotUrl?: string;
+  skipped?: boolean;
+}
+
+export interface BrandExtractionInput {
+  source: Extract<DesignSystemSource, 'url' | 'manual'>;
+  sourceValue?: string;
+  manual?: Record<string, unknown>;
+}
+
+export interface SaveDesignSystemProfileResult {
+  local: boolean;
+  remote: boolean;
+}
+
+export const DEFAULT_DESIGN_SYSTEM_TOKENS: DesignSystemTokens = {
+  colors: {
+    primary: '#111111',
+    secondary: '#525252',
+    accent: '#f59e0b',
+    background: '#1a1a1a',
+    surface: '#222222',
+    text: '#f5f5f5',
+  },
+  typography: {
+    heading: 'DM Sans',
+    body: 'DM Sans',
+  },
+  spacing: {
+    xs: '4px',
+    sm: '8px',
+    md: '12px',
+    lg: '16px',
+    xl: '24px',
+  },
+  radii: {
+    sm: '8px',
+    md: '12px',
+    lg: '16px',
+    xl: '24px',
+  },
+};
+
+const FALLBACK_ACCENTS = ['#f59e0b', '#0ea5e9', '#22c55e', '#ef4444', '#a855f7', '#14b8a6'];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = asString(record[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function createProfileId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `dsp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function readStoredProfile(): DesignSystemProfile | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(DESIGN_SYSTEM_PROFILE_STORAGE_KEY);
+    if (!stored) return null;
+    return JSON.parse(stored) as DesignSystemProfile;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredProfile(profile: DesignSystemProfile): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    localStorage.setItem(DESIGN_SYSTEM_PROFILE_STORAGE_KEY, JSON.stringify(profile));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getAuthHeaders(): Record<string, string> {
+  const token = authTokenStore.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function getCreativeBrandEndpoint(): string | null {
+  const configured =
+    process.env.NEXT_PUBLIC_CREATIVE_BRAND_ENDPOINT ||
+    process.env.NEXT_PUBLIC_CREATIVE_DESIGN_URL ||
+    process.env.NEXT_PUBLIC_CREATIVE_URL;
+
+  if (!configured) return null;
+
+  const base = configured.replace(/\/+$/, '');
+  if (/\/brand$/i.test(base)) return base;
+  return `${base}/api/v1/design/brand`;
+}
+
+function inferUrlTokens(url: string): DesignSystemTokens {
+  const accent = FALLBACK_ACCENTS[hashString(url) % FALLBACK_ACCENTS.length];
+  return normalizeDesignTokens({
+    colors: {
+      primary: DEFAULT_DESIGN_SYSTEM_TOKENS.colors.primary,
+      secondary: DEFAULT_DESIGN_SYSTEM_TOKENS.colors.secondary,
+      accent,
+    },
+  });
+}
+
+export function normalizeDesignTokens(rawTokens: unknown): DesignSystemTokens {
+  const raw = isObject(rawTokens) && isObject(rawTokens.tokens)
+    ? rawTokens.tokens
+    : rawTokens;
+  const tokenRecord = isObject(raw) ? raw : {};
+
+  const rawColors = tokenRecord.colors ?? tokenRecord.palette;
+  const colorArray = Array.isArray(rawColors) ? rawColors.map(asString).filter(Boolean) : [];
+  const colorRecord = isObject(rawColors) ? rawColors : {};
+
+  const rawFonts = isObject(tokenRecord.fonts) ? tokenRecord.fonts : {};
+  const rawTypography = isObject(tokenRecord.typography) ? tokenRecord.typography : {};
+  const rawRadii = isObject(tokenRecord.radii) ? tokenRecord.radii : {};
+  const rawSpacing = isObject(tokenRecord.spacing) ? tokenRecord.spacing : {};
+
+  const primary = pickString(colorRecord, ['primary', 'brand', 'main']) ?? colorArray[0] ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.primary;
+  const secondary = pickString(colorRecord, ['secondary', 'muted']) ?? colorArray[1] ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.secondary;
+  const accent = pickString(colorRecord, ['accent', 'highlight']) ?? colorArray[2] ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.accent;
+  const radius = asString(tokenRecord.borderRadius) ?? asString(tokenRecord.radius);
+
+  return {
+    colors: {
+      primary,
+      secondary,
+      accent,
+      background: pickString(colorRecord, ['background', 'bg']) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.background,
+      surface: pickString(colorRecord, ['surface', 'card']) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.surface,
+      text: pickString(colorRecord, ['text', 'foreground']) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.colors.text,
+    },
+    typography: {
+      heading: pickString(rawTypography, ['heading', 'display']) ?? pickString(rawFonts, ['heading', 'display']) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.typography.heading,
+      body: pickString(rawTypography, ['body', 'sans']) ?? pickString(rawFonts, ['body', 'sans']) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.typography.body,
+    },
+    spacing: {
+      xs: asString(rawSpacing.xs) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.spacing.xs,
+      sm: asString(rawSpacing.sm) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.spacing.sm,
+      md: asString(rawSpacing.md) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.spacing.md,
+      lg: asString(rawSpacing.lg) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.spacing.lg,
+      xl: asString(rawSpacing.xl) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.spacing.xl,
+    },
+    radii: {
+      sm: asString(rawRadii.sm) ?? radius ?? DEFAULT_DESIGN_SYSTEM_TOKENS.radii.sm,
+      md: asString(rawRadii.md) ?? radius ?? DEFAULT_DESIGN_SYSTEM_TOKENS.radii.md,
+      lg: asString(rawRadii.lg) ?? radius ?? DEFAULT_DESIGN_SYSTEM_TOKENS.radii.lg,
+      xl: asString(rawRadii.xl) ?? DEFAULT_DESIGN_SYSTEM_TOKENS.radii.xl,
+    },
+  };
+}
+
+export function buildDesignSystemProfile({
+  source,
+  sourceValue,
+  tokens = DEFAULT_DESIGN_SYSTEM_TOKENS,
+  screenshotUrl,
+  skipped = false,
+}: {
+  source: DesignSystemSource;
+  sourceValue?: string;
+  tokens?: DesignSystemTokens;
+  screenshotUrl?: string;
+  skipped?: boolean;
+}): DesignSystemProfile {
+  return {
+    id: createProfileId(),
+    source,
+    sourceValue,
+    tokens,
+    completedAt: new Date().toISOString(),
+    screenshotUrl,
+    skipped,
+  };
+}
+
+export function shouldShowDesignSystemOnboarding(
+  appMode: AppModeForDesignOnboarding,
+  profile: DesignSystemProfile | null,
+  isLoading: boolean,
+): boolean {
+  return appMode === 'design' && !isLoading && !profile;
+}
+
+export async function extractDesignSystemProfile(input: BrandExtractionInput): Promise<DesignSystemProfile> {
+  if (input.source === 'manual') {
+    return buildDesignSystemProfile({
+      source: 'manual',
+      sourceValue: input.sourceValue,
+      tokens: normalizeDesignTokens(input.manual ?? {}),
+    });
+  }
+
+  const sourceValue = input.sourceValue?.trim();
+  if (!sourceValue) {
+    throw new Error('Enter a brand URL before extracting tokens.');
+  }
+
+  const endpoint = getCreativeBrandEndpoint();
+  if (endpoint && typeof fetch !== 'undefined') {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        credentials: getCredentialsMode(),
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders(),
+        },
+        body: JSON.stringify({ url: sourceValue }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        return buildDesignSystemProfile({
+          source: 'url',
+          sourceValue,
+          tokens: normalizeDesignTokens(data.tokens ?? data),
+          screenshotUrl: data.screenshot_url ?? data.screenshotUrl,
+        });
+      }
+    } catch {
+      // Fall through to deterministic local extraction so the onboarding is not blocked.
+    }
+  }
+
+  return buildDesignSystemProfile({
+    source: 'url',
+    sourceValue,
+    tokens: inferUrlTokens(sourceValue),
+  });
+}
+
+export async function loadDesignSystemProfile(): Promise<DesignSystemProfile | null> {
+  const localProfile = readStoredProfile();
+  if (localProfile) return localProfile;
+
+  if (typeof fetch === 'undefined') return null;
+
+  try {
+    const response = await fetch(GATEWAY_ENDPOINTS.ACCOUNTS.ME, {
+      method: 'GET',
+      credentials: getCredentialsMode(),
+      headers: getAuthHeaders(),
+    });
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const profile = data?.preferences?.design_system_profile as DesignSystemProfile | undefined;
+    if (!profile) return null;
+
+    writeStoredProfile(profile);
+    return profile;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveDesignSystemProfile(profile: DesignSystemProfile): Promise<SaveDesignSystemProfileResult> {
+  const local = writeStoredProfile(profile);
+  let remote = false;
+
+  if (typeof fetch === 'undefined') {
+    return { local, remote };
+  }
+
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...getAuthHeaders(),
+    };
+    const currentResponse = await fetch(GATEWAY_ENDPOINTS.ACCOUNTS.ME, {
+      method: 'GET',
+      credentials: getCredentialsMode(),
+      headers,
+    });
+    const currentProfile = currentResponse.ok ? await currentResponse.json() : {};
+    const preferences = {
+      ...(currentProfile?.preferences ?? {}),
+      design_system_profile: profile,
+    };
+
+    const response = await fetch(GATEWAY_ENDPOINTS.ACCOUNTS.ME, {
+      method: 'PATCH',
+      credentials: getCredentialsMode(),
+      headers,
+      body: JSON.stringify({ preferences }),
+    });
+    if (response.ok) {
+      const updatedProfile = await response.json().catch(() => null);
+      remote = Boolean(updatedProfile?.preferences?.design_system_profile);
+    }
+  } catch {
+    remote = false;
+  }
+
+  return { local, remote };
+}
+
+export function clearStoredDesignSystemProfile(): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(DESIGN_SYSTEM_PROFILE_STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}

--- a/src/components/ui/chat/DesignSystemOnboarding.tsx
+++ b/src/components/ui/chat/DesignSystemOnboarding.tsx
@@ -1,0 +1,426 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  buildDesignSystemProfile,
+  normalizeDesignTokens,
+  type BrandExtractionInput,
+  type DesignSystemProfile,
+} from '../../../api/designSystemProfileService';
+
+interface ManualTokenState {
+  primary: string;
+  secondary: string;
+  accent: string;
+  heading: string;
+  body: string;
+  radius: string;
+  notes: string;
+}
+
+export interface DesignSystemOnboardingProps {
+  open: boolean;
+  profile: DesignSystemProfile | null;
+  isExtracting?: boolean;
+  isSaving?: boolean;
+  error?: string | null;
+  onExtract: (input: BrandExtractionInput) => Promise<DesignSystemProfile>;
+  onSave: (profile: DesignSystemProfile) => Promise<unknown>;
+  onSkip: () => Promise<unknown>;
+}
+
+const DEFAULT_MANUAL_STATE: ManualTokenState = {
+  primary: '#111111',
+  secondary: '#525252',
+  accent: '#f59e0b',
+  heading: 'DM Sans',
+  body: 'DM Sans',
+  radius: '16px',
+  notes: '',
+};
+
+export function buildManualDesignSystemProfile(manual: ManualTokenState): DesignSystemProfile {
+  return buildDesignSystemProfile({
+    source: 'manual',
+    sourceValue: manual.notes.trim() ? 'manual-notes' : 'manual',
+    tokens: normalizeDesignTokens({
+      colors: {
+        primary: manual.primary,
+        secondary: manual.secondary,
+        accent: manual.accent,
+      },
+      fonts: {
+        heading: manual.heading,
+        body: manual.body,
+      },
+      borderRadius: manual.radius,
+      notes: manual.notes,
+    }),
+  });
+}
+
+const TokenPreview: React.FC<{ profile: DesignSystemProfile }> = ({ profile }) => {
+  const { tokens } = profile;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-2">
+        {[
+          ['Primary', tokens.colors.primary],
+          ['Secondary', tokens.colors.secondary],
+          ['Accent', tokens.colors.accent],
+        ].map(([label, color]) => (
+          <div key={label} className="rounded-xl border border-white/10 bg-white/[0.03] p-2">
+            <div
+              className="mb-2 h-12 rounded-lg border border-white/10"
+              style={{ background: color }}
+            />
+            <div className="text-[10px] uppercase tracking-[0.2em] text-white/35">{label}</div>
+            <div className="text-xs text-white/80">{color}</div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="overflow-hidden rounded-2xl border p-4"
+        style={{
+          background: tokens.colors.background,
+          borderColor: tokens.colors.secondary,
+          color: tokens.colors.text,
+          borderRadius: tokens.radii.lg,
+          fontFamily: tokens.typography.body,
+        }}
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.24em] opacity-60">Live sample</div>
+            <h3
+              className="mt-1 text-2xl font-semibold tracking-[-0.03em]"
+              style={{ fontFamily: tokens.typography.heading }}
+            >
+              Launch brief
+            </h3>
+          </div>
+          <div
+            className="h-9 w-9 rounded-full"
+            style={{ background: tokens.colors.accent }}
+          />
+        </div>
+        <p className="max-w-[32ch] text-sm leading-6 opacity-75">
+          Future Design mode outputs will borrow this color rhythm, radius, and type voice.
+        </p>
+        <button
+          type="button"
+          className="mt-5 rounded-full px-4 py-2 text-sm font-semibold"
+          style={{
+            background: tokens.colors.accent,
+            color: tokens.colors.background,
+            borderRadius: tokens.radii.xl,
+          }}
+        >
+          Generate with this system
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const DesignSystemOnboarding: React.FC<DesignSystemOnboardingProps> = ({
+  open,
+  profile,
+  isExtracting = false,
+  isSaving = false,
+  error,
+  onExtract,
+  onSave,
+  onSkip,
+}) => {
+  const [source, setSource] = useState<'url' | 'manual'>('url');
+  const [url, setUrl] = useState('');
+  const [manual, setManual] = useState<ManualTokenState>(DEFAULT_MANUAL_STATE);
+  const [draftProfile, setDraftProfile] = useState<DesignSystemProfile | null>(profile);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setDraftProfile(profile);
+    setLocalError(null);
+  }, [open, profile]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        void onSkip().catch(() => {
+          setLocalError('Could not skip setup. Try again.');
+        });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onSkip]);
+
+  const manualPreviewProfile = useMemo(() => buildManualDesignSystemProfile(manual), [manual]);
+  const previewProfile = source === 'manual' ? manualPreviewProfile : draftProfile ?? manualPreviewProfile;
+
+  const updateManual = useCallback((field: keyof ManualTokenState, value: string) => {
+    setManual((current) => ({ ...current, [field]: value }));
+  }, []);
+
+  const handleExtract = useCallback(async () => {
+    setLocalError(null);
+    try {
+      const extracted = await onExtract({ source: 'url', sourceValue: url });
+      setDraftProfile(extracted);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Could not extract brand tokens.');
+    }
+  }, [onExtract, url]);
+
+  const handleSave = useCallback(async () => {
+    setLocalError(null);
+    try {
+      const nextProfile = source === 'manual'
+        ? buildManualDesignSystemProfile(manual)
+        : draftProfile ?? await onExtract({ source: 'url', sourceValue: url });
+      await onSave(nextProfile);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Could not save the design system.');
+    }
+  }, [draftProfile, manual, onExtract, onSave, source, url]);
+
+  const handleFileUpload = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      updateManual('notes', text.slice(0, 6000));
+      setSource('manual');
+    } catch {
+      setLocalError('Could not read that brand file. Paste the guidance manually instead.');
+    }
+  }, [updateManual]);
+
+  if (!open) return null;
+
+  const message = localError || error;
+  const busy = isExtracting || isSaving;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur-md"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="design-system-onboarding-title"
+    >
+      <div className="relative flex max-h-[92vh] w-full max-w-5xl overflow-hidden rounded-[2rem] border border-white/10 bg-[#111111] text-white shadow-2xl">
+        <div className="hidden w-[32%] flex-col justify-between border-r border-white/10 bg-[#181818] p-8 md:flex">
+          <div>
+            <div className="mb-6 inline-flex rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200">
+              Design mode setup
+            </div>
+            <h2
+              id="design-system-onboarding-title"
+              className="text-4xl font-semibold tracking-[-0.05em]"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              Teach Mate your visual language once.
+            </h2>
+            <p className="mt-4 text-sm leading-6 text-white/55">
+              Share a brand source, adjust the tokens, and every future design request starts with
+              a profile instead of a blank canvas.
+            </p>
+          </div>
+
+          <div className="space-y-4 text-sm">
+            {['Share source', 'Extract tokens', 'Confirm system'].map((label, index) => (
+              <div key={label} className="flex items-center gap-3 text-white/65">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full border border-white/15 text-xs">
+                  {index + 1}
+                </span>
+                {label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid min-h-[640px] flex-1 grid-cols-1 overflow-y-auto md:grid-cols-[1fr_360px]">
+          <section className="space-y-6 p-5 sm:p-8">
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => setSource('url')}
+                className={`rounded-full px-4 py-2 text-sm transition ${source === 'url' ? 'bg-white text-black' : 'bg-white/5 text-white/70 hover:bg-white/10'}`}
+              >
+                URL extraction
+              </button>
+              <button
+                type="button"
+                onClick={() => setSource('manual')}
+                className={`rounded-full px-4 py-2 text-sm transition ${source === 'manual' ? 'bg-white text-black' : 'bg-white/5 text-white/70 hover:bg-white/10'}`}
+              >
+                Manual fallback
+              </button>
+            </div>
+
+            {source === 'url' ? (
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-white/75" htmlFor="brand-url">
+                  Brand URL
+                </label>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <input
+                    id="brand-url"
+                    type="url"
+                    value={url}
+                    onChange={(event) => setUrl(event.target.value)}
+                    placeholder="https://yourbrand.com"
+                    className="min-h-12 flex-1 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-amber-300/60"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleExtract}
+                    disabled={busy}
+                    className="min-h-12 rounded-2xl bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isExtracting ? 'Extracting...' : 'Extract tokens'}
+                  </button>
+                </div>
+                <p className="text-xs leading-5 text-white/45">
+                  Uses the Creative brand extraction route when configured, then falls back to a
+                  deterministic local profile so first-run setup never blocks Design mode.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  {[
+                    ['Primary', 'primary'],
+                    ['Secondary', 'secondary'],
+                    ['Accent', 'accent'],
+                  ].map(([label, field]) => (
+                    <label key={field} className="space-y-2 text-sm text-white/70">
+                      {label}
+                      <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-2">
+                        <input
+                          type="color"
+                          value={manual[field as keyof ManualTokenState]}
+                          onChange={(event) => updateManual(field as keyof ManualTokenState, event.target.value)}
+                          className="h-9 w-10 rounded border-0 bg-transparent"
+                        />
+                        <input
+                          value={manual[field as keyof ManualTokenState]}
+                          onChange={(event) => updateManual(field as keyof ManualTokenState, event.target.value)}
+                          className="min-w-0 flex-1 bg-transparent text-xs text-white outline-none"
+                        />
+                      </div>
+                    </label>
+                  ))}
+                </div>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  <label className="space-y-2 text-sm text-white/70">
+                    Heading font
+                    <input
+                      value={manual.heading}
+                      onChange={(event) => updateManual('heading', event.target.value)}
+                      className="h-12 w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm text-white outline-none focus:border-amber-300/60"
+                    />
+                  </label>
+                  <label className="space-y-2 text-sm text-white/70">
+                    Body font
+                    <input
+                      value={manual.body}
+                      onChange={(event) => updateManual('body', event.target.value)}
+                      className="h-12 w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm text-white outline-none focus:border-amber-300/60"
+                    />
+                  </label>
+                  <label className="space-y-2 text-sm text-white/70">
+                    Radius
+                    <input
+                      value={manual.radius}
+                      onChange={(event) => updateManual('radius', event.target.value)}
+                      className="h-12 w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm text-white outline-none focus:border-amber-300/60"
+                    />
+                  </label>
+                </div>
+
+                <label className="block space-y-2 text-sm text-white/70">
+                  Brand notes or uploaded guidelines
+                  <textarea
+                    value={manual.notes}
+                    onChange={(event) => updateManual('notes', event.target.value)}
+                    placeholder="Paste tone, layout rules, typography notes, or component guidance..."
+                    className="min-h-28 w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm leading-6 text-white outline-none transition placeholder:text-white/25 focus:border-amber-300/60"
+                  />
+                </label>
+                <label className="inline-flex cursor-pointer items-center rounded-full border border-dashed border-white/20 px-4 py-2 text-xs text-white/55 transition hover:border-amber-300/50 hover:text-amber-100">
+                  Upload guidelines
+                  <input
+                    type="file"
+                    accept=".txt,.md,.json,.css"
+                    className="sr-only"
+                    onChange={handleFileUpload}
+                  />
+                </label>
+              </div>
+            )}
+
+            {message && (
+              <div className="rounded-2xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-100">
+                {message}
+              </div>
+            )}
+
+            <div className="flex flex-col-reverse gap-3 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  void onSkip().catch(() => {
+                    setLocalError('Could not skip setup. Try again.');
+                  });
+                }}
+                disabled={busy}
+                className="rounded-full px-4 py-2 text-sm text-white/45 transition hover:bg-white/5 hover:text-white/75 disabled:cursor-not-allowed"
+              >
+                Skip, use defaults
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={busy}
+                className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSaving ? 'Saving...' : 'Save design system'}
+              </button>
+            </div>
+          </section>
+
+          <aside className="border-t border-white/10 bg-white/[0.03] p-5 md:border-l md:border-t-0 md:p-6">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <div className="text-[10px] uppercase tracking-[0.22em] text-white/35">Preview</div>
+                <div className="mt-1 text-sm text-white/70">
+                  {previewProfile.source === 'url' ? previewProfile.sourceValue || 'URL source' : 'Manual profile'}
+                </div>
+              </div>
+              {previewProfile.screenshotUrl && (
+                <a
+                  href={previewProfile.screenshotUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-amber-200 underline-offset-4 hover:underline"
+                >
+                  screenshot
+                </a>
+              )}
+            </div>
+            <TokenPreview profile={previewProfile} />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/chat/__tests__/DesignSystemOnboarding.test.ts
+++ b/src/components/ui/chat/__tests__/DesignSystemOnboarding.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { buildManualDesignSystemProfile } from '../DesignSystemOnboarding';
+
+describe('DesignSystemOnboarding helpers', () => {
+  test('builds a manual design profile from editable onboarding fields', () => {
+    vi.setSystemTime(new Date('2026-04-23T08:00:00.000Z'));
+
+    const profile = buildManualDesignSystemProfile({
+      primary: '#101828',
+      secondary: '#667085',
+      accent: '#f97316',
+      heading: 'Fraunces',
+      body: 'DM Sans',
+      radius: '18px',
+      notes: 'Editorial, warm, confident.',
+    });
+
+    expect(profile.source).toBe('manual');
+    expect(profile.sourceValue).toBe('manual-notes');
+    expect(profile.completedAt).toBe('2026-04-23T08:00:00.000Z');
+    expect(profile.tokens.colors.primary).toBe('#101828');
+    expect(profile.tokens.colors.accent).toBe('#f97316');
+    expect(profile.tokens.typography.heading).toBe('Fraunces');
+    expect(profile.tokens.radii.lg).toBe('18px');
+  });
+});

--- a/src/hooks/useDesignSystemProfile.ts
+++ b/src/hooks/useDesignSystemProfile.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  buildDesignSystemProfile,
+  extractDesignSystemProfile,
+  loadDesignSystemProfile,
+  saveDesignSystemProfile,
+  type BrandExtractionInput,
+  type DesignSystemProfile,
+  type SaveDesignSystemProfileResult,
+} from '../api/designSystemProfileService';
+
+export interface UseDesignSystemProfileResult {
+  profile: DesignSystemProfile | null;
+  isLoading: boolean;
+  isExtracting: boolean;
+  isSaving: boolean;
+  error: string | null;
+  extractProfile: (input: BrandExtractionInput) => Promise<DesignSystemProfile>;
+  saveProfile: (profile: DesignSystemProfile) => Promise<SaveDesignSystemProfileResult>;
+  skipOnboarding: () => Promise<SaveDesignSystemProfileResult>;
+}
+
+export function useDesignSystemProfile(enabled = true): UseDesignSystemProfileResult {
+  const [profile, setProfile] = useState<DesignSystemProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isExtracting, setIsExtracting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const loadedProfile = await loadDesignSystemProfile();
+        if (!cancelled) setProfile(loadedProfile);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load design profile.');
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  const extractProfile = useCallback(async (input: BrandExtractionInput) => {
+    setIsExtracting(true);
+    setError(null);
+    try {
+      const extractedProfile = await extractDesignSystemProfile(input);
+      return extractedProfile;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to extract brand tokens.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsExtracting(false);
+    }
+  }, []);
+
+  const saveProfile = useCallback(async (nextProfile: DesignSystemProfile) => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      const result = await saveDesignSystemProfile(nextProfile);
+      setProfile(nextProfile);
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save design profile.';
+      setError(message);
+      throw new Error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, []);
+
+  const skipOnboarding = useCallback(async () => {
+    const defaultProfile = buildDesignSystemProfile({
+      source: 'defaults',
+      skipped: true,
+    });
+    return saveProfile(defaultProfile);
+  }, [saveProfile]);
+
+  return {
+    profile,
+    isLoading,
+    isExtracting,
+    isSaving,
+    error,
+    extractProfile,
+    saveProfile,
+    skipOnboarding,
+  };
+}

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -41,6 +41,7 @@ import { RightPanel } from '../components/ui/chat/RightPanel';
 import { RightSidebarLayout } from '../components/ui/chat/RightSidebarLayout';
 import { BrowserPanel } from '../components/ui/chat/BrowserPanel';
 import { DesignPanel } from '../components/ui/chat/DesignPanel';
+import { DesignSystemOnboarding } from '../components/ui/chat/DesignSystemOnboarding';
 import { ModeSwitcher, type AppMode } from '../components/ui/chat/ModeSwitcher';
 import { AppId } from '../types/appTypes';
 import { useBrowserControl } from '@isa/hooks';
@@ -57,6 +58,8 @@ import { useHuntActions } from '../stores/useWidgetStores';
 import { ArtifactMessage } from '../types/chatTypes';
 import { detectPluginTrigger, executePlugin } from '../plugins';
 import { useTask } from '../hooks/useTask';
+import { useDesignSystemProfile } from '../hooks/useDesignSystemProfile';
+import { shouldShowDesignSystemOnboarding } from '../api/designSystemProfileService';
 
 // 🆕 HIL (Human-in-the-Loop) 导入
 import { HILInterruptModal } from '../components/ui/hil/HILInterruptModal';
@@ -149,6 +152,8 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
   // Get chat interface state using the hook (now pure state aggregation)
   const chatInterface = useChat();
+
+  const designSystemProfile = useDesignSystemProfile(appMode === 'design');
 
   // Get authentication state
   const { authUser } = useAuth();
@@ -415,7 +420,27 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     }
 
     if (appMode === 'design') {
-      return <DesignPanel />;
+      const showOnboarding = shouldShowDesignSystemOnboarding(
+        appMode,
+        designSystemProfile.profile,
+        designSystemProfile.isLoading,
+      );
+
+      return (
+        <div className="relative h-full">
+          <DesignPanel />
+          <DesignSystemOnboarding
+            open={showOnboarding}
+            profile={designSystemProfile.profile}
+            isExtracting={designSystemProfile.isExtracting}
+            isSaving={designSystemProfile.isSaving}
+            error={designSystemProfile.error}
+            onExtract={designSystemProfile.extractProfile}
+            onSave={designSystemProfile.saveProfile}
+            onSkip={designSystemProfile.skipOnboarding}
+          />
+        </div>
+      );
     }
 
     return null;
@@ -429,6 +454,14 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
     clickAt,
     currentScreenshot,
     currentUrl,
+    designSystemProfile.error,
+    designSystemProfile.extractProfile,
+    designSystemProfile.isExtracting,
+    designSystemProfile.isLoading,
+    designSystemProfile.isSaving,
+    designSystemProfile.profile,
+    designSystemProfile.saveProfile,
+    designSystemProfile.skipOnboarding,
     handleBrowserApprove,
     handleBrowserReject,
     isConnected,


### PR DESCRIPTION
## Summary
- Add first-entry Design mode onboarding for brand/design-system setup.
- Support URL extraction through a configured Creative brand endpoint, with deterministic local fallback.
- Add manual fallback for colors, typography, radius, notes, and uploaded text guidelines.
- Persist locally first and best-effort sync the profile into isA_user account preferences.

## Tests
- npm test -- src/api/__tests__/designSystemProfileService.test.ts src/components/ui/chat/__tests__/DesignSystemOnboarding.test.ts
- git diff --check -- src/api/designSystemProfileService.ts src/api/__tests__/designSystemProfileService.test.ts src/hooks/useDesignSystemProfile.ts src/components/ui/chat/DesignSystemOnboarding.tsx src/components/ui/chat/__tests__/DesignSystemOnboarding.test.ts src/modules/ChatModule.tsx
- ./node_modules/.bin/tsc --noEmit --pretty false filtered to touched files: no diagnostics

## Notes
- Full repo typecheck still has unrelated existing type debt outside these touched files.

Fixes #285
