### PR TITLE
fix(ui): wire command palette conversation search

### DIFF
--- a/src/components/ui/chat/CommandPalette.tsx
+++ b/src/components/ui/chat/CommandPalette.tsx
@@ -7,9 +7,10 @@
  * - Backdrop: rgba(0,0,0,0.5)
  */
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { GATEWAY_ENDPOINTS } from '../../../config/gatewayConfig';
+import { GATEWAY_ENDPOINTS, getAuthHeaders } from '../../../config/gatewayConfig';
+import { getCredentialsMode } from '../../../utils/authCookieHelper';
 
-interface SearchResult {
+export interface SearchResult {
   id: string;
   title: string;
   snippet?: string;
@@ -25,8 +26,45 @@ const DEFAULT_ACTIONS: SearchResult[] = [
 interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
-  onSelectConversation?: (sessionId: string) => void;
+  onSelectConversation?: (sessionId: string, result: SearchResult) => void;
   onAction?: (actionId: string) => void;
+}
+
+interface CommandPaletteActivationHandlers {
+  onClose: () => void;
+  onSelectConversation?: (sessionId: string, result: SearchResult) => void;
+  onAction?: (actionId: string) => void;
+}
+
+export function buildCommandPaletteSearchRequest(query: string, limit = 10): {
+  url: string;
+  init: RequestInit;
+} {
+  const params = new URLSearchParams({
+    q: query,
+    limit: String(limit),
+  });
+
+  return {
+    url: `${GATEWAY_ENDPOINTS.SESSIONS.SEARCH}?${params.toString()}`,
+    init: {
+      credentials: getCredentialsMode(),
+      headers: getAuthHeaders(),
+    },
+  };
+}
+
+export function activateCommandPaletteResult(
+  item: SearchResult,
+  handlers: CommandPaletteActivationHandlers,
+): void {
+  if (item.type === 'conversation') {
+    handlers.onSelectConversation?.(item.id, item);
+  } else {
+    handlers.onAction?.(item.id);
+  }
+
+  handlers.onClose();
 }
 
 export const CommandPalette: React.FC<CommandPaletteProps> = ({
@@ -58,7 +96,8 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
     }
     setLoading(true);
     try {
-      const res = await fetch(`${GATEWAY_ENDPOINTS.SESSIONS.SEARCH}?q=${encodeURIComponent(q)}&limit=10`);
+      const { url, init } = buildCommandPaletteSearchRequest(q);
+      const res = await fetch(url, init);
       if (res.ok) {
         const data = await res.json();
         const sessions = (data.results || data.sessions || []).map((s: any) => ({
@@ -69,13 +108,24 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
           timestamp: s.created_at || s.timestamp,
         }));
         setResults(sessions.length > 0 ? sessions : DEFAULT_ACTIONS);
+      } else {
+        setResults(DEFAULT_ACTIONS);
       }
     } catch {
       // Silently fail — show default actions
+      setResults(DEFAULT_ACTIONS);
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const activateResult = useCallback((item: SearchResult) => {
+    activateCommandPaletteResult(item, {
+      onSelectConversation,
+      onAction,
+      onClose,
+    });
+  }, [onAction, onClose, onSelectConversation]);
 
   // Debounced search
   const handleQueryChange = (value: string) => {
@@ -95,10 +145,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
       setSelectedIndex(i => Math.max(i - 1, 0));
     } else if (e.key === 'Enter' && results[selectedIndex]) {
       e.preventDefault();
-      const item = results[selectedIndex];
-      if (item.type === 'conversation') onSelectConversation?.(item.id);
-      else onAction?.(item.id);
-      onClose();
+      activateResult(results[selectedIndex]);
     } else if (e.key === 'Escape') {
       onClose();
     }
@@ -135,11 +182,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
           {results.map((item, i) => (
             <button
               key={item.id}
-              onClick={() => {
-                if (item.type === 'conversation') onSelectConversation?.(item.id);
-                else onAction?.(item.id);
-                onClose();
-              }}
+              onClick={() => activateResult(item)}
               className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors ${
                 i === selectedIndex
                   ? 'bg-gray-100 dark:bg-white/10'

--- a/src/components/ui/chat/__tests__/CommandPalette.test.ts
+++ b/src/components/ui/chat/__tests__/CommandPalette.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+import {
+  activateCommandPaletteResult,
+  buildCommandPaletteSearchRequest,
+} from '../CommandPalette';
+import { authTokenStore } from '../../../../stores/authTokenStore';
+
+describe('CommandPalette helpers', () => {
+  beforeEach(() => {
+    authTokenStore.clearToken();
+  });
+
+  test('builds an authenticated gateway search request', () => {
+    authTokenStore.setToken('test-token');
+
+    const request = buildCommandPaletteSearchRequest('roadmap search');
+    const url = new URL(request.url);
+
+    expect(url.pathname).toContain('/sessions/search');
+    expect(url.searchParams.get('q')).toBe('roadmap search');
+    expect(url.searchParams.get('limit')).toBe('10');
+    expect(request.init.credentials).toBe('include');
+    expect(request.init.headers).toMatchObject({
+      Authorization: 'Bearer test-token',
+    });
+  });
+
+  test('routes conversation selection before closing the palette', () => {
+    const onSelectConversation = vi.fn();
+    const onAction = vi.fn();
+    const onClose = vi.fn();
+
+    activateCommandPaletteResult(
+      { id: 'session-123', title: 'Roadmap', type: 'conversation' },
+      { onSelectConversation, onAction, onClose },
+    );
+
+    expect(onSelectConversation).toHaveBeenCalledWith(
+      'session-123',
+      expect.objectContaining({ title: 'Roadmap' }),
+    );
+    expect(onAction).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  test('routes action selection through the same activation helper', () => {
+    const onSelectConversation = vi.fn();
+    const onAction = vi.fn();
+    const onClose = vi.fn();
+
+    activateCommandPaletteResult(
+      { id: 'settings', title: 'Settings', type: 'action' },
+      { onSelectConversation, onAction, onClose },
+    );
+
+    expect(onAction).toHaveBeenCalledWith('settings');
+    expect(onSelectConversation).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/modules/AppModule.tsx
+++ b/src/modules/AppModule.tsx
@@ -42,6 +42,7 @@ import { RightSidebarLayout } from '../components/ui/chat/RightSidebarLayout';
 import UserButtonContainer from '../components/ui/user/UserButtonContainer';
 import { UserPortal } from '../components/ui/user/UserPortal';
 import { CommandPalette } from '../components/ui/chat/CommandPalette';
+import type { SearchResult } from '../components/ui/chat/CommandPalette';
 import { SettingsModal } from '../components/ui/settings/SettingsModal';
 import { ArtifactCanvas } from '../components/ui/chat/ArtifactCanvas';
 import { ArtifactSheet } from '../components/ui/chat/ArtifactSheet';
@@ -54,6 +55,9 @@ import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useChat } from '../hooks/useChat';
 import { useArtifactLogic } from './ArtifactModule';
 import { useAppStore } from '../stores/useAppStore';
+import { useChatStore } from '../stores/useChatStore';
+import { useSessionStore } from '../stores/useSessionStore';
+import type { ChatSession } from '../stores/useSessionStore';
 import { widgetHandler } from '../components/core/WidgetHandler';
 import { logger, LogCategory } from '../utils/logger';
 import { AppId } from '../types/appTypes';
@@ -128,6 +132,47 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
     setShowRightSidebar,
     setTriggeredAppInput
   } = useAppStore();
+
+  const handleSelectConversation = useCallback((sessionId: string, result?: SearchResult) => {
+    const sessionStore = useSessionStore.getState();
+    let selectedSession = sessionStore.getSessionById(sessionId);
+
+    if (!selectedSession && result) {
+      const fallbackSession: ChatSession = {
+        id: sessionId,
+        title: result.title || 'Untitled',
+        lastMessage: result.snippet || 'No messages',
+        timestamp: result.timestamp || new Date().toISOString(),
+        messageCount: 0,
+        artifacts: [],
+        messages: [],
+        metadata: {
+          api_session_id: sessionId,
+          source: 'command_palette_search',
+        },
+      };
+
+      useSessionStore.setState((state) => ({
+        sessions: [...state.sessions, fallbackSession],
+      }));
+      selectedSession = fallbackSession;
+    } else if (!selectedSession) {
+      logger.warn(LogCategory.CHAT_FLOW, 'Command palette selected a session that is not loaded locally', {
+        sessionId,
+      });
+    }
+
+    sessionStore.selectSession(sessionId);
+    useChatStore.getState().loadMessagesFromSession(sessionId);
+    setTriggeredAppInput('');
+    setCurrentApp(null);
+    setShowRightSidebar(false);
+
+    logger.info(LogCategory.CHAT_FLOW, 'Command palette selected conversation', {
+      sessionId,
+      sessionLoaded: !!selectedSession,
+    });
+  }, [setCurrentApp, setShowRightSidebar, setTriggeredAppInput]);
 
   // Create translated available apps
   const availableApps = useMemo(() => [
@@ -356,6 +401,7 @@ export const AppModule: React.FC<AppModuleProps> = (props) => {
         <CommandPalette
           open={showCommandPalette}
           onClose={() => setShowCommandPalette(false)}
+          onSelectConversation={handleSelectConversation}
           onAction={(id) => {
             if (id === 'new-chat') handleStartNewChat();
             if (id === 'settings') setShowSettings(true);


### PR DESCRIPTION
## Summary
- Adds an authenticated command-palette search request builder using gateway credentials and auth headers.
- Uses one activation helper for keyboard and mouse result selection.
- Wires command-palette conversation selection into `AppModule` so selecting a result changes the active session and reloads chat-store messages.
- Adds a lightweight fallback session when a backend search result is not already loaded locally.

Fixes #346
Parent Epic: #181

## Tests
| Check | Result |
| --- | --- |
| `npm test -- src/components/ui/chat/__tests__/CommandPalette.test.ts` | Passed, 3 tests |
| `npm test` | Failed on existing unrelated baseline failures: missing `RealAPIEventMapping`, chat streaming callback expectations, `MateEventAdapter` lifecycle count, and config endpoint expectation drift. New `CommandPalette` tests passed inside the full run. |
| `npx tsc --noEmit --pretty false` | Failed on existing repo-wide type debt: desktop Electron/Forge types, demo imports, SDK React type duplication, session/theme/task/user type issues. No changed-file errors appeared after the callback ordering fix. |

## Notes
- Existing unrelated worktree changes were left unstaged and untouched.
