### PR TITLE
refactor(streaming): use SDK streaming adapters

### DIFF
--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -323,6 +323,18 @@ describe('ChatService', () => {
       expect(callbacks.onToolCompleted).toHaveBeenCalledWith('search', { data: [] }, undefined, 120);
     });
 
+    test('canonical tool_call running → onToolExecuting', async () => {
+      await streamEvent({
+        type: 'tool_call',
+        data: {
+          toolName: 'search',
+          status: 'running',
+          progress: 50,
+        },
+      });
+      expect(callbacks.onToolExecuting).toHaveBeenCalledWith('search', 'running', 50);
+    });
+
     test('run_finished → onStreamComplete', async () => {
       await streamEvent({ type: 'run_finished', content: 'final' });
       expect(callbacks.onStreamComplete).toHaveBeenCalledWith('final');
@@ -354,6 +366,13 @@ describe('ChatService', () => {
       await streamEvent({ type: 'error', message: 'bad request' });
       expect(callbacks.onError).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'bad request' })
+      );
+    });
+
+    test('canonical error event uses data.message', async () => {
+      await streamEvent({ type: 'error', data: { message: 'sdk failure' } });
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'sdk failure' })
       );
     });
 
@@ -528,6 +547,29 @@ describe('ChatService', () => {
         tool_name: 'ComputerUseAgent',
         action_type: 'navigate',
         target: 'https://example.com',
+      };
+      await streamEvent(event);
+
+      expect(callbacks.onHILInterruptDetected).toHaveBeenCalledWith(event);
+      expect(callbacks.onBrowserAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'navigate',
+          status: 'pending',
+          target: 'https://example.com',
+        }),
+      );
+    });
+
+    test('canonical hil_request also creates pending browser action', async () => {
+      const event = {
+        type: 'hil_request',
+        thread_id: 'thread-1',
+        data: {
+          checkpointId: 'cp-1',
+          tool_name: 'ComputerUseAgent',
+          action_type: 'navigate',
+          target: 'https://example.com',
+        },
       };
       await streamEvent(event);
 

--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -328,6 +328,23 @@ describe('ChatService', () => {
       expect(callbacks.onStreamComplete).toHaveBeenCalledWith('final');
     });
 
+    test('canonical done event completes without a separate DONE sentinel', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable([
+          `data: ${JSON.stringify({ type: 'done' })}`,
+        ])
+      );
+      mockParser.parse.mockReturnValueOnce({
+        type: 'done',
+        data: { finalContent: 'final from sdk' },
+      });
+
+      await service.sendMessage('Hi', defaultMetadata, defaultToken, callbacks);
+
+      expect(callbacks.onStreamComplete).toHaveBeenCalledWith('final from sdk');
+      expect(mockConnection.close).toHaveBeenCalled();
+    });
+
     test('run_error → onError', async () => {
       await streamEvent({ type: 'run_error', error: { message: 'boom' } });
       expect(callbacks.onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }));
@@ -536,6 +553,12 @@ describe('ChatService', () => {
       expect(callbacks.onArtifactUpdated).toHaveBeenCalledWith(artifact);
     });
 
+    test('canonical artifact update → onArtifactUpdated', async () => {
+      const artifact = { id: 'a1', title: 'code.py', version: 2 };
+      await streamEvent({ type: 'artifact', data: { action: 'updated', artifact } });
+      expect(callbacks.onArtifactUpdated).toHaveBeenCalledWith(artifact);
+    });
+
     test('status_update → onStreamStatus', async () => {
       await streamEvent({ type: 'status_update', status: 'Thinking...' });
       expect(callbacks.onStreamStatus).toHaveBeenCalledWith('Thinking...');
@@ -644,6 +667,23 @@ describe('ChatService', () => {
       await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
 
       expect(callbacks.onStreamComplete).toHaveBeenCalled();
+    });
+
+    test('completes when Mate adapter emits a terminal event without DONE sentinel', async () => {
+      mockConnection.stream.mockReturnValue(
+        createAsyncIterable([
+          `data: ${JSON.stringify({ type: 'result', content: 'done' })}`,
+        ])
+      );
+      mockAdaptMateEvent.mockReturnValue({
+        events: [{ type: 'run_finished', content: 'mate final' }],
+        updatedContext: { runId: 'mate-run-1', sessionId: 'mate-session-1', currentMessageId: null },
+      });
+
+      await service.sendMessageViaMate('Hi', mateMetadata, defaultToken, callbacks);
+
+      expect(callbacks.onStreamComplete).toHaveBeenCalledWith('mate final');
+      expect(mockConnection.close).toHaveBeenCalled();
     });
   });
 

--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -242,37 +242,18 @@ export function adaptMateEvent(
     }
 
     case 'result': {
-      // Final result — if no text message was started, emit start+content+end
-      if (!currentMessageId) {
-        currentMessageId = generateId('msg');
+      // Final result closes an active message. Without one, only finish the run.
+      if (currentMessageId) {
         results.push({
-          type: 'text_message_start',
+          type: 'text_message_end',
           thread_id: threadId,
           timestamp: now,
           run_id: context.runId,
           message_id: currentMessageId,
-          role: 'assistant',
+          final_content: event.content,
         });
-        if (event.content) {
-          results.push({
-            type: 'text_message_content',
-            thread_id: threadId,
-            timestamp: now,
-            run_id: context.runId,
-            message_id: currentMessageId,
-            delta: event.content,
-          });
-        }
+        currentMessageId = null;
       }
-      results.push({
-        type: 'text_message_end',
-        thread_id: threadId,
-        timestamp: now,
-        run_id: context.runId,
-        message_id: currentMessageId,
-        final_content: event.content,
-      });
-      currentMessageId = null;
       results.push({
         type: 'run_finished',
         thread_id: threadId,

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -83,6 +83,8 @@ export class ChatService {
   private readonly version = '3.0.0';
   /** Tracks whether onStreamStart has been called for the current request */
   private _streamStarted = false;
+  /** Tracks whether a typed/legacy event already emitted completion */
+  private _streamCompleted = false;
   
   /**
    * 发送消息 - 符合 how_to_chat.md 标准格式
@@ -107,6 +109,7 @@ export class ChatService {
     
     try {
       this._streamStarted = false; // Reset for new request
+      this._streamCompleted = false;
       // 构建标准的Chat API payload (符合 how_to_chat.md)
       const payload = {
         message,
@@ -176,7 +179,10 @@ export class ChatService {
           if (!streamEnded) {
             streamEnded = true;
             await connection.close();
-            callbacks.onStreamComplete?.(finalContent);
+            if (!this._streamCompleted) {
+              callbacks.onStreamComplete?.(finalContent);
+              this._streamCompleted = true;
+            }
             resolve();
           }
         };
@@ -217,6 +223,10 @@ export class ChatService {
                     
                     // 直接调用相应的回调函数
                     this.handleAGUIEvent(aguiEvent, callbacks);
+                    if (this.isTerminalStreamEvent(aguiEvent)) {
+                      await handleComplete();
+                      return;
+                    }
                     
                   } catch (parseError) {
                     log.warn('Failed to parse event', parseError);
@@ -255,11 +265,95 @@ export class ChatService {
     }
     
     switch (event.type) {
+      // Canonical SDK streaming protocol
+      case 'status': {
+        const data = event.data || {};
+        const phase = data.phase || data.status;
+        const message = data.message || data.status;
+        if (!this._streamStarted && ['connecting', 'preparing', 'generating'].includes(phase)) {
+          this._streamStarted = true;
+          callbacks.onStreamStart?.(event.id || data.messageId || data.message_id || data.runId || `stream-${Date.now()}`, message || 'Starting...');
+        } else if (message) {
+          callbacks.onStreamStatus?.(message);
+        }
+        break;
+      }
+
+      case 'content': {
+        const data = event.data || {};
+        const delta = data.delta || data.content || '';
+        if (delta) {
+          if (!this._streamStarted) {
+            this._streamStarted = true;
+            callbacks.onStreamStart?.(event.id || data.messageId || data.message_id || data.runId || `stream-${Date.now()}`, 'Generating...');
+          }
+          callbacks.onStreamContent?.(delta);
+        }
+        break;
+      }
+
+      case 'thinking': {
+        const data = event.data || {};
+        callbacks.onStreamStatus?.(data.message || 'Thinking...');
+        break;
+      }
+
+      case 'done': {
+        const data = event.data || {};
+        callbacks.onStreamComplete?.(data.finalContent || data.content);
+        this._streamCompleted = true;
+        break;
+      }
+
+      case 'tool_call': {
+        const data = event.data || {};
+        const status = data.status;
+        if (status === 'result' || status === 'error') {
+          callbacks.onToolCompleted?.(data.toolName, data.result, data.error);
+        } else if (status === 'calling') {
+          callbacks.onToolStart?.(data.toolName, data.callId, data.arguments);
+        } else {
+          callbacks.onToolExecuting?.(data.toolName, status, data.progress);
+        }
+        break;
+      }
+
+      case 'task_progress':
+        callbacks.onTaskProgress?.(event.data);
+        break;
+
+      case 'artifact': {
+        const data = event.data || {};
+        if (data.action === 'updated') {
+          callbacks.onArtifactUpdated?.(data.artifact || data);
+        } else {
+          callbacks.onArtifactCreated?.(data.artifact || data);
+        }
+        break;
+      }
+
+      case 'billing': {
+        const data = event.data || event;
+        callbacks.onBillingUpdate?.({
+          creditsRemaining: data.creditsRemaining ?? data.credits_remaining,
+          totalCredits: data.totalCredits ?? data.total_credits,
+          modelCalls: data.modelCalls ?? data.model_calls,
+          toolCalls: data.toolCalls ?? data.tool_calls,
+          cost: data.creditsUsed ?? data.cost,
+        });
+        break;
+      }
+
+      case 'hil_request':
+        callbacks.onHILInterruptDetected?.(event.data || event);
+        break;
+
       // 基础流程事件
       case 'run_started':
-        // Don't call onStreamStart here — wait for text_message_start or first content.
-        // The placeholder in messageHandlers handles the "waiting" UX.
-        log.debug('Run started', { runId: event.run_id });
+        if (!this._streamStarted) {
+          this._streamStarted = true;
+          callbacks.onStreamStart?.(event.message_id || event.run_id, 'Starting...');
+        }
         break;
 
       case 'text_message_start':
@@ -277,6 +371,8 @@ export class ChatService {
           callbacks.onStreamStart?.(event.message_id || event.run_id, 'Generating...');
           callbacks.onStreamContent?.(event.final_content || event.content);
         }
+        callbacks.onStreamComplete?.(event.final_content || event.content);
+        this._streamCompleted = true;
         break;
 
       case 'text_delta':
@@ -293,9 +389,8 @@ export class ChatService {
         
       case 'run_finished':
       case 'run_completed':
-        // Don't call onStreamComplete here — handleComplete does it when stream ends.
-        // Calling it here causes duplicate finishStreamingMessage().
-        log.debug('Run finished', { runId: event.run_id });
+        callbacks.onStreamComplete?.(event.final_content || event.content);
+        this._streamCompleted = true;
         break;
         
       case 'run_error':
@@ -304,8 +399,8 @@ export class ChatService {
         break;
         
       case 'stream_done':
-        // Don't call onStreamComplete here — handleComplete does it once when SSE ends.
-        log.debug('Stream done event received');
+        callbacks.onStreamComplete?.(event.final_content || event.content);
+        this._streamCompleted = true;
         break;
         
       // 工具执行事件
@@ -350,16 +445,6 @@ export class ChatService {
       // 业务功能事件
       case 'memory_update':
         callbacks.onMemoryUpdate?.(event.memory_data, event.operation);
-        break;
-        
-      case 'billing':
-        callbacks.onBillingUpdate?.({
-          creditsRemaining: event.credits_remaining,
-          totalCredits: event.total_credits,
-          modelCalls: event.model_calls,
-          toolCalls: event.tool_calls,
-          cost: event.cost
-        });
         break;
         
       // Resume事件
@@ -628,6 +713,10 @@ export class ChatService {
       durationMs: event?.durationMs || event?.duration_ms || data?.durationMs || data?.duration_ms,
     };
   }
+
+  private isTerminalStreamEvent(event: any): boolean {
+    return ['done', 'stream_done', 'run_finished', 'run_completed'].includes(event?.type);
+  }
   
   /**
    * Send message via isA_Mate backend (streaming SSE).
@@ -670,6 +759,7 @@ export class ChatService {
       return new Promise<void>((resolve, reject) => {
         let streamEnded = false;
         this._streamStarted = false; // Reset for new request
+        this._streamCompleted = false;
         const { startEvent, context } = createMateStreamContext(metadata.session_id);
         let adaptCtx = context;
 
@@ -680,7 +770,10 @@ export class ChatService {
           if (!streamEnded) {
             streamEnded = true;
             await connection.close();
-            callbacks.onStreamComplete?.(finalContent);
+            if (!this._streamCompleted) {
+              callbacks.onStreamComplete?.(finalContent);
+              this._streamCompleted = true;
+            }
             resolve();
           }
         };
@@ -719,6 +812,10 @@ export class ChatService {
 
                     for (const aguiEvent of events) {
                       this.handleAGUIEvent(aguiEvent, callbacks);
+                      if (this.isTerminalStreamEvent(aguiEvent)) {
+                        await handleComplete();
+                        return;
+                      }
                     }
                   } catch (parseError) {
                     log.warn('Failed to parse Mate event', parseError);

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -294,7 +294,7 @@ export class ChatService {
 
       case 'thinking': {
         const data = event.data || {};
-        callbacks.onStreamStatus?.(data.message || 'Thinking...');
+        callbacks.onStreamStatus?.(data.delta || data.message || 'Thinking...');
         break;
       }
 
@@ -309,7 +309,7 @@ export class ChatService {
         const data = event.data || {};
         const status = data.status;
         if (status === 'result' || status === 'error') {
-          callbacks.onToolCompleted?.(data.toolName, data.result, data.error);
+          callbacks.onToolCompleted?.(data.toolName, data.result, data.error, data.durationMs ?? data.duration_ms);
         } else if (status === 'calling') {
           callbacks.onToolStart?.(data.toolName, data.callId, data.arguments);
         } else {
@@ -345,7 +345,10 @@ export class ChatService {
       }
 
       case 'hil_request':
-        callbacks.onHILInterruptDetected?.(event.data || event);
+        callbacks.onHILInterruptDetected?.(event);
+        if (this.isBrowserControlEvent(event)) {
+          callbacks.onBrowserAction?.(this.normalizeBrowserAction({ ...event, status: 'pending' }));
+        }
         break;
 
       // 基础流程事件
@@ -395,7 +398,7 @@ export class ChatService {
         
       case 'run_error':
       case 'error':
-        callbacks.onError?.(new Error(event.error?.message || event.message || 'Unknown error'));
+        callbacks.onError?.(new Error(event.data?.message || event.error?.message || event.message || 'Unknown error'));
         break;
         
       case 'stream_done':

--- a/src/api/parsing/AGUIEventParser.ts
+++ b/src/api/parsing/AGUIEventParser.ts
@@ -27,8 +27,10 @@ class AGUIEventParser {
 
   private addAppCompatibilityFields(event: StreamingEvent, raw: RawSSEData): StreamingEvent {
     const additions: Record<string, any> = {};
+    const eventAdditions: Record<string, any> = {};
     const messageId = raw.message_id ?? raw.messageId;
     const runId = raw.run_id ?? raw.runId;
+    const threadId = raw.thread_id ?? raw.threadId ?? raw.session_id ?? raw.sessionId;
 
     if (messageId) {
       additions.messageId = messageId;
@@ -37,6 +39,16 @@ class AGUIEventParser {
     if (runId) {
       additions.runId = runId;
       additions.run_id = runId;
+    }
+    if (threadId) {
+      additions.threadId = threadId;
+      additions.thread_id = threadId;
+      eventAdditions.threadId = threadId;
+      eventAdditions.thread_id = threadId;
+    }
+    if (raw.metadata) {
+      additions.metadata = raw.metadata;
+      eventAdditions.metadata = raw.metadata;
     }
 
     if (event.type === 'done') {
@@ -61,13 +73,106 @@ class AGUIEventParser {
       additions.artifact = raw.artifact;
     }
 
+    if (event.type === 'tool_call') {
+      const durationMs = raw.durationMs ?? raw.duration_ms;
+      Object.assign(additions, {
+        toolName: (event.data as Record<string, any>).toolName ?? raw.tool_name,
+        tool_name: raw.tool_name ?? (event.data as Record<string, any>).toolName,
+        callId: (event.data as Record<string, any>).callId ?? raw.tool_call_id,
+        tool_call_id: raw.tool_call_id ?? (event.data as Record<string, any>).callId,
+        progress: raw.progress,
+        durationMs,
+        duration_ms: durationMs,
+      });
+
+      if (raw.type === 'tool_executing') {
+        additions.status = raw.status || 'running';
+      } else if (raw.type === 'tool_call_start') {
+        additions.status = 'calling';
+      }
+    }
+
+    if (event.type === 'task_progress') {
+      const eventData = event.data as Record<string, any>;
+      const task = raw.task || {};
+      const currentStep = Number(eventData.currentStep || 0);
+      const totalSteps = Number(eventData.totalSteps || 1);
+      const rawPercentage = typeof task.percentage === 'number' ? task.percentage : task.progress;
+      const percentage = typeof rawPercentage === 'number'
+        ? rawPercentage
+        : totalSteps > 0
+          ? Math.round((currentStep / totalSteps) * 100)
+          : 0;
+
+      Object.assign(additions, {
+        percentage,
+        currentStepName:
+          task.currentStepName ||
+          task.stepName ||
+          task.name ||
+          task.title ||
+          eventData.toolName ||
+          raw.tool_name ||
+          'In progress',
+        estimatedTimeRemaining:
+          task.estimatedTimeRemaining ??
+          eventData.estimatedTimeRemaining ??
+          eventData.estimatedSecondsRemaining,
+        estimatedSecondsRemaining:
+          eventData.estimatedSecondsRemaining ??
+          task.estimatedSecondsRemaining,
+      });
+    }
+
+    if (event.type === 'hil_request') {
+      Object.assign(additions, {
+        checkpoint_id: raw.checkpoint_id ?? (event.data as Record<string, any>).checkpointId,
+        tool_name:
+          raw.tool_name ??
+          raw.metadata?.tool_name ??
+          raw.metadata?.custom_data?.tool_name,
+        action_type:
+          raw.action_type ??
+          raw.metadata?.action_type ??
+          raw.metadata?.custom_data?.type,
+        target:
+          raw.target ??
+          raw.url ??
+          raw.metadata?.target ??
+          raw.metadata?.url ??
+          raw.metadata?.custom_data?.target ??
+          raw.metadata?.custom_data?.url,
+        x: raw.x ?? raw.metadata?.x ?? raw.metadata?.custom_data?.x,
+        y: raw.y ?? raw.metadata?.y ?? raw.metadata?.custom_data?.y,
+      });
+    }
+
+    if (event.type === 'error') {
+      Object.assign(additions, {
+        message:
+          (event.data as Record<string, any>).message ??
+          raw.message ??
+          (typeof raw.error === 'string' ? raw.error : raw.error?.message),
+        code:
+          (event.data as Record<string, any>).code ??
+          raw.code ??
+          (typeof raw.error === 'object' ? raw.error?.code : undefined),
+      });
+    }
+
     const filteredAdditions = Object.fromEntries(
       Object.entries(additions).filter(([, value]) => value !== undefined)
     );
-    if (Object.keys(filteredAdditions).length === 0) return event;
+    const filteredEventAdditions = Object.fromEntries(
+      Object.entries(eventAdditions).filter(([, value]) => value !== undefined)
+    );
+    if (Object.keys(filteredAdditions).length === 0 && Object.keys(filteredEventAdditions).length === 0) {
+      return event;
+    }
 
     return {
       ...event,
+      ...filteredEventAdditions,
       data: {
         ...(event.data as Record<string, any>),
         ...filteredAdditions,

--- a/src/api/parsing/AGUIEventParser.ts
+++ b/src/api/parsing/AGUIEventParser.ts
@@ -1,107 +1,81 @@
 /**
- * AGUIEventParser — AGUI/Legacy event → StreamingEvent conversion.
+ * AGUIEventParser — thin app compatibility wrapper around @isa/core streaming.
  *
- * MIGRATION NOTE (#281): This file has been reduced from 1,234 lines to ~120.
- * The full typed StreamingEvent protocol now lives in @isa/core (isA_App_SDK#287).
- * When @isa/core is published with streaming exports, replace this file with:
- *
- *   export { StreamingEventParser as AGUIEventParser } from '@isa/core';
- *   export { type StreamingEvent as AGUIEvent } from '@isa/core';
- *
- * Until then, this is a standalone reimplementation matching the SDK contract.
+ * The canonical StreamingEvent protocol lives in the SDK. This file keeps the
+ * historical factory name used by chatService while delegating parsing to
+ * StreamingEventParser.
  */
 
-// ---------------------------------------------------------------------------
-// StreamingEvent types (mirrors @isa/core/streaming/StreamingEvent)
-// ---------------------------------------------------------------------------
-
-export interface StreamingEvent {
-  type: string;
-  data: Record<string, any>;
-  id?: string;
-  timestamp: string;
-}
+import {
+  StreamingEventParser,
+  type RawSSEData,
+  type StreamingEvent,
+} from '@isa/core';
 
 export type AGUIEvent = StreamingEvent;
 export type AGUIEventType = string;
 export type BaseAGUIEvent = StreamingEvent;
 
-// ---------------------------------------------------------------------------
-// Raw SSE data shape
-// ---------------------------------------------------------------------------
-
-interface RawSSEData {
-  type?: string;
-  event?: string;
-  data?: any;
-  id?: string;
-  timestamp?: string;
-  delta?: string;
-  content?: string;
-  message_id?: string;
-  run_id?: string;
-  tool_name?: string;
-  tool_call_id?: string;
-  parameters?: Record<string, any>;
-  result?: any;
-  error?: string | { message: string; code?: string };
-  status?: string;
-  progress?: number;
-  task?: any;
-  interrupt?: any;
-  hil_interrupt?: any;
-  artifact?: any;
-  checkpoint_id?: string;
-  node_name?: string;
-  token_count?: number;
-  cost?: number;
-  credits_remaining?: number;
-  total_credits?: number;
-  model_calls?: number;
-  tool_calls?: number;
-  model?: string;
-  custom_llm_chunk?: string;
-  image_url?: string;
-  graph_data?: any;
-  state_data?: any;
-  node?: string;
-  memory_data?: any;
-  operation?: string;
-  reason?: string;
-  success?: boolean;
-  resumed_from?: string;
-  finish_reason?: string;
-  [key: string]: any;
-}
-
-// ---------------------------------------------------------------------------
-// Parser
-// ---------------------------------------------------------------------------
-
 class AGUIEventParser {
-  /**
-   * Parse raw SSE event data. Returns the event as-is for the callback router
-   * in chatService.ts (which handles the event-to-callback mapping).
-   *
-   * This is intentionally pass-through: chatService.handleAGUIEvent already
-   * has the full switch/case logic. We just ensure required fields exist.
-   */
-  parse(raw: RawSSEData): RawSSEData | null {
-    if (!raw || typeof raw !== 'object') return null;
-    const eventType = raw.type || raw.event;
-    if (!eventType) return null;
+  private readonly parser = new StreamingEventParser();
+
+  parse(raw: RawSSEData): StreamingEvent | null {
+    const event = this.parser.parse(raw);
+    if (!event) return null;
+    return this.addAppCompatibilityFields(event, raw);
+  }
+
+  private addAppCompatibilityFields(event: StreamingEvent, raw: RawSSEData): StreamingEvent {
+    const additions: Record<string, any> = {};
+    const messageId = raw.message_id ?? raw.messageId;
+    const runId = raw.run_id ?? raw.runId;
+
+    if (messageId) {
+      additions.messageId = messageId;
+      additions.message_id = messageId;
+    }
+    if (runId) {
+      additions.runId = runId;
+      additions.run_id = runId;
+    }
+
+    if (event.type === 'done') {
+      const finalContent = raw.final_content ?? raw.finalContent ?? raw.content;
+      if (finalContent !== undefined) {
+        additions.finalContent = finalContent;
+        additions.final_content = finalContent;
+      }
+    }
+
+    if (event.type === 'billing') {
+      Object.assign(additions, {
+        totalCredits: raw.totalCredits ?? raw.total_credits,
+        modelCalls: raw.modelCalls ?? raw.model_calls,
+        toolCalls: raw.toolCalls ?? raw.tool_calls,
+        cost: raw.cost,
+      });
+    }
+
+    if (event.type === 'artifact') {
+      additions.action = raw.type === 'artifact_updated' ? 'updated' : 'created';
+      additions.artifact = raw.artifact;
+    }
+
+    const filteredAdditions = Object.fromEntries(
+      Object.entries(additions).filter(([, value]) => value !== undefined)
+    );
+    if (Object.keys(filteredAdditions).length === 0) return event;
 
     return {
-      ...raw,
-      type: eventType,
-      timestamp: raw.timestamp || new Date().toISOString(),
-    };
+      ...event,
+      data: {
+        ...(event.data as Record<string, any>),
+        ...filteredAdditions,
+      },
+    } as StreamingEvent;
   }
 }
 
-/**
- * Factory function — backward-compatible with existing chatService.ts usage.
- */
 export function createAGUIEventParser(_options?: Record<string, any>) {
   return new AGUIEventParser();
 }

--- a/src/api/parsing/ContentParser.ts
+++ b/src/api/parsing/ContentParser.ts
@@ -1,14 +1,10 @@
 /**
  * ContentParser — Content type detection and structured parsing.
  *
- * MIGRATION NOTE (#281): Reduced from 542 lines to ~100.
- * Full implementation extracted to @isa/core ContentTypeDetector (isA_App_SDK#288).
- * When @isa/core is published, replace with:
- *
- *   export { ContentTypeDetector as ContentParser } from '@isa/core';
- *   export type { DetectedContent as ParsedContent, ContentType } from '@isa/core';
+ * Thin app compatibility wrapper around @isa/core ContentTypeDetector.
  */
 
+import { ContentTypeDetector } from '@isa/core';
 import { BaseParser } from './Parser';
 
 export type ContentType = 'text' | 'markdown' | 'code' | 'image' | 'mixed' | 'json' | 'html' | 'url';
@@ -39,7 +35,9 @@ export interface ParsedContent {
 
 export class ContentParser extends BaseParser<string, ParsedContent> {
   readonly name = 'content_parser';
-  readonly version = '2.0.0';
+  readonly version = '3.0.0-sdk';
+
+  private readonly detector = new ContentTypeDetector();
 
   canParse(data: string): boolean {
     return typeof data === 'string' && data.length > 0;
@@ -48,30 +46,18 @@ export class ContentParser extends BaseParser<string, ParsedContent> {
   parse(content: string): ParsedContent | null {
     if (!content || typeof content !== 'string') return null;
 
-    const hasCodeBlock = /```\w*\n[\s\S]*?\n```/.test(content);
-    const hasMarkdown = (content.match(/(?:^|\n)(#{1,6}\s|[*\-]\s|\d+\.\s|>\s|\*\*.*\*\*)/g) || []).length >= 2;
-    const hasImage = /https?:\/\/[^\s]*\.(jpg|jpeg|png|gif|webp|svg)/i.test(content);
-
-    let primaryType: ContentType = 'text';
-    if (hasCodeBlock) primaryType = 'code';
-    else if (hasImage) primaryType = 'image';
-    else if (hasMarkdown) primaryType = 'markdown';
-
-    const isMixed = [hasCodeBlock, hasMarkdown, hasImage].filter(Boolean).length > 1;
+    const detected = this.detector.detect(content);
+    const typeDistribution = detected.elements.reduce<Record<string, number>>((acc, element) => {
+      acc[element.type] = (acc[element.type] || 0) + 1;
+      return acc;
+    }, {});
 
     return {
-      raw: content,
-      primaryType: isMixed ? 'mixed' : primaryType,
-      elements: [{ type: primaryType, content }],
-      isMixed,
-      renderHints: {
-        variant: primaryType === 'code' ? 'artifact' : 'chat',
-        complexity: content.length > 2000 ? 'complex' : content.length > 500 ? 'moderate' : 'simple',
-      },
+      ...detected,
       stats: {
         totalLength: content.length,
-        elementCount: 1,
-        typeDistribution: { [primaryType]: 1 },
+        elementCount: detected.elements.length,
+        typeDistribution,
       },
     };
   }

--- a/src/api/parsing/RealAPIEventMapping.ts
+++ b/src/api/parsing/RealAPIEventMapping.ts
@@ -1,0 +1,205 @@
+import type { AGUIEventType } from '../../types/aguiTypes';
+
+export interface RealAPIEvent {
+  type: string;
+  content?: string;
+  timestamp?: string;
+  session_id?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface CustomEventAnalysis {
+  hasLLMChunk: boolean;
+  hasProgress: boolean;
+  hasTaskPlanning: boolean;
+  rawChunk?: Record<string, any>;
+  progressInfo?: string;
+}
+
+export class RealAPIEventMapper {
+  static analyzeCustomEvent(event: RealAPIEvent): CustomEventAnalysis {
+    const rawChunk = event.metadata?.raw_chunk;
+    const data = String(rawChunk?.data || '');
+    const progressInfo = this.parseProgressInfo(data);
+
+    return {
+      hasLLMChunk: typeof rawChunk?.custom_llm_chunk === 'string',
+      hasProgress: Boolean(progressInfo),
+      hasTaskPlanning: /task|plan/i.test(data),
+      rawChunk,
+      ...(progressInfo && { progressInfo }),
+    };
+  }
+
+  static extractLLMChunk(event: RealAPIEvent): string | undefined {
+    const chunk = event.metadata?.raw_chunk?.custom_llm_chunk;
+    return typeof chunk === 'string' ? chunk : undefined;
+  }
+
+  static extractToolCalls(event: RealAPIEvent): Array<{ name: string; args: Record<string, any> }> | undefined {
+    return event.metadata?.tool_calls;
+  }
+
+  static extractToolResult(event: RealAPIEvent): any {
+    if (!event.content) return undefined;
+    const jsonStart = event.content.indexOf('{');
+    if (jsonStart < 0) return undefined;
+
+    try {
+      return JSON.parse(event.content.slice(jsonStart));
+    } catch {
+      return undefined;
+    }
+  }
+
+  static parseProgressInfo(data: string): string | undefined {
+    const match = data.match(/^\[([^\]]+)]\s+([A-Za-z]+)(?:\s+execution)?(?:\s+\(([^)]+)\))?/);
+    if (!match) return undefined;
+
+    const [, toolName, status, count] = match;
+    return `${toolName} ${status.toLowerCase()}${count ? ` (${count})` : ''}`;
+  }
+}
+
+export class RealAPIToAGUIMapper {
+  static mapToAGUI(event: RealAPIEvent): Array<Record<string, any>> {
+    const timestamp = event.timestamp || new Date().toISOString();
+    const threadId = event.session_id || 'default';
+
+    switch (event.type) {
+      case 'start':
+        return [{
+          type: 'run_started' as AGUIEventType,
+          thread_id: threadId,
+          timestamp,
+        }];
+
+      case 'content':
+        return this.mapContentEvent(event, threadId, timestamp);
+
+      case 'custom_event':
+        return this.mapCustomEvent(event, threadId, timestamp);
+
+      case 'tool_calls': {
+        const call = RealAPIEventMapper.extractToolCalls(event)?.[0];
+        return call
+          ? [{
+              type: 'tool_call_start' as AGUIEventType,
+              thread_id: threadId,
+              timestamp,
+              tool_name: call.name,
+              parameters: call.args,
+            }]
+          : [];
+      }
+
+      case 'tool_result_msg': {
+        const result = RealAPIEventMapper.extractToolResult(event);
+        return result
+          ? [{
+              type: 'tool_call_end' as AGUIEventType,
+              thread_id: threadId,
+              timestamp,
+              tool_name: result.action,
+              result: result.data,
+              error: result.status === 'success' ? undefined : result.error,
+            }]
+          : [];
+      }
+
+      default:
+        return [];
+    }
+  }
+
+  private static mapContentEvent(event: RealAPIEvent, threadId: string, timestamp: string): Array<Record<string, any>> {
+    const messageId = `msg_${timestamp}`;
+    return [
+      {
+        type: 'text_message_start' as AGUIEventType,
+        thread_id: threadId,
+        timestamp,
+        message_id: messageId,
+        role: 'assistant',
+      },
+      {
+        type: 'text_message_content' as AGUIEventType,
+        thread_id: threadId,
+        timestamp,
+        message_id: messageId,
+        delta: event.content || '',
+      },
+      {
+        type: 'text_message_end' as AGUIEventType,
+        thread_id: threadId,
+        timestamp,
+        message_id: messageId,
+        final_content: event.content || '',
+      },
+    ];
+  }
+
+  private static mapCustomEvent(event: RealAPIEvent, threadId: string, timestamp: string): Array<Record<string, any>> {
+    const chunk = RealAPIEventMapper.extractLLMChunk(event);
+    if (chunk !== undefined) {
+      return [{
+        type: 'text_message_content' as AGUIEventType,
+        thread_id: threadId,
+        timestamp,
+        delta: chunk,
+      }];
+    }
+
+    const progressInfo = RealAPIEventMapper.analyzeCustomEvent(event).progressInfo;
+    if (!progressInfo) return [];
+
+    const [toolName, status] = progressInfo.split(' ');
+    return [{
+      type: 'tool_executing' as AGUIEventType,
+      thread_id: threadId,
+      timestamp,
+      tool_name: toolName,
+      status,
+      progress: status === 'completed' ? 100 : 0,
+    }];
+  }
+}
+
+export class ResponseExtractor {
+  private chunks: string[] = [];
+  private toolResults: any[] = [];
+
+  processEvent(event: RealAPIEvent): Record<string, any> {
+    const result: Record<string, any> = {};
+
+    if (event.type === 'content' && event.content) {
+      result.complete_response = event.content;
+    }
+
+    const chunk = RealAPIEventMapper.extractLLMChunk(event);
+    if (chunk !== undefined) {
+      this.chunks.push(chunk);
+    }
+
+    const toolResult = RealAPIEventMapper.extractToolResult(event);
+    if (toolResult) {
+      this.toolResults.push(toolResult);
+      result.tool_result = toolResult;
+    }
+
+    const progressUpdate = RealAPIEventMapper.analyzeCustomEvent(event).progressInfo;
+    if (progressUpdate) {
+      result.progress_update = progressUpdate;
+    }
+
+    return result;
+  }
+
+  getReconstructedResponse(): string {
+    return this.chunks.join('');
+  }
+
+  getToolResults(): any[] {
+    return [...this.toolResults];
+  }
+}

--- a/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
+++ b/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test, vi } from 'vitest';
+
+describe('streaming SDK parser adapters', () => {
+  test('AGUIEventParser delegates legacy text deltas to the SDK StreamingEventParser', async () => {
+    const { createAGUIEventParser } = await import('../AGUIEventParser');
+
+    const parser = createAGUIEventParser();
+    const event = parser.parse({
+      type: 'text_message_content',
+      content: 'Hello from Mate',
+      timestamp: '2026-04-23T08:00:00.000Z',
+    });
+
+    expect(event).toMatchObject({
+      type: 'content',
+      data: {
+        delta: 'Hello from Mate',
+        contentType: 'text',
+      },
+      timestamp: '2026-04-23T08:00:00.000Z',
+    });
+  });
+
+  test('AGUIEventParser preserves app compatibility fields on normalized SDK events', async () => {
+    const { createAGUIEventParser } = await import('../AGUIEventParser');
+
+    const parser = createAGUIEventParser();
+    const done = parser.parse({
+      type: 'text_message_end',
+      final_content: 'complete response',
+      message_id: 'msg-1',
+      run_id: 'run-1',
+    });
+    const billing = parser.parse({
+      type: 'billing',
+      cost: 0.25,
+      credits_remaining: 9,
+      total_credits: 10,
+      model_calls: 2,
+      tool_calls: 3,
+    });
+    const artifact = parser.parse({
+      type: 'artifact_updated',
+      artifact: { id: 'artifact-1', title: 'Plan' },
+    });
+
+    expect(done).toMatchObject({
+      type: 'done',
+      data: {
+        finalContent: 'complete response',
+        messageId: 'msg-1',
+        runId: 'run-1',
+      },
+    });
+    expect(billing).toMatchObject({
+      type: 'billing',
+      data: {
+        creditsRemaining: 9,
+        totalCredits: 10,
+        modelCalls: 2,
+        toolCalls: 3,
+        cost: 0.25,
+      },
+    });
+    expect(artifact).toMatchObject({
+      type: 'artifact',
+      data: {
+        action: 'updated',
+        artifact: { id: 'artifact-1', title: 'Plan' },
+      },
+    });
+  });
+
+  test('ContentParser delegates detection to the SDK ContentTypeDetector', async () => {
+    const { createContentParser } = await import('../ContentParser');
+
+    const parser = createContentParser();
+    const parsed = parser.parse('{"status":"ok"}');
+
+    expect(parsed).toMatchObject({
+      raw: '{"status":"ok"}',
+      primaryType: 'json',
+      isMixed: false,
+      elements: [
+        {
+          type: 'json',
+          content: '{"status":"ok"}',
+        },
+      ],
+      renderHints: {
+        variant: 'chat',
+        complexity: 'simple',
+      },
+    });
+    expect(parsed?.stats).toMatchObject({
+      totalLength: 15,
+      elementCount: 1,
+      typeDistribution: { json: 1 },
+    });
+  });
+});
+
+vi.mock('@isa/transport', () => {
+  class MockSSEClient {
+    static instances: MockSSEClient[] = [];
+
+    private eventCallbacks = new Set<(event: { event: string; data: string; id?: string }) => void>();
+    private connectionCallbacks = new Set<(event: { type: string }) => void>();
+
+    constructor(public config: any) {
+      MockSSEClient.instances.push(this);
+    }
+
+    async connect() {
+      this.connectionCallbacks.forEach(callback => callback({ type: 'connected' }));
+    }
+
+    disconnect() {
+      this.connectionCallbacks.forEach(callback => callback({ type: 'disconnected' }));
+    }
+
+    onEvent(callback: (event: { event: string; data: string; id?: string }) => void) {
+      this.eventCallbacks.add(callback);
+      return () => this.eventCallbacks.delete(callback);
+    }
+
+    onConnection(callback: (event: { type: string }) => void) {
+      this.connectionCallbacks.add(callback);
+      return () => this.connectionCallbacks.delete(callback);
+    }
+
+    emit(event: { event: string; data: string; id?: string }) {
+      this.eventCallbacks.forEach(callback => callback(event));
+    }
+  }
+
+  return { SSEClient: MockSSEClient };
+});
+
+describe('SSETransport SDK adapter', () => {
+  test('wraps @isa/transport SSEClient behind the app stream contract', async () => {
+    const { SSEClient } = await import('@isa/transport');
+    const { createSSETransport } = await import('../../transport/SSETransport');
+
+    const transport = createSSETransport({ url: '', timeout: 5000 });
+    const connection = await transport.connect('https://example.test/stream', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test-token' },
+      body: JSON.stringify({ message: 'hi' }),
+    });
+
+    const sdkClient = (SSEClient as any).instances[0];
+    expect(sdkClient.config).toMatchObject({
+      url: 'https://example.test/stream',
+      method: 'POST',
+      headers: { Authorization: 'Bearer test-token' },
+      body: JSON.stringify({ message: 'hi' }),
+      timeout: 5000,
+    });
+
+    const iterator = connection.stream()[Symbol.asyncIterator]();
+    sdkClient.emit({ event: 'message', data: '{"type":"content","data":{"delta":"hi"}}' });
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: 'data: {"type":"content","data":{"delta":"hi"}}',
+      done: false,
+    });
+
+    await connection.close();
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+});

--- a/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
+++ b/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
@@ -43,6 +43,32 @@ describe('streaming SDK parser adapters', () => {
       type: 'artifact_updated',
       artifact: { id: 'artifact-1', title: 'Plan' },
     });
+    const toolExecuting = parser.parse({
+      type: 'tool_executing',
+      tool_name: 'search',
+      tool_call_id: 'tool-1',
+      status: 'running',
+      progress: 42,
+    });
+    const taskProgress = parser.parse({
+      type: 'task_progress_update',
+      task: {
+        id: 'task-1',
+        name: 'Search web',
+        status: 'running',
+        progress: 50,
+        totalSteps: 4,
+      },
+      thread_id: 'thread-1',
+    });
+    const hilRequest = parser.parse({
+      type: 'hil_approval_required',
+      thread_id: 'thread-1',
+      checkpoint_id: 'cp-1',
+      tool_name: 'ComputerUseAgent',
+      action_type: 'navigate',
+      target: 'https://example.com',
+    });
 
     expect(done).toMatchObject({
       type: 'done',
@@ -67,6 +93,36 @@ describe('streaming SDK parser adapters', () => {
       data: {
         action: 'updated',
         artifact: { id: 'artifact-1', title: 'Plan' },
+      },
+    });
+    expect(toolExecuting).toMatchObject({
+      type: 'tool_call',
+      data: {
+        toolName: 'search',
+        tool_name: 'search',
+        callId: 'tool-1',
+        tool_call_id: 'tool-1',
+        status: 'running',
+        progress: 42,
+      },
+    });
+    expect(taskProgress).toMatchObject({
+      type: 'task_progress',
+      thread_id: 'thread-1',
+      data: {
+        thread_id: 'thread-1',
+        currentStepName: 'Search web',
+        percentage: 50,
+      },
+    });
+    expect(hilRequest).toMatchObject({
+      type: 'hil_request',
+      thread_id: 'thread-1',
+      data: {
+        checkpoint_id: 'cp-1',
+        tool_name: 'ComputerUseAgent',
+        action_type: 'navigate',
+        target: 'https://example.com',
       },
     });
   });

--- a/src/api/transport/SSETransport.ts
+++ b/src/api/transport/SSETransport.ts
@@ -1,30 +1,23 @@
 /**
- * ============================================================================
- * SSE Transport - Using @isa/core SDK
- * ============================================================================
- * 
- * Migrated from custom implementation to @isa/core AgentService SSE handling
- * 
- * Architecture Benefits:
- * ✅ SDK: @isa/core AgentService with built-in SSE streaming
- * ✅ Events: Comprehensive event parsing and handling
- * ✅ Error handling: Built-in SDK error management
- * ✅ Types: SDK-provided type safety
+ * SSETransport — app compatibility adapter over @isa/transport SSEClient.
+ *
+ * chatService still consumes the historical createSSETransport().connect().stream()
+ * contract. The generic SSE connection mechanics now live in the SDK client.
  */
 
+import { SSEClient } from '@isa/transport';
 import { createLogger, LogCategory } from '../../utils/logger';
 
 const log = createLogger('SSETransport', LogCategory.API_REQUEST);
 
-// Re-export compatibility types
 export enum ConnectionState {
   IDLE = 'idle',
-  CONNECTING = 'connecting', 
+  CONNECTING = 'connecting',
   CONNECTED = 'connected',
   STREAMING = 'streaming',
   CLOSING = 'closing',
   CLOSED = 'closed',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
 export interface ConnectionConfig {
@@ -60,170 +53,129 @@ export interface SSETransportConfig extends ConnectionConfig {
   withCredentials?: boolean;
 }
 
-// ================================================================================
-// SSE Connection Wrapper (Compatibility Layer)
-// ================================================================================
+type Unsubscribe = () => void;
 
 export class SSEConnection {
   public readonly id: string;
   public readonly url: string;
   public readonly protocol = 'sse';
-  
+
   private _state: ConnectionState = ConnectionState.IDLE;
   private listeners = new Map<string, ConnectionEventListener[]>();
   private metadata: Record<string, any> = {};
-  private abortController?: AbortController;
-  private isStreamActive = false;
-  private connectOptions: ConnectionOptions = {};
-  
+  private client: SSEClient | null = null;
+  private unsubs: Unsubscribe[] = [];
+  private queue: string[] = [];
+  private waiters: Array<(value: IteratorResult<string>) => void> = [];
+  private streamClosed = false;
+
   constructor(private config: SSETransportConfig) {
-    this.id = `conn_${Date.now()}_${Math.random().toString(36).substring(2)}`;
+    this.id = `conn_${Date.now()}_${Math.random().toString(36).slice(2)}`;
     this.url = config.url;
   }
-  
+
   get state(): ConnectionState {
     return this._state;
   }
-  
-  /**
-   * Prepare connection state and abort controller.
-   * For SSE-over-POST, the actual HTTP request is made in stream()
-   * since the request body is needed at connection time.
-   * Call connect() before stream() to initialise state.
-   */
+
   async connect(options: ConnectionOptions = {}): Promise<void> {
-    if (this.isConnected()) {
-      return;
-    }
+    if (this.isConnected()) return;
 
-    // Store options (method, body, headers) for use in stream()
-    this.connectOptions = options;
     this.setState(ConnectionState.CONNECTING);
-    this.abortController = new AbortController();
+    this.streamClosed = false;
 
-    // Mark as ready — the real HTTP fetch happens in stream()
-    this.setState(ConnectionState.CONNECTED);
+    const method = options.method === 'GET' ? 'GET' : 'POST';
+    const headers = {
+      ...this.config.headers,
+      ...options.headers,
+    };
+
+    this.client = new SSEClient({
+      url: this.config.url,
+      headers,
+      method,
+      body: this.normalizeBody(options.body),
+      timeout: this.config.timeout,
+      reconnect: Boolean(this.config.maxReconnectAttempts ?? this.config.retryConfig?.maxRetries),
+      reconnectInterval: this.config.reconnectInterval ?? this.config.retryConfig?.retryDelay,
+      maxReconnectAttempts: this.config.maxReconnectAttempts ?? this.config.retryConfig?.maxRetries,
+      withCredentials: this.config.withCredentials,
+    });
+
+    this.unsubs = [
+      this.client.onEvent(event => {
+        const raw = this.formatEvent(event);
+        this.emit('data', { data: raw, timestamp: Date.now() });
+        this.enqueue(raw);
+      }),
+      this.client.onConnection(event => {
+        if (event.type === 'connected') {
+          this.setState(ConnectionState.CONNECTED);
+          this.emit('open', { timestamp: Date.now() });
+        } else if (event.type === 'disconnected') {
+          this.closeQueuedStream();
+          this.setState(ConnectionState.CLOSED);
+          this.emit('close', { timestamp: Date.now() });
+        } else if (event.type === 'error') {
+          const error = new Error(String(event.details?.message || 'SSE connection error'));
+          this.setState(ConnectionState.ERROR);
+          this.emit('error', { error, timestamp: Date.now() });
+        }
+      }),
+    ];
+
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => {
+        this.close().catch(error => log.warn('Failed to close aborted SSE connection', error));
+      }, { once: true });
+    }
+
+    await this.client.connect();
+    if (this._state === ConnectionState.CONNECTING) {
+      this.setState(ConnectionState.CONNECTED);
+    }
   }
-  
+
   async close(code?: number, reason?: string): Promise<void> {
-    if (this._state === ConnectionState.CLOSED || this._state === ConnectionState.CLOSING) {
-      return;
-    }
-    
+    if (this._state === ConnectionState.CLOSED || this._state === ConnectionState.CLOSING) return;
+
     this.setState(ConnectionState.CLOSING);
-    
-    try {
-      if (this.abortController) {
-        this.abortController.abort();
-      }
-      
-      this.isStreamActive = false;
-      this.setState(ConnectionState.CLOSED);
-      this.setMetadata('closeCode', code);
-      this.setMetadata('closeReason', reason);
-      
-      this.emit('close', { 
-        data: { code, reason }, 
-        timestamp: Date.now() 
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        // Normal abort
-      } else {
-        log.warn('Error during close', error);
-      }
-      this.setState(ConnectionState.CLOSED);
+    this.setMetadata('closeCode', code);
+    this.setMetadata('closeReason', reason);
+
+    for (const unsub of this.unsubs) {
+      unsub();
     }
+    this.unsubs = [];
+
+    this.client?.disconnect();
+    this.client = null;
+    this.closeQueuedStream();
+    this.setState(ConnectionState.CLOSED);
+    this.emit('close', { data: { code, reason }, timestamp: Date.now() });
   }
-  
+
   async* stream(): AsyncIterable<string> {
     if (!this.isConnected()) {
       throw this.createError('Connection not established', 'NOT_CONNECTED');
     }
-    
+
     this.setState(ConnectionState.STREAMING);
-    this.isStreamActive = true;
-    
+
     try {
-      // Create fetch request for SSE, merging connect() options
-      const response = await fetch(this.url, {
-        method: this.connectOptions.method || 'POST',
-        headers: {
-          'Accept': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          'Content-Type': 'application/json',
-          ...this.config.headers,
-          ...this.connectOptions.headers,
-        },
-        body: this.connectOptions.body,
-        signal: this.abortController?.signal,
-      });
-      
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      
-      if (!response.body) {
-        throw new Error('No response body received');
-      }
-      
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-      
-      while (this.isStreamActive) {
-        const { done, value } = await reader.read();
-        
-        if (done) {
-          break;
+      while (true) {
+        if (this.queue.length > 0) {
+          yield this.queue.shift()!;
+          continue;
         }
-        
-        const chunk = decoder.decode(value, { stream: true });
-        buffer += chunk;
-        
-        // Process SSE data lines
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        
-        for (const line of lines) {
-          const trimmedLine = line.trim();
-          if (trimmedLine) {
-            // Support standard SSE format and raw JSON
-            if (trimmedLine.startsWith('data:') || 
-                trimmedLine.startsWith('event:') || 
-                trimmedLine.startsWith('id:') || 
-                trimmedLine.startsWith('retry:')) {
-              this.emit('data', { data: trimmedLine, timestamp: Date.now() });
-              yield trimmedLine;
-            } else {
-              // Handle raw JSON data
-              try {
-                JSON.parse(trimmedLine);
-                this.emit('data', { data: `data: ${trimmedLine}`, timestamp: Date.now() });
-                yield `data: ${trimmedLine}`;
-              } catch {
-                this.emit('data', { data: trimmedLine, timestamp: Date.now() });
-                yield trimmedLine;
-              }
-            }
-          }
-        }
-      }
-      
-      // Process remaining buffer data
-      if (buffer.trim()) {
-        this.emit('data', { data: buffer, timestamp: Date.now() });
-        yield buffer;
-      }
-      
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        // Stream was aborted
-      } else {
-        log.error('Stream reading error', error);
-        const streamError = error instanceof Error ? error : new Error(String(error));
-        this.emit('error', { error: streamError, timestamp: Date.now() });
-        throw streamError;
+
+        if (this.streamClosed) break;
+
+        const result = await new Promise<IteratorResult<string>>(resolve => {
+          this.waiters.push(resolve);
+        });
+        if (result.done) break;
+        yield result.value;
       }
     } finally {
       if (this._state === ConnectionState.STREAMING) {
@@ -231,60 +183,84 @@ export class SSEConnection {
       }
     }
   }
-  
-  // Event system
+
   on(event: string, listener: ConnectionEventListener): void {
     const eventListeners = this.listeners.get(event) || [];
     eventListeners.push(listener);
     this.listeners.set(event, eventListeners);
   }
-  
+
   off(event: string, listener: ConnectionEventListener): void {
     const eventListeners = this.listeners.get(event) || [];
     const index = eventListeners.indexOf(listener);
-    if (index >= 0) {
-      eventListeners.splice(index, 1);
-    }
+    if (index >= 0) eventListeners.splice(index, 1);
   }
-  
-  // State queries
+
   isConnected(): boolean {
     return this._state === ConnectionState.CONNECTED || this._state === ConnectionState.STREAMING;
   }
-  
+
   isStreaming(): boolean {
     return this._state === ConnectionState.STREAMING;
   }
-  
-  // Metadata
+
   getMetadata(): Record<string, any> {
     return { ...this.metadata };
   }
-  
+
+  private enqueue(value: string): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ value, done: false });
+      return;
+    }
+    this.queue.push(value);
+  }
+
+  private closeQueuedStream(): void {
+    this.streamClosed = true;
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.({ value: undefined as any, done: true });
+    }
+  }
+
+  private normalizeBody(body?: string | FormData | ArrayBuffer): string | object | undefined {
+    if (!body) return undefined;
+    if (typeof body === 'string') return body;
+    return body as any;
+  }
+
+  private formatEvent(event: { event: string; data: string; id?: string }): string {
+    const lines: string[] = [];
+    if (event.id) lines.push(`id: ${event.id}`);
+    if (event.event && event.event !== 'message') lines.push(`event: ${event.event}`);
+    lines.push(`data: ${event.data}`);
+    return lines.join('\n');
+  }
+
   private setMetadata(key: string, value: any): void {
     this.metadata[key] = value;
   }
-  
+
   private setState(newState: ConnectionState): void {
     const oldState = this._state;
     this._state = newState;
-    
     this.emit('stateChange', {
       type: 'stateChange' as any,
       data: { oldState, newState },
-      timestamp: Date.now()
+      timestamp: Date.now(),
     });
   }
-  
+
   private emit(event: string, eventData: Omit<ConnectionEvent, 'type'> & { type?: any }): void {
     const listeners = this.listeners.get(event) || [];
     const connectionEvent: ConnectionEvent = {
       type: eventData.type || event as any,
       data: eventData.data,
       error: eventData.error,
-      timestamp: eventData.timestamp || Date.now()
+      timestamp: eventData.timestamp || Date.now(),
     };
-    
+
     for (const listener of listeners) {
       try {
         listener(connectionEvent);
@@ -293,7 +269,7 @@ export class SSEConnection {
       }
     }
   }
-  
+
   private createError(message: string, code?: string): Error {
     const error = new Error(message);
     (error as any).code = code || 'CONNECTION_ERROR';
@@ -302,24 +278,18 @@ export class SSEConnection {
   }
 }
 
-// ================================================================================
-// SSE Transport Factory (Compatibility)
-// ================================================================================
-
 export class SSETransportFactory {
   readonly protocol = 'sse';
-  
+
   async createConnection(config: ConnectionConfig): Promise<SSEConnection> {
-    const sseConfig: SSETransportConfig = {
+    return new SSEConnection({
       ...config,
       reconnectInterval: 1000,
       maxReconnectAttempts: 3,
-      withCredentials: true
-    };
-    
-    return new SSEConnection(sseConfig);
+      withCredentials: true,
+    });
   }
-  
+
   supportsUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
@@ -330,113 +300,51 @@ export class SSETransportFactory {
   }
 }
 
-// ================================================================================
-// SSE Transport Manager (Compatibility)
-// ================================================================================
-
 export class SSETransport {
-  private config: SSETransportConfig;
-  private factory: SSETransportFactory;
-  
-  constructor(config: SSETransportConfig = { url: '' }) {
-    this.config = config;
-    this.factory = new SSETransportFactory();
-  }
-  
-  /**
-   * Connect to SSE endpoint
-   */
+  private factory = new SSETransportFactory();
+
+  constructor(private config: SSETransportConfig = { url: '' }) {}
+
   async connect(endpoint: string, options: ConnectionOptions = {}): Promise<SSEConnection> {
-    const connectionConfig: SSETransportConfig = {
+    const connection = await this.factory.createConnection({
       ...this.config,
-      url: endpoint
-    };
-    
-    const connection = await this.factory.createConnection(connectionConfig);
+      url: endpoint,
+    });
     await connection.connect(options);
-    
     return connection;
   }
-  
-  /**
-   * Update transport config
-   */
+
   updateConfig(newConfig: Partial<SSETransportConfig>): void {
     this.config = { ...this.config, ...newConfig };
   }
-  
-  /**
-   * Get current config
-   */
+
   getConfig(): Readonly<SSETransportConfig> {
     return { ...this.config };
   }
 }
 
-// ================================================================================
-// Factory Functions (Compatibility)
-// ================================================================================
+export const createSSETransport = (config: SSETransportConfig = { url: '' }): SSETransport =>
+  new SSETransport(config);
 
-/**
- * Create SSE transport instance
- */
-export const createSSETransport = (config: SSETransportConfig = { url: '' }): SSETransport => {
-  return new SSETransport(config);
-};
+export const createSSETransportFactory = (): SSETransportFactory =>
+  new SSETransportFactory();
 
-/**
- * Create SSE connection factory
- */
-export const createSSETransportFactory = (): SSETransportFactory => {
-  return new SSETransportFactory();
-};
-
-// ================================================================================
-// Predefined Configurations (Compatibility)
-// ================================================================================
-
-/**
- * Standard SSE transport config
- */
 export const StandardSSEConfig: SSETransportConfig = {
   url: '',
-  timeout: 300000, // 5 minutes
+  timeout: 300000,
   reconnectInterval: 1000,
   maxReconnectAttempts: 3,
   withCredentials: true,
   retryConfig: {
     maxRetries: 3,
     retryDelay: 1000,
-    backoffMultiplier: 1.5
-  }
+    backoffMultiplier: 1.5,
+  },
 };
 
-/**
- * Long-lived SSE config
- */
 export const LongLivedSSEConfig: SSETransportConfig = {
   ...StandardSSEConfig,
-  timeout: 600000, // 10 minutes
+  timeout: 600000,
   maxReconnectAttempts: 5,
-  reconnectInterval: 2000
+  reconnectInterval: 2000,
 };
-
-// ================================================================================
-// Migration Note
-// ================================================================================
-
-/**
- * MIGRATION NOTE:
- * 
- * This is a compatibility wrapper. For new implementations, consider using:
- * 
- * import { AgentService } from '@isa/core';
- * 
- * const agentService = new AgentService();
- * await agentService.chat(request, {
- *   onContentToken: (event) => console.log(event.content),
- *   onError: (error) => console.error(error)
- * });
- * 
- * The AgentService provides built-in SSE handling with comprehensive event parsing.
- */

--- a/src/components/ui/chat/InputAreaLayout.tsx
+++ b/src/components/ui/chat/InputAreaLayout.tsx
@@ -8,33 +8,7 @@ import { useProgressiveStage } from '../../../hooks/useProgressiveStage';
 import { useMessageStore } from '../../../stores/useMessageStore';
 import { useStreamingStore } from '../../../stores/useStreamingStore';
 import { ModelSelectorDropdown } from './ModelSelectorDropdown';
-// SDK streaming component — inline implementation until @isa/ui-web dist is rebuilt (#290)
-const StreamingStatusLine: React.FC<{
-  phase: string;
-  message?: string;
-  isThinking?: boolean;
-  activeTasks?: number;
-  className?: string;
-}> = ({ phase, message, isThinking, activeTasks, className = '' }) => {
-  const defaultMessages: Record<string, string> = {
-    idle: '', connecting: 'Connecting...', preparing: 'Preparing...',
-    generating: 'Responding...', done: '',
-  };
-  const text = message || defaultMessages[phase] || '';
-  if (!text && !isThinking && !activeTasks) return null;
-
-  return (
-    <div className={`flex items-center gap-1.5 ${className}`} role="status" aria-live="polite">
-      {phase !== 'idle' && phase !== 'done' && (
-        <span className={`w-1.5 h-1.5 rounded-full ${isThinking ? 'bg-amber-400' : 'bg-blue-400'} animate-pulse`} />
-      )}
-      <span>{isThinking ? 'Thinking...' : text}</span>
-      {activeTasks != null && activeTasks > 0 && (
-        <span className="ml-auto opacity-70">{activeTasks} task{activeTasks !== 1 ? 's' : ''} active</span>
-      )}
-    </div>
-  );
-};
+import { StreamingStatusLine } from './streamingSdkCompat';
 const log = createLogger('InputAreaLayout');
 
 export interface InputAreaLayoutProps {

--- a/src/components/ui/chat/MessageList.tsx
+++ b/src/components/ui/chat/MessageList.tsx
@@ -20,7 +20,7 @@
  * - 在新架构中被ChatContentLayout使用
  * - 不处理业务逻辑，只负责消息的视觉呈现
  */
-import React, { memo, useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import React, { memo, useState, useMemo, useRef, useCallback } from 'react';
 import { createLogger } from '../../../utils/logger';
 import { ChatMessage, ArtifactMessage, RegularMessage } from '../../../types/chatTypes';
 const log = createLogger('MessageList');
@@ -45,31 +45,9 @@ import { ChannelOriginBadge } from './ChannelOriginBadge';
 import { DelegationCard } from './DelegationCard';
 import { DeepThinking as DeepThinkingOriginal } from '@isa/ui-web';
 import type { ThinkingStep, DeepThinkingProps } from '@isa/ui-web';
+import { ThinkingBlock } from './streamingSdkCompat';
 // Cast to work around React types version mismatch between packages
 const DeepThinking = DeepThinkingOriginal as React.FC<DeepThinkingProps>;
-// SDK streaming components — inline until @isa/ui-web dist is rebuilt (#290)
-const ThinkingBlock: React.FC<{
-  isThinking: boolean; content: string; autoCollapse?: boolean; className?: string;
-}> = ({ isThinking, content, className = '' }) => {
-  const [expanded, setExpanded] = useState(isThinking);
-  useEffect(() => { if (isThinking) setExpanded(true); }, [isThinking]);
-  useEffect(() => { if (!isThinking) { const t = setTimeout(() => setExpanded(false), 500); return () => clearTimeout(t); } }, [isThinking]);
-  if (!content && !isThinking) return null;
-  return (
-    <div className={`border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-2 ${className}`}>
-      <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center gap-2 px-3 py-2 bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 dark:text-gray-400 text-left">
-        <span style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', fontSize: '8px' }}>▶</span>
-        {isThinking && <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />}
-        <span className="font-medium">{isThinking ? 'Thinking...' : 'Thought process'}</span>
-      </button>
-      {expanded && (
-        <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 font-mono whitespace-pre-wrap max-h-96 overflow-auto">
-          {content}{isThinking && <span className="opacity-40 animate-pulse">▋</span>}
-        </div>
-      )}
-    </div>
-  );
-};
 const ToolCallDisplay: React.FC<any> = () => null; // Placeholder until wired
 import { GentleNotification } from './GentleNotification';
 import type { GentleNotificationType } from './GentleNotification';

--- a/src/components/ui/chat/streamingSdkCompat.tsx
+++ b/src/components/ui/chat/streamingSdkCompat.tsx
@@ -1,0 +1,14 @@
+import type React from 'react';
+import {
+  StreamingStatusLine as SDKStreamingStatusLine,
+  ThinkingBlock as SDKThinkingBlock,
+} from '@isa/ui-web';
+import type {
+  StreamingStatusLineProps,
+  ThinkingBlockProps,
+} from '@isa/ui-web';
+
+// Centralize React type casts while the app and SDK resolve separate @types/react copies.
+export const StreamingStatusLine = SDKStreamingStatusLine as React.FC<StreamingStatusLineProps>;
+export const ThinkingBlock = SDKThinkingBlock as React.FC<ThinkingBlockProps>;
+export type { StreamingStatusLineProps, ThinkingBlockProps };

--- a/src/stores/useStreamingStore.ts
+++ b/src/stores/useStreamingStore.ts
@@ -1,6 +1,6 @@
 /**
  * ============================================================================
- * Streaming State Store (useStreamingStore.ts) — Buffers, timers, typing, loading
+ * Streaming State Store (useStreamingStore.ts) — app-specific streaming bridge
  * ============================================================================
  *
  * Extracted from useChatStore as part of #124.
@@ -12,8 +12,8 @@
  *   - useTaskProgress() — typed task progress
  *
  * This store remains because it coordinates cross-store state (useMessageStore,
- * useSessionStore) which is isA_-specific. When @isa/hooks is published,
- * this store should delegate to the SDK hooks internally.
+ * useSessionStore) which is isA_-specific. Generic buffer/timer state is kept
+ * outside Zustand so the store no longer owns streaming protocol internals.
  *
  * Does NOT handle:
  *   - Message array CRUD or history (useMessageStore)
@@ -37,11 +37,15 @@ import { createContentParser, ParsedContent } from '../api/parsing/ContentParser
 // and referenced from ChatModule.tsx).  Encapsulated here.
 // ---------------------------------------------------------------------------
 const _streamingFlushTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+const _streamingBuffers: Map<string, string[]> = new Map();
+const _streamingLastFlush: Map<string, number> = new Map();
 
 /** Expose for external callers that need to clear all timers (e.g. clearMessages). */
 export function clearAllFlushTimers(): void {
   _streamingFlushTimers.forEach(t => clearTimeout(t));
   _streamingFlushTimers.clear();
+  _streamingBuffers.clear();
+  _streamingLastFlush.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -49,10 +53,6 @@ export function clearAllFlushTimers(): void {
 // ---------------------------------------------------------------------------
 
 export interface StreamingStoreState {
-  /** Per-message buffered chunks awaiting flush */
-  streamingBuffers: Record<string, string[]>;
-  /** Timestamp of last flush per message id */
-  streamingLastFlush: Record<string, number>;
   /** Whether the assistant is "typing" */
   isTyping: boolean;
   /** Generic loading flag for chat operations */
@@ -99,8 +99,6 @@ export type StreamingStore = StreamingStoreState & StreamingActions;
 export const useStreamingStore = create<StreamingStore>()(
   subscribeWithSelector((set, get) => ({
     // Initial state
-    streamingBuffers: {},
-    streamingLastFlush: {},
     isTyping: false,
     chatLoading: false,
     activeAbortController: null,
@@ -151,11 +149,8 @@ export const useStreamingStore = create<StreamingStore>()(
       // Write messages back to message store
       useMessageStore.setState({ messages: newMessages });
 
-      // Update local buffers
-      set((state) => ({
-        streamingBuffers: { ...state.streamingBuffers, [id]: [] },
-        streamingLastFlush: { ...state.streamingLastFlush, [id]: Date.now() }
-      }));
+      _streamingBuffers.set(id, []);
+      _streamingLastFlush.set(id, Date.now());
 
       logger.debug(LogCategory.CHAT_FLOW, 'Streaming message started', { id, status });
     },
@@ -170,45 +165,37 @@ export const useStreamingStore = create<StreamingStore>()(
 
       const messageId = lastMessage.id;
 
-      set((state) => {
-        const existingBuffer = state.streamingBuffers[messageId] || [];
-        const updatedBuffer = [...existingBuffer, content];
+      const existingBuffer = _streamingBuffers.get(messageId) || [];
+      const updatedBuffer = [...existingBuffer, content];
+      const now = Date.now();
+      const lastFlush = _streamingLastFlush.get(messageId) || 0;
+      const shouldFlush = updatedBuffer.length >= 20 || now - lastFlush >= 50;
+      const flushContent = shouldFlush ? updatedBuffer.join('') : '';
+      const nextBuffer = shouldFlush ? [] : updatedBuffer;
 
-        const now = Date.now();
-        const lastFlush = state.streamingLastFlush[messageId] || 0;
-        const shouldFlush = updatedBuffer.length >= 20 || now - lastFlush >= 50;
-        const flushContent = shouldFlush ? updatedBuffer.join('') : '';
-        const nextBuffer = shouldFlush ? [] : updatedBuffer;
+      _streamingBuffers.set(messageId, nextBuffer);
+      if (shouldFlush) {
+        _streamingLastFlush.set(messageId, now);
+        flushedMessageId = messageId;
+      } else {
+        flushedMessageId = null;
+      }
 
-        if (shouldFlush) {
-          flushedMessageId = messageId;
-        } else {
-          flushedMessageId = null;
-        }
-
-        if (shouldFlush) {
-          // Flush content into the message store's messages array
-          const msgs = useMessageStore.getState().messages;
-          const last = msgs[msgs.length - 1];
-          if (last && last.id === messageId && last.isStreaming) {
-            const updatedMsgs = [...msgs];
-            if (last.type === 'regular') {
-              updatedMsgs[updatedMsgs.length - 1] = { ...last, content: last.content + flushContent };
-            } else if (last.type === 'artifact') {
-              const currentArtifactContent = typeof last.artifact.content === 'string' ? last.artifact.content : '';
-              updatedMsgs[updatedMsgs.length - 1] = { ...last, artifact: { ...last.artifact, content: currentArtifactContent + flushContent } };
-            }
-            useMessageStore.setState({ messages: updatedMsgs });
+      if (shouldFlush) {
+        // Flush content into the message store's messages array
+        const msgs = useMessageStore.getState().messages;
+        const last = msgs[msgs.length - 1];
+        if (last && last.id === messageId && last.isStreaming) {
+          const updatedMsgs = [...msgs];
+          if (last.type === 'regular') {
+            updatedMsgs[updatedMsgs.length - 1] = { ...last, content: last.content + flushContent };
+          } else if (last.type === 'artifact') {
+            const currentArtifactContent = typeof last.artifact.content === 'string' ? last.artifact.content : '';
+            updatedMsgs[updatedMsgs.length - 1] = { ...last, artifact: { ...last.artifact, content: currentArtifactContent + flushContent } };
           }
+          useMessageStore.setState({ messages: updatedMsgs });
         }
-
-        return {
-          streamingBuffers: { ...state.streamingBuffers, [messageId]: nextBuffer },
-          streamingLastFlush: shouldFlush
-            ? { ...state.streamingLastFlush, [messageId]: now }
-            : state.streamingLastFlush
-        };
-      });
+      }
 
       // Manage auto-flush timer
       const mid = messageId;
@@ -218,8 +205,7 @@ export const useStreamingStore = create<StreamingStore>()(
       if (!flushedMessageId) {
         const timer = setTimeout(() => {
           _streamingFlushTimers.delete(mid);
-          const sState = get();
-          const buf = sState.streamingBuffers[mid];
+          const buf = _streamingBuffers.get(mid);
           if (!buf || buf.length === 0) return;
           const flushContent = buf.join('');
 
@@ -235,10 +221,8 @@ export const useStreamingStore = create<StreamingStore>()(
           }
           useMessageStore.setState({ messages: updatedMessages });
 
-          set((s) => ({
-            streamingBuffers: { ...s.streamingBuffers, [mid]: [] },
-            streamingLastFlush: { ...s.streamingLastFlush, [mid]: Date.now() },
-          }));
+          _streamingBuffers.set(mid, []);
+          _streamingLastFlush.set(mid, Date.now());
         }, 100);
         _streamingFlushTimers.set(mid, timer);
       } else {
@@ -261,8 +245,7 @@ export const useStreamingStore = create<StreamingStore>()(
         _streamingFlushTimers.delete(messageId);
       }
 
-      const state = get();
-      const buffer = state.streamingBuffers[messageId] || [];
+      const buffer = _streamingBuffers.get(messageId) || [];
       const flushContent = buffer.length > 0 ? buffer.join('') : '';
 
       const finalizedMessage =
@@ -329,14 +312,8 @@ export const useStreamingStore = create<StreamingStore>()(
         });
       }
 
-      // Clear buffers
-      set((s) => {
-        const nextBuffers = { ...s.streamingBuffers };
-        const nextLastFlush = { ...s.streamingLastFlush };
-        delete nextBuffers[messageId];
-        delete nextLastFlush[messageId];
-        return { streamingBuffers: nextBuffers, streamingLastFlush: nextLastFlush };
-      });
+      _streamingBuffers.delete(messageId);
+      _streamingLastFlush.delete(messageId);
 
       logger.debug(LogCategory.CHAT_FLOW, 'Streaming message finished');
     },


### PR DESCRIPTION
## Summary
- Fixes #348 under parent #280.
- Replaces local AGUI/content/SSE implementations with thin app compatibility wrappers over @isa/core and @isa/transport.
- Replaces inline StreamingStatusLine and ThinkingBlock fallbacks with @isa/ui-web components behind a centralized compatibility shim.
- Moves generic stream buffer/flush maps out of Zustand state and preserves app-specific streaming coordination in useStreamingStore.
- Adds regression coverage for SDK parser compatibility, canonical terminal events, and Mate terminal completion.

## Verification
- PASS: npm test -- src/api/parsing/__tests__/StreamingSdkAdapters.test.ts src/api/parsing/__tests__/RealAPIEventMapping.test.ts (21 tests)
- PASS: npm test -- src/api/__tests__/chatService.test.ts src/api/adapters/__tests__/MateEventAdapter.test.ts (79 tests)
- BASELINE FAIL: npm test (599 passed, 2 existing account-route config failures: src/config/__tests__/config.test.ts and src/config/__tests__/gatewayIntegration.test.ts)
- PASS: git diff --cached --check
- PASS: changed-file TypeScript filter produced no errors for this branch's files
- BASELINE FAIL: npm run build is blocked by existing ESLint rule-definition errors in ArtifactPanel.tsx, CodeSandboxPanel.tsx, and UserButtonContainer.tsx

## Notes
- The SDK parser normalizes legacy AGUI events. The app wrapper preserves compatibility fields still consumed by isA_ callbacks: final content, run/message IDs, legacy billing counters, and artifact update intent.