### PR TITLE
fix(ui): wire new chat shortcut

### DIFF
--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -3,7 +3,6 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import { GATEWAY_ENDPOINTS } from '../config/gatewayConfig';
-import { gatewayFetch } from '../config/gatewayConfig';
 
 export interface AvailableModel {
   id: string;

--- a/src/modules/AppModule.tsx
+++ b/src/modules/AppModule.tsx
@@ -90,12 +90,17 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
   const [showSettings, setShowSettings] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
 
+  const handleStartNewChat = useCallback(() => {
+    useAppStore.getState().startNewChat();
+  }, []);
+
   // Register global keyboard shortcuts (#198)
   useKeyboardShortcuts(useMemo(() => [
     { key: 'k', meta: true, description: 'Search conversations', category: 'Navigation', action: () => setShowCommandPalette(true) },
     { key: ',', meta: true, description: 'Open settings', category: 'Navigation', action: () => setShowSettings(true) },
+    { key: 'n', meta: true, description: 'New chat', category: 'Chat', action: handleStartNewChat },
     { key: '?', description: 'Show keyboard shortcuts', category: 'Help', action: () => setShowShortcuts(true) },
-  ], []));
+  ], [handleStartNewChat]));
   
   // Right panel state
   const [showRightPanel, setShowRightPanel] = useState(false);
@@ -352,6 +357,7 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
           open={showCommandPalette}
           onClose={() => setShowCommandPalette(false)}
           onAction={(id) => {
+            if (id === 'new-chat') handleStartNewChat();
             if (id === 'settings') setShowSettings(true);
           }}
         />


### PR DESCRIPTION
## Summary
Completes a small #181 navigation/settings integration gap by making the advertised New Chat command executable from both Cmd+N and the Command Palette action list. Also removes a stale named import from useModelSelection that pointed at a non-exported gateway helper and produced a touched-file TypeScript diagnostic.

## Changes
- Wire Cmd+N through the global keyboard shortcut registry to start a new chat.
- Wire the Command Palette New Chat action to the same app-level startNewChat behavior.
- Remove the unused invalid gatewayFetch import from useModelSelection.

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | src/config/__tests__/sdkResolution.test.ts, src/hooks/__tests__/useProgressiveStage.test.ts | Pass, 10 tests |
| L2 Component | Not available for AppModule keyboard event wiring in current node test setup | N/A |
| L3 Integration | Touched-file TypeScript diagnostic filter | Pass, no touched-file diagnostics |
| L4 API | Not applicable | N/A |
| L5 Smoke | Not run for this small slice | N/A |

Additional checks:
- git diff --check on touched files passed.
- Full repo tsc is still blocked by existing unrelated type debt outside this slice.

## Related Issues
Related to #181