### PR TITLE
feat(ui): connect memory manager to API

### DIFF
--- a/src/api/__tests__/memoryService.test.ts
+++ b/src/api/__tests__/memoryService.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  filterMemories,
+  memoryService,
+  normalizeMemory,
+} from '../memoryService';
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://gateway.test',
+  },
+}));
+
+vi.mock('../../stores/authTokenStore', () => ({
+  authTokenStore: { getToken: () => 'mock-token' },
+}));
+
+vi.mock('../../utils/authCookieHelper', () => ({
+  getCredentialsMode: () => 'include',
+}));
+
+describe('memoryService', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  test('normalizes memory-service records into UI memories', () => {
+    expect(normalizeMemory({
+      id: 'mem-1',
+      memory_type: 'semantic',
+      definition: 'A design system is a reusable visual language.',
+      created_at: '2026-04-23T08:00:00.000Z',
+    })).toMatchObject({
+      id: 'mem-1',
+      type: 'semantic',
+      content: 'A design system is a reusable visual language.',
+      created_at: '2026-04-23T08:00:00.000Z',
+    });
+  });
+
+  test('filters memories by content and type', () => {
+    const memories = [
+      normalizeMemory({ id: 'fact-1', memory_type: 'factual', content: 'Likes black coffee' }),
+      normalizeMemory({ id: 'work-1', memory_type: 'working', content: 'Draft launch plan' }),
+    ];
+
+    expect(filterMemories(memories, '')).toHaveLength(2);
+    expect(filterMemories(memories, 'coffee')).toEqual([memories[0]]);
+    expect(filterMemories(memories, 'working')).toEqual([memories[1]]);
+  });
+
+  test('lists memories through the gateway memory API', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        memories: [{ id: 'mem-1', memory_type: 'factual', content: 'Likes tea' }],
+      }),
+    } as Response);
+
+    const memories = await memoryService.listMemories({ userId: 'usr-1' });
+
+    expect(memories).toHaveLength(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://gateway.test/api/v1/memories?user_id=usr-1&limit=100',
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+        headers: { Authorization: 'Bearer mock-token' },
+      }),
+    );
+  });
+
+  test('updates memory content by type and id', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    await memoryService.updateMemory({
+      userId: 'usr-1',
+      memoryId: 'mem-1',
+      type: 'factual',
+      content: 'Likes green tea',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://gateway.test/api/v1/memories/factual/mem-1?user_id=usr-1',
+      expect.objectContaining({
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          Authorization: 'Bearer mock-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ content: 'Likes green tea' }),
+      }),
+    );
+  });
+
+  test('deletes memory by type and id', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    await memoryService.deleteMemory({
+      userId: 'usr-1',
+      memoryId: 'mem-1',
+      type: 'working',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://gateway.test/api/v1/memories/working/mem-1?user_id=usr-1',
+      expect.objectContaining({
+        method: 'DELETE',
+        credentials: 'include',
+      }),
+    );
+  });
+});

--- a/src/api/memoryService.ts
+++ b/src/api/memoryService.ts
@@ -1,0 +1,203 @@
+import { GATEWAY_CONFIG } from '../config/gatewayConfig';
+import { authTokenStore } from '../stores/authTokenStore';
+import { getCredentialsMode } from '../utils/authCookieHelper';
+
+export type MemoryType = 'factual' | 'episodic' | 'semantic' | 'procedural' | 'working';
+
+export interface UserMemory {
+  id: string;
+  type: MemoryType;
+  content: string;
+  created_at?: string;
+  updated_at?: string;
+  importance_score?: number;
+  confidence?: number;
+  tags?: string[];
+  raw: Record<string, unknown>;
+}
+
+export interface ListMemoriesParams {
+  userId: string;
+  type?: MemoryType;
+  query?: string;
+  limit?: number;
+}
+
+export interface UpdateMemoryParams {
+  userId: string;
+  memoryId: string;
+  type: MemoryType;
+  content: string;
+}
+
+export interface DeleteMemoryParams {
+  userId: string;
+  memoryId: string;
+  type: MemoryType;
+}
+
+export const MEMORY_TYPES: MemoryType[] = ['factual', 'episodic', 'semantic', 'procedural', 'working'];
+
+function getAuthHeaders(): Record<string, string> {
+  const token = authTokenStore.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function memoryBaseUrl(): string {
+  return `${GATEWAY_CONFIG.BASE_URL.replace(/\/+$/, '')}/api/v1/memories`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === 'string';
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeType(value: unknown): MemoryType {
+  const candidate = asString(value);
+  return MEMORY_TYPES.includes(candidate as MemoryType)
+    ? candidate as MemoryType
+    : 'factual';
+}
+
+function fallbackContent(record: Record<string, unknown>, type: MemoryType): string {
+  const explicit = asString(record.content);
+  if (explicit) return explicit;
+
+  if (type === 'factual') {
+    const subject = asString(record.subject);
+    const predicate = asString(record.predicate);
+    const objectValue = asString(record.object_value);
+    return [subject, predicate, objectValue].filter(Boolean).join(' ');
+  }
+
+  if (type === 'semantic') {
+    return asString(record.definition) ?? asString(record.concept_type) ?? '';
+  }
+
+  if (type === 'procedural') {
+    const steps = Array.isArray(record.steps)
+      ? record.steps.map((step) => {
+        const item = asRecord(step);
+        return asString(item.description) ?? asString(item.content);
+      }).filter(isString)
+      : [];
+    return steps.length > 0 ? steps.join('\n') : asString(record.skill_type) ?? '';
+  }
+
+  if (type === 'episodic') {
+    return asString(record.event_type) ?? asString(record.location) ?? '';
+  }
+
+  const taskContext = asRecord(record.task_context);
+  return asString(record.task_id) ?? asString(taskContext.summary) ?? '';
+}
+
+export function normalizeMemory(rawMemory: unknown): UserMemory {
+  const record = asRecord(rawMemory);
+  const type = normalizeType(record.memory_type ?? record.type);
+  const id = asString(record.id) ?? asString(record.memory_id) ?? `${type}-${Date.now()}`;
+
+  return {
+    id,
+    type,
+    content: fallbackContent(record, type),
+    created_at: asString(record.created_at),
+    updated_at: asString(record.updated_at),
+    importance_score: asNumber(record.importance_score),
+    confidence: asNumber(record.confidence),
+    tags: Array.isArray(record.tags) ? record.tags.map(asString).filter(isString) : [],
+    raw: record,
+  };
+}
+
+export function filterMemories(memories: UserMemory[], query: string): UserMemory[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return memories;
+
+  return memories.filter((memory) => {
+    return memory.content.toLowerCase().includes(normalized)
+      || memory.type.toLowerCase().includes(normalized)
+      || memory.tags?.some((tag) => tag.toLowerCase().includes(normalized));
+  });
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export class MemoryService {
+  async listMemories({ userId, type, query, limit = 100 }: ListMemoriesParams): Promise<UserMemory[]> {
+    const params = new URLSearchParams({
+      user_id: userId,
+      limit: String(limit),
+    });
+
+    if (type) params.set('memory_type', type);
+
+    const response = await fetch(`${memoryBaseUrl()}?${params.toString()}`, {
+      method: 'GET',
+      credentials: getCredentialsMode(),
+      headers: getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to list memories (${response.status})`);
+    }
+
+    const parsed = await parseJsonResponse(response);
+    const data = asRecord(parsed);
+    const rawMemories = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(data.memories) ? data.memories : [];
+    return filterMemories(rawMemories.map(normalizeMemory), query ?? '');
+  }
+
+  async updateMemory({ userId, memoryId, type, content }: UpdateMemoryParams): Promise<void> {
+    const params = new URLSearchParams({ user_id: userId });
+    const response = await fetch(`${memoryBaseUrl()}/${encodeURIComponent(type)}/${encodeURIComponent(memoryId)}?${params.toString()}`, {
+      method: 'PUT',
+      credentials: getCredentialsMode(),
+      headers: {
+        ...getAuthHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update memory (${response.status})`);
+    }
+  }
+
+  async deleteMemory({ userId, memoryId, type }: DeleteMemoryParams): Promise<void> {
+    const params = new URLSearchParams({ user_id: userId });
+    const response = await fetch(`${memoryBaseUrl()}/${encodeURIComponent(type)}/${encodeURIComponent(memoryId)}?${params.toString()}`, {
+      method: 'DELETE',
+      credentials: getCredentialsMode(),
+      headers: getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete memory (${response.status})`);
+    }
+  }
+}
+
+export const memoryService = new MemoryService();

--- a/src/components/ui/settings/MemoryManager.tsx
+++ b/src/components/ui/settings/MemoryManager.tsx
@@ -1,22 +1,31 @@
-/**
- * MemoryManager — View, edit, delete memories in settings (#203)
- * Connects to isA_OS memory CRUD API (#386).
- */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-interface Memory {
-  id: string;
-  type: 'factual' | 'episodic' | 'semantic' | 'procedural' | 'working';
-  content: string;
-  created_at?: string;
-}
+import {
+  filterMemories,
+  memoryService,
+  MEMORY_TYPES,
+  type MemoryType,
+  type UserMemory,
+} from '../../../api/memoryService';
+import { useAuth } from '../../../hooks/useAuth';
 
-const TYPE_LABELS: Record<string, string> = {
-  factual: 'Facts', episodic: 'Episodes', semantic: 'Knowledge',
-  procedural: 'How-to', working: 'Active',
+const TYPE_LABELS: Record<MemoryType, string> = {
+  factual: 'Facts',
+  episodic: 'Episodes',
+  semantic: 'Knowledge',
+  procedural: 'How-to',
+  working: 'Active',
 };
 
-const TYPE_COLORS: Record<string, string> = {
+const TYPE_DESCRIPTIONS: Record<MemoryType, string> = {
+  factual: 'Stable facts Mate has learned about you.',
+  episodic: 'Events and interactions from past sessions.',
+  semantic: 'Concepts, definitions, and domain knowledge.',
+  procedural: 'Steps, workflows, and preferred processes.',
+  working: 'Short-term context currently being used.',
+};
+
+const TYPE_COLORS: Record<MemoryType, string> = {
   factual: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
   episodic: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
   semantic: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
@@ -24,48 +33,161 @@ const TYPE_COLORS: Record<string, string> = {
   working: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
 };
 
+type GroupedMemories = Record<MemoryType, UserMemory[]>;
+
+export function resolveMemoryUserId(authUser: unknown): string | null {
+  if (!authUser || typeof authUser !== 'object') return null;
+
+  const record = authUser as Record<string, unknown>;
+  const candidate = record.sub ?? record.auth0_id ?? record.user_id ?? record.id;
+  return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null;
+}
+
+export function groupMemoriesByType(memories: UserMemory[]): GroupedMemories {
+  return MEMORY_TYPES.reduce<GroupedMemories>((groups, type) => {
+    groups[type] = memories.filter((memory) => memory.type === type);
+    return groups;
+  }, {
+    factual: [],
+    episodic: [],
+    semantic: [],
+    procedural: [],
+    working: [],
+  });
+}
+
+function formatMemoryDate(value?: string): string | null {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
 export const MemoryManager: React.FC = () => {
-  const [memories, setMemories] = useState<Memory[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { authUser, isLoading: authLoading } = useAuth();
+  const userId = resolveMemoryUserId(authUser);
+
+  const [memories, setMemories] = useState<UserMemory[]>([]);
+  const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Fetch memories from Mate API (isA_OS #386)
-    (async () => {
-      try {
-        const mateUrl = process.env.NEXT_PUBLIC_MATE_URL || 'http://localhost:18789';
-        const res = await fetch(`${mateUrl}/api/v1/memories`, { credentials: 'include' });
-        if (res.ok) {
-          const data = await res.json();
-          setMemories(Array.isArray(data) ? data : data.memories || []);
-        }
-      } catch {
-        // Memory API not available — show empty state
-      } finally {
+    let cancelled = false;
+
+    const loadMemories = async () => {
+      if (authLoading) return;
+
+      if (!userId) {
+        setMemories([]);
         setLoading(false);
+        return;
       }
-    })();
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const nextMemories = await memoryService.listMemories({ userId });
+        if (!cancelled) setMemories(nextMemories);
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(getErrorMessage(loadError, 'Failed to load memories'));
+          setMemories([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void loadMemories();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, userId]);
+
+  const filtered = useMemo(() => filterMemories(memories, search), [memories, search]);
+  const grouped = useMemo(() => groupMemoriesByType(filtered), [filtered]);
+  const allGrouped = useMemo(() => groupMemoriesByType(memories), [memories]);
+
+  const startEditing = useCallback((memory: UserMemory) => {
+    setEditingId(memory.id);
+    setEditContent(memory.content);
+    setError(null);
   }, []);
 
-  const filtered = memories.filter(m =>
-    !search || m.content.toLowerCase().includes(search.toLowerCase()) || m.type.includes(search.toLowerCase())
-  );
-
-  const grouped = filtered.reduce<Record<string, Memory[]>>((acc, m) => {
-    (acc[m.type] ??= []).push(m);
-    return acc;
-  }, {});
-
-  const handleDelete = useCallback((id: string) => {
-    setMemories(prev => prev.filter(m => m.id !== id));
-  }, []);
-
-  const handleSaveEdit = useCallback((id: string) => {
-    setMemories(prev => prev.map(m => m.id === id ? { ...m, content: editContent } : m));
+  const cancelEditing = useCallback(() => {
     setEditingId(null);
-  }, [editContent]);
+    setEditContent('');
+  }, []);
+
+  const handleDelete = useCallback(async (memory: UserMemory) => {
+    if (!userId) return;
+
+    setDeletingId(memory.id);
+    setError(null);
+
+    try {
+      await memoryService.deleteMemory({
+        userId,
+        memoryId: memory.id,
+        type: memory.type,
+      });
+      setMemories(prev => prev.filter(item => item.id !== memory.id));
+      if (editingId === memory.id) cancelEditing();
+    } catch (deleteError) {
+      setError(getErrorMessage(deleteError, 'Failed to delete memory'));
+    } finally {
+      setDeletingId(null);
+    }
+  }, [cancelEditing, editingId, userId]);
+
+  const handleSaveEdit = useCallback(async (memory: UserMemory) => {
+    if (!userId) return;
+
+    const nextContent = editContent.trim();
+    if (!nextContent) {
+      setError('Memory content cannot be empty.');
+      return;
+    }
+
+    setSavingId(memory.id);
+    setError(null);
+
+    try {
+      await memoryService.updateMemory({
+        userId,
+        memoryId: memory.id,
+        type: memory.type,
+        content: nextContent,
+      });
+      setMemories(prev => prev.map(item => (
+        item.id === memory.id
+          ? { ...item, content: nextContent, updated_at: new Date().toISOString() }
+          : item
+      )));
+      cancelEditing();
+    } catch (saveError) {
+      setError(getErrorMessage(saveError, 'Failed to update memory'));
+    } finally {
+      setSavingId(null);
+    }
+  }, [cancelEditing, editContent, userId]);
 
   return (
     <div className="space-y-4">
@@ -76,17 +198,48 @@ export const MemoryManager: React.FC = () => {
         </p>
       </div>
 
-      {/* Search */}
+      {!authLoading && !userId ? (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center dark:border-gray-700 dark:bg-white/5">
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Sign in to manage memories</p>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Memory records are scoped to your authenticated user id.
+          </p>
+        </div>
+      ) : null}
+
       <input
         value={search}
         onChange={e => setSearch(e.target.value)}
         placeholder="Search memories..."
+        disabled={!userId || loading}
         className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
 
-      {loading ? (
+      {userId ? (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+          {MEMORY_TYPES.map((type) => (
+            <div key={type} className="rounded-xl border border-gray-100 bg-white p-2.5 dark:border-gray-800 dark:bg-gray-900/40">
+              <div className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${TYPE_COLORS[type]}`}>
+                {TYPE_LABELS[type]}
+              </div>
+              <div className="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+                {allGrouped[type].length}
+              </div>
+              <div className="truncate text-[11px] text-gray-400">{type}</div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {authLoading || loading ? (
         <div className="py-8 text-center text-sm text-gray-400">Loading memories...</div>
-      ) : memories.length === 0 ? (
+      ) : userId && memories.length === 0 ? (
         <div className="py-12 text-center">
           <svg className="w-12 h-12 mx-auto text-gray-200 dark:text-gray-700 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
@@ -94,50 +247,102 @@ export const MemoryManager: React.FC = () => {
           <p className="text-sm text-gray-500 dark:text-gray-400">No memories yet</p>
           <p className="text-xs text-gray-400 mt-1">Mate will learn about you through conversations</p>
         </div>
-      ) : (
-        Object.entries(grouped).map(([type, mems]) => (
-          <div key={type}>
-            <div className="flex items-center gap-2 mb-2">
-              <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${TYPE_COLORS[type] || TYPE_COLORS.working}`}>
-                {TYPE_LABELS[type] || type}
-              </span>
-              <span className="text-xs text-gray-400">{mems.length}</span>
-            </div>
-            <div className="space-y-2">
-              {mems.map(m => (
-                <div key={m.id} className="group flex items-start gap-2 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
-                  {editingId === m.id ? (
-                    <div className="flex-1">
-                      <textarea
-                        value={editContent}
-                        onChange={e => setEditContent(e.target.value)}
-                        className="w-full p-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-none focus:outline-none focus:ring-1 focus:ring-blue-500"
-                        rows={2}
-                      />
-                      <div className="flex gap-1 mt-1">
-                        <button onClick={() => handleSaveEdit(m.id)} className="text-xs px-2 py-1 bg-blue-500 text-white rounded">Save</button>
-                        <button onClick={() => setEditingId(null)} className="text-xs px-2 py-1 text-gray-500 hover:text-gray-700">Cancel</button>
-                      </div>
+      ) : userId && filtered.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-400">No memories match "{search}".</div>
+      ) : userId ? (
+        MEMORY_TYPES.map((type) => {
+          const mems = grouped[type];
+          if (mems.length === 0) return null;
+
+          return (
+            <div key={type}>
+              <div className="mb-2 flex items-center gap-2">
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[type]}`}>
+                  {TYPE_LABELS[type]}
+                </span>
+                <span className="text-xs text-gray-400">{mems.length}</span>
+                <span className="hidden text-xs text-gray-400 sm:inline">{TYPE_DESCRIPTIONS[type]}</span>
+              </div>
+              <div className="space-y-2">
+                {mems.map((memory) => {
+                  const isEditing = editingId === memory.id;
+                  const isSaving = savingId === memory.id;
+                  const isDeleting = deletingId === memory.id;
+                  const createdAt = formatMemoryDate(memory.created_at ?? memory.updated_at);
+
+                  return (
+                    <div key={memory.id} className="group rounded-xl border border-transparent px-3 py-2 transition-colors hover:border-gray-100 hover:bg-gray-50 dark:hover:border-white/10 dark:hover:bg-white/5">
+                      {isEditing ? (
+                        <div>
+                          <textarea
+                            value={editContent}
+                            onChange={e => setEditContent(e.target.value)}
+                            className="w-full resize-none rounded-lg border border-gray-200 bg-white p-2 text-sm text-gray-900 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                            rows={3}
+                          />
+                          <div className="mt-2 flex gap-1">
+                            <button
+                              onClick={() => void handleSaveEdit(memory)}
+                              disabled={isSaving}
+                              className="rounded bg-blue-500 px-2 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {isSaving ? 'Saving...' : 'Save'}
+                            </button>
+                            <button
+                              onClick={cancelEditing}
+                              disabled={isSaving}
+                              className="rounded px-2 py-1 text-xs text-gray-500 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:text-gray-200"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-start gap-2">
+                          <div className="min-w-0 flex-1">
+                            <p className="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300">{memory.content}</p>
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-gray-400">
+                              <span>{memory.type}</span>
+                              {createdAt ? <span>{createdAt}</span> : null}
+                              {memory.tags?.map((tag) => (
+                                <span key={tag} className="rounded-full bg-gray-100 px-1.5 py-0.5 dark:bg-gray-800">
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                          <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                            <button
+                              onClick={() => startEditing(memory)}
+                              disabled={isDeleting}
+                              className="p-1 text-gray-400 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                              title="Edit"
+                            >
+                              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>
+                            </button>
+                            <button
+                              onClick={() => void handleDelete(memory)}
+                              disabled={isDeleting}
+                              className="p-1 text-gray-400 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+                              title="Delete"
+                            >
+                              {isDeleting ? (
+                                <span className="text-[11px]">...</span>
+                              ) : (
+                                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
+                              )}
+                            </button>
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  ) : (
-                    <>
-                      <p className="flex-1 text-sm text-gray-700 dark:text-gray-300">{m.content}</p>
-                      <div className="opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
-                        <button onClick={() => { setEditingId(m.id); setEditContent(m.content); }} className="p-1 text-gray-400 hover:text-blue-500" title="Edit">
-                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>
-                        </button>
-                        <button onClick={() => handleDelete(m.id)} className="p-1 text-gray-400 hover:text-red-500" title="Delete">
-                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-                        </button>
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))
-      )}
+          );
+        })
+      ) : null}
     </div>
   );
 };

--- a/src/components/ui/settings/__tests__/MemoryManager.test.tsx
+++ b/src/components/ui/settings/__tests__/MemoryManager.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+
+import { groupMemoriesByType, resolveMemoryUserId } from '../MemoryManager';
+import type { UserMemory } from '../../../../api/memoryService';
+
+function memory(id: string, type: UserMemory['type']): UserMemory {
+  return {
+    id,
+    type,
+    content: `${type} memory`,
+    raw: {},
+  };
+}
+
+describe('MemoryManager helpers', () => {
+  test('resolves the authenticated memory user id from supported auth shapes', () => {
+    expect(resolveMemoryUserId({ sub: 'auth0|abc' })).toBe('auth0|abc');
+    expect(resolveMemoryUserId({ auth0_id: 'auth0|legacy' })).toBe('auth0|legacy');
+    expect(resolveMemoryUserId({ user_id: 'usr-1' })).toBe('usr-1');
+    expect(resolveMemoryUserId({ id: 'fallback-id' })).toBe('fallback-id');
+    expect(resolveMemoryUserId({ sub: '   ' })).toBeNull();
+    expect(resolveMemoryUserId(null)).toBeNull();
+  });
+
+  test('groups every supported memory type for settings display', () => {
+    const grouped = groupMemoriesByType([
+      memory('fact-1', 'factual'),
+      memory('fact-2', 'factual'),
+      memory('work-1', 'working'),
+    ]);
+
+    expect(grouped.factual).toHaveLength(2);
+    expect(grouped.episodic).toHaveLength(0);
+    expect(grouped.semantic).toHaveLength(0);
+    expect(grouped.procedural).toHaveLength(0);
+    expect(grouped.working).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Connects the settings MemoryManager to the gateway memory CRUD API so users can view, search, edit, and delete memories from their authenticated account.

## Changes
- Added memoryService for list/update/delete against /api/v1/memories with memory normalization for factual, episodic, semantic, procedural, and working records.
- Updated Settings > Memory to use authenticated user id, display all memory type counts, handle loading/error/sign-in states, and persist edit/delete operations through the API.
- Added unit/helper tests for the API service and settings memory grouping/user id resolution.

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | src/api/__tests__/memoryService.test.ts, src/components/ui/settings/__tests__/MemoryManager.test.tsx | Pass, 7 tests |
| L2 Component | Settings MemoryManager helper coverage | Pass |
| L3 Integration | Gateway memory API contract mocked at service boundary | Pass |
| L4 API | Not run against live service | N/A |
| L5 Smoke | Full npm test attempted | Fails on unrelated existing suites: chatService, MateEventAdapter, gateway config tests, missing RealAPIEventMapping |

Additional checks:
- git diff --check on touched files passed.
- Touched-file TypeScript diagnostic filter returned no errors; full tsc still fails on existing repo type debt.

## Related Issues
Fixes #203
Parent Epic: #183