### PR TITLE
feat(core): persist artifact lifecycle state

### DIFF
--- a/src/stores/__tests__/useArtifactManager.test.ts
+++ b/src/stores/__tests__/useArtifactManager.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+type ArtifactManagerModule = typeof import('../useArtifactManager');
+type ArtifactTypesModule = typeof import('../../types/artifactTypes');
+
+let useArtifactManager: ArtifactManagerModule['useArtifactManager'];
+let getActiveVersion: ArtifactTypesModule['getActiveVersion'];
+let artifactManagerStorageKey: string;
+
+async function loadArtifactManager() {
+  vi.resetModules();
+  vi.stubGlobal('localStorage', localStorageMock);
+
+  const artifactManagerModule = await import('../useArtifactManager');
+  const artifactTypesModule = await import('../../types/artifactTypes');
+
+  useArtifactManager = artifactManagerModule.useArtifactManager;
+  artifactManagerStorageKey = artifactManagerModule.ARTIFACT_MANAGER_STORAGE_KEY;
+  getActiveVersion = artifactTypesModule.getActiveVersion;
+
+  await (useArtifactManager as any).persist?.rehydrate?.();
+}
+
+function createA2UISurface() {
+  const surfaceState = {
+    surfaceId: 'surface_trip_plan',
+    phase: 'streaming',
+    components: [
+      { id: 'summary', type: 'text', value: 'Draft itinerary' },
+    ],
+  };
+
+  const artifactId = useArtifactManager.getState().createArtifact({
+    title: 'Trip planner',
+    content: '{"title":"Draft itinerary"}',
+    contentType: 'a2ui_surface',
+    sessionId: 'session-1',
+    sourceMessageId: 'msg-1',
+    a2uiState: surfaceState,
+  });
+
+  return { artifactId, surfaceState };
+}
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('useArtifactManager', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    await loadArtifactManager();
+    useArtifactManager.setState({
+      artifacts: {},
+      openArtifactId: null,
+      panelLayout: 'closed',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  test('creates an A2UI surface artifact with initial state and shared panel identity', () => {
+    const { artifactId, surfaceState } = createA2UISurface();
+    const artifact = useArtifactManager.getState().getArtifact(artifactId);
+
+    expect(artifact).toBeDefined();
+    expect(artifact?.sourceMessageId).toBe('msg-1');
+    expect(getActiveVersion(artifact!).a2uiState).toEqual(surfaceState);
+
+    useArtifactManager.getState().openArtifact(artifactId, 'inspect');
+    expect(useArtifactManager.getState().openArtifactId).toBe(artifactId);
+    expect(useArtifactManager.getState().panelLayout).toBe('inspect');
+
+    useArtifactManager.getState().openArtifact(artifactId, 'canvas');
+    expect(useArtifactManager.getState().openArtifactId).toBe(artifactId);
+    expect(useArtifactManager.getState().panelLayout).toBe('canvas');
+    expect(useArtifactManager.getState().getSessionArtifacts('session-1')).toHaveLength(1);
+  });
+
+  test('adds immutable versions for artifact edits without mutating history', () => {
+    const { artifactId, surfaceState } = createA2UISurface();
+    const original = useArtifactManager.getState().getArtifact(artifactId)!;
+    const originalVersion = { ...original.versions[0] };
+
+    useArtifactManager
+      .getState()
+      .addVersion(artifactId, '{"title":"Updated itinerary"}', 'Make the itinerary actionable');
+
+    const updated = useArtifactManager.getState().getArtifact(artifactId)!;
+    expect(updated.versions).toHaveLength(2);
+    expect(updated.activeVersionIndex).toBe(1);
+    expect(updated.versions[0]).toEqual(originalVersion);
+    expect(updated.versions[0].content).toBe('{"title":"Draft itinerary"}');
+    expect(updated.versions[0].a2uiState).toEqual(surfaceState);
+    expect(updated.versions[1]).toMatchObject({
+      number: 2,
+      content: '{"title":"Updated itinerary"}',
+      contentType: 'a2ui_surface',
+      instruction: 'Make the itinerary actionable',
+      createdBy: 'agent',
+      a2uiState: surfaceState,
+    });
+  });
+
+  test('forks from the active version while preserving the A2UI surface state', () => {
+    const { artifactId, surfaceState } = createA2UISurface();
+    useArtifactManager
+      .getState()
+      .addVersion(artifactId, '{"title":"Updated itinerary"}', 'Make the itinerary actionable');
+
+    const forkedId = useArtifactManager.getState().forkArtifact(artifactId);
+    const forked = forkedId ? useArtifactManager.getState().getArtifact(forkedId) : undefined;
+
+    expect(forkedId).toBeTruthy();
+    expect(forked).toBeDefined();
+    expect(forked?.parentId).toBe(artifactId);
+    expect(forked?.versions).toHaveLength(1);
+    expect(forked?.versions[0]).toMatchObject({
+      number: 1,
+      content: '{"title":"Updated itinerary"}',
+      contentType: 'a2ui_surface',
+      a2uiState: surfaceState,
+    });
+  });
+
+  test('persists artifact versions across store reloads', async () => {
+    const { artifactId, surfaceState } = createA2UISurface();
+    useArtifactManager
+      .getState()
+      .addVersion(artifactId, '{"title":"Updated itinerary"}', 'Make the itinerary actionable');
+
+    const stored = localStorageMock.getItem(artifactManagerStorageKey);
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored!).state.artifacts[artifactId].versions).toHaveLength(2);
+
+    await loadArtifactManager();
+
+    const restored = useArtifactManager.getState().getArtifact(artifactId);
+    expect(restored).toBeDefined();
+    expect(restored?.versions).toHaveLength(2);
+    expect(restored?.activeVersionIndex).toBe(1);
+    expect(restored?.versions[0].a2uiState).toEqual(surfaceState);
+    expect(restored?.versions[1]).toMatchObject({
+      content: '{"title":"Updated itinerary"}',
+      instruction: 'Make the itinerary actionable',
+      a2uiState: surfaceState,
+    });
+  });
+
+  test('registers completed chat A2UI artifact messages with surface state', async () => {
+    const { useChatStore } = await import('../useChatStore');
+    const surfaceState = {
+      surfaceId: 'surface_from_mate',
+      phase: 'complete',
+      components: [{ id: 'answer', type: 'markdown', value: 'Ready' }],
+    };
+
+    useChatStore.setState({
+      messages: [],
+      streamingBuffers: {},
+      streamingLastFlush: {},
+    });
+
+    useChatStore.getState().addMessage({
+      id: 'msg-a2ui',
+      type: 'artifact',
+      role: 'assistant',
+      content: 'Generated Mate surface',
+      timestamp: '2026-04-23T08:00:00.000Z',
+      userPrompt: 'Build an interactive answer',
+      artifact: {
+        id: 'artifact-a2ui',
+        widgetType: 'mate',
+        widgetName: 'Mate Surface',
+        version: 1,
+        contentType: 'a2ui_surface',
+        content: { title: 'Interactive answer' },
+        a2uiState: surfaceState,
+      },
+      isStreaming: false,
+    } as any);
+
+    await flushAsyncWork();
+
+    const artifact = Object.values(useArtifactManager.getState().artifacts).find(
+      node => node.sourceMessageId === 'msg-a2ui',
+    );
+
+    expect(artifact).toBeDefined();
+    expect(artifact?.contentType).toBe('a2ui_surface');
+    expect(getActiveVersion(artifact!).content).toBe(JSON.stringify({ title: 'Interactive answer' }, null, 2));
+    expect(getActiveVersion(artifact!).a2uiState).toEqual(surfaceState);
+  });
+});

--- a/src/stores/useArtifactManager.ts
+++ b/src/stores/useArtifactManager.ts
@@ -5,7 +5,7 @@
  * All artifacts flow through this store — widgets create, panel displays, chat previews.
  */
 import { create } from 'zustand';
-import { subscribeWithSelector } from 'zustand/middleware';
+import { persist, subscribeWithSelector } from 'zustand/middleware';
 import type {
   ArtifactNode,
   ArtifactContentType,
@@ -36,6 +36,7 @@ interface ArtifactManagerActions {
     filename?: string;
     sessionId?: string;
     sourceMessageId?: string;
+    a2uiState?: Record<string, unknown>;
   }) => string;
 
   /** Add a new version to an existing artifact */
@@ -65,87 +66,98 @@ interface ArtifactManagerActions {
 
 type ArtifactManagerStore = ArtifactManagerState & ArtifactManagerActions;
 
+export const ARTIFACT_MANAGER_STORAGE_KEY = 'isa-artifact-manager';
+
 export const useArtifactManager = create<ArtifactManagerStore>()(
-  subscribeWithSelector((set, get) => ({
-    artifacts: {},
-    openArtifactId: null,
-    panelLayout: 'closed',
+  subscribeWithSelector(
+    persist(
+      (set, get) => ({
+        artifacts: {},
+        openArtifactId: null,
+        panelLayout: 'closed',
 
-    createArtifact: (params) => {
-      const node = createArtifactNode(params);
-      set(state => ({
-        artifacts: { ...state.artifacts, [node.id]: node },
-      }));
-      return node.id;
-    },
+        createArtifact: (params) => {
+          const node = createArtifactNode(params);
+          set(state => ({
+            artifacts: { ...state.artifacts, [node.id]: node },
+          }));
+          return node.id;
+        },
 
-    addVersion: (artifactId, content, instruction) => {
-      set(state => {
-        const artifact = state.artifacts[artifactId];
-        if (!artifact) return state;
-        const updated = addArtifactVersion(artifact, content, instruction);
-        return {
-          artifacts: { ...state.artifacts, [artifactId]: updated },
-        };
-      });
-    },
+        addVersion: (artifactId, content, instruction) => {
+          set(state => {
+            const artifact = state.artifacts[artifactId];
+            if (!artifact) return state;
+            const updated = addArtifactVersion(artifact, content, instruction);
+            return {
+              artifacts: { ...state.artifacts, [artifactId]: updated },
+            };
+          });
+        },
 
-    setActiveVersion: (artifactId, versionIndex) => {
-      set(state => {
-        const artifact = state.artifacts[artifactId];
-        if (!artifact || versionIndex < 0 || versionIndex >= artifact.versions.length) return state;
-        return {
-          artifacts: {
-            ...state.artifacts,
-            [artifactId]: { ...artifact, activeVersionIndex: versionIndex },
-          },
-        };
-      });
-    },
+        setActiveVersion: (artifactId, versionIndex) => {
+          set(state => {
+            const artifact = state.artifacts[artifactId];
+            if (!artifact || versionIndex < 0 || versionIndex >= artifact.versions.length) return state;
+            return {
+              artifacts: {
+                ...state.artifacts,
+                [artifactId]: { ...artifact, activeVersionIndex: versionIndex },
+              },
+            };
+          });
+        },
 
-    forkArtifact: (artifactId) => {
-      const artifact = get().artifacts[artifactId];
-      if (!artifact) return null;
-      const activeVersion = getActiveVersion(artifact);
-      const forked = createArtifactNode({
-        title: `${artifact.title} (fork)`,
-        content: activeVersion.content,
-        contentType: artifact.contentType,
-        language: activeVersion.language,
-        widgetType: artifact.widgetType,
-        sessionId: artifact.sessionId,
-      });
-      const forkedWithParent = { ...forked, parentId: artifactId };
-      set(state => ({
-        artifacts: { ...state.artifacts, [forkedWithParent.id]: forkedWithParent },
-      }));
-      return forkedWithParent.id;
-    },
+        forkArtifact: (artifactId) => {
+          const artifact = get().artifacts[artifactId];
+          if (!artifact) return null;
+          const activeVersion = getActiveVersion(artifact);
+          const forked = createArtifactNode({
+            title: `${artifact.title} (fork)`,
+            content: activeVersion.content,
+            contentType: artifact.contentType,
+            language: activeVersion.language,
+            widgetType: artifact.widgetType,
+            sessionId: artifact.sessionId,
+            a2uiState: activeVersion.a2uiState,
+          });
+          const forkedWithParent = { ...forked, parentId: artifactId };
+          set(state => ({
+            artifacts: { ...state.artifacts, [forkedWithParent.id]: forkedWithParent },
+          }));
+          return forkedWithParent.id;
+        },
 
-    openArtifact: (artifactId, layout = 'inspect') => {
-      set({ openArtifactId: artifactId, panelLayout: layout });
-    },
+        openArtifact: (artifactId, layout = 'inspect') => {
+          set({ openArtifactId: artifactId, panelLayout: layout });
+        },
 
-    closePanel: () => {
-      set({ openArtifactId: null, panelLayout: 'closed' });
-    },
+        closePanel: () => {
+          set({ openArtifactId: null, panelLayout: 'closed' });
+        },
 
-    removeArtifact: (artifactId) => {
-      set(state => {
-        const { [artifactId]: _, ...rest } = state.artifacts;
-        return {
-          artifacts: rest,
-          openArtifactId: state.openArtifactId === artifactId ? null : state.openArtifactId,
-          panelLayout: state.openArtifactId === artifactId ? 'closed' : state.panelLayout,
-        };
-      });
-    },
+        removeArtifact: (artifactId) => {
+          set(state => {
+            const { [artifactId]: _, ...rest } = state.artifacts;
+            return {
+              artifacts: rest,
+              openArtifactId: state.openArtifactId === artifactId ? null : state.openArtifactId,
+              panelLayout: state.openArtifactId === artifactId ? 'closed' : state.panelLayout,
+            };
+          });
+        },
 
-    getArtifact: (artifactId) => get().artifacts[artifactId],
+        getArtifact: (artifactId) => get().artifacts[artifactId],
 
-    getSessionArtifacts: (sessionId) =>
-      Object.values(get().artifacts).filter(a => a.sessionId === sessionId),
-  }))
+        getSessionArtifacts: (sessionId) =>
+          Object.values(get().artifacts).filter(a => a.sessionId === sessionId),
+      }),
+      {
+        name: ARTIFACT_MANAGER_STORAGE_KEY,
+        partialize: state => ({ artifacts: state.artifacts }),
+      },
+    ),
+  )
 );
 
 // Selectors

--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -193,13 +193,15 @@ export const useChatStore = create<ChatStore>()(
             // Only register if not already in the store
             const existing = Object.values(am.artifacts).find(a => a.sourceMessageId === message.id);
             if (!existing) {
+              const a2uiState = art.a2uiState ?? art.metadata?.a2uiState ?? art.metadata?.surfaceState;
               am.createArtifact({
                 title: art.widgetName || art.widgetType || 'Artifact',
                 content: typeof art.content === 'string' ? art.content : JSON.stringify(art.content, null, 2),
-                contentType: art.contentType || 'text',
+                contentType: art.contentType || (a2uiState ? 'a2ui_surface' : 'text'),
                 widgetType: art.widgetType,
                 sessionId: (message as any).sessionId,
                 sourceMessageId: message.id,
+                a2uiState,
               });
             }
           }

--- a/src/types/artifactTypes.ts
+++ b/src/types/artifactTypes.ts
@@ -172,12 +172,14 @@ export function addArtifactVersion(
   createdBy: 'user' | 'agent' = 'agent',
 ): ArtifactNode {
   const now = new Date().toISOString();
+  const activeVersion = getActiveVersion(artifact);
   const newVersion: ArtifactVersion = {
     versionId: `v_${Date.now().toString(36)}`,
     number: artifact.versions.length + 1,
     content,
     contentType: artifact.contentType,
-    language: artifact.versions[0]?.language,
+    language: activeVersion.language,
+    a2uiState: activeVersion.a2uiState,
     instruction,
     createdBy,
     createdAt: now,

--- a/src/types/chatTypes.ts
+++ b/src/types/chatTypes.ts
@@ -22,6 +22,8 @@
  *   - 用户认证类型（由auth_types.ts处理）
  */
 
+import type { ArtifactContentType } from './artifactTypes';
+
 // Schedule confirmation data — attached to assistant messages when a job is created
 export interface ScheduleConfirmationData {
   jobId: string;
@@ -99,8 +101,9 @@ export interface ArtifactMessage extends BaseMessage {
     widgetType: string; // 'dream', 'hunt', 'omni', etc.
     widgetName?: string; // 显示名称
     version: number;
-    contentType: 'image' | 'text' | 'data' | 'analysis' | 'knowledge' | 'search_results';
+    contentType: ArtifactContentType | 'knowledge';
     content: any; // 工件的实际内容 - can be 'Loading...' during streaming
+    a2uiState?: Record<string, unknown>;
     metadata?: {
       originalInput?: string;
       parameters?: Record<string, any>;


### PR DESCRIPTION
## Summary
- persist unified artifact lifecycle state in the artifact manager while keeping panel layout ephemeral
- preserve A2UI surface state through edit versions and fork transforms
- pass Mate chat artifact a2uiState into the artifact manager registration path
- add lifecycle coverage for A2UI creation, shared panel identity, immutable versions, fork transforms, persistence/reload, and chat handoff

Fixes #349
Parent: #249

## Verification
- PASS: npm test -- src/stores/__tests__/useArtifactManager.test.ts (5 tests)
- FAIL BASELINE: npm test (7 failed / 575 passed / 582 total; existing failures in RealAPIEventMapping import, chatService/MateEventAdapter lifecycle expectations, and account route config tests)
- FAIL BASELINE: npx tsc --noEmit --pretty false (existing desktop/Electron missing modules, SDK React type duplication, demo imports, and unrelated store/service type errors)
- PASS: git diff --check