### PR TITLE
test: stabilize baseline frontend test suite

### DIFF
--- a/src/api/__tests__/userService.test.ts
+++ b/src/api/__tests__/userService.test.ts
@@ -126,7 +126,11 @@ describe('UserService', () => {
 
       const result = await service.ensureUserExists(userData);
 
-      expect(getMocks().mockPost).toHaveBeenCalledWith('/api/v1/users/ensure', userData);
+      expect(getMocks().mockPost).toHaveBeenCalledWith('/api/v1/accounts/ensure', {
+        user_id: 'auth0|123',
+        email: 'alice@example.com',
+        name: 'Alice',
+      });
       expect(result).toEqual(mockUser);
     });
 

--- a/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
+++ b/src/api/parsing/__tests__/StreamingSdkAdapters.test.ts
@@ -19,7 +19,7 @@ describe('streaming SDK parser adapters', () => {
       },
       timestamp: '2026-04-23T08:00:00.000Z',
     });
-  });
+  }, 15000);
 
   test('AGUIEventParser preserves app compatibility fields on normalized SDK events', async () => {
     const { createAGUIEventParser } = await import('../AGUIEventParser');
@@ -125,7 +125,7 @@ describe('streaming SDK parser adapters', () => {
         target: 'https://example.com',
       },
     });
-  });
+  }, 15000);
 
   test('ContentParser delegates detection to the SDK ContentTypeDetector', async () => {
     const { createContentParser } = await import('../ContentParser');
@@ -153,7 +153,7 @@ describe('streaming SDK parser adapters', () => {
       elementCount: 1,
       typeDistribution: { json: 1 },
     });
-  });
+  }, 15000);
 });
 
 vi.mock('@isa/transport', () => {

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -57,6 +57,12 @@ describe('API path configuration', () => {
     expect(API_PATHS.EXECUTION.HEALTH).toMatch(/^\//);
     expect(API_PATHS.SESSION.BASE).toMatch(/^\//);
   });
+
+  test('user routes match the current account service contract', () => {
+    expect(API_PATHS.USER.ME).toBe('/api/v1/accounts/me');
+    expect(API_PATHS.USER.ENSURE).toBe('/api/v1/accounts/ensure');
+    expect(API_PATHS.USER.SUBSCRIPTION).toBe('/api/v1/accounts/{userId}/subscription');
+  });
 });
 
 describe('timeout configuration', () => {

--- a/src/config/__tests__/gatewayConfig.test.ts
+++ b/src/config/__tests__/gatewayConfig.test.ts
@@ -28,10 +28,10 @@ describe('GATEWAY_CONFIG', () => {
 
 describe('GATEWAY_SERVICES', () => {
   test('core services are defined', () => {
-    expect(GATEWAY_SERVICES.AGENTS).toBe('agents');
-    expect(GATEWAY_SERVICES.ACCOUNTS).toBe('accounts');
-    expect(GATEWAY_SERVICES.SESSIONS).toBe('sessions');
-    expect(GATEWAY_SERVICES.AUTH).toBe('auth');
+    expect(GATEWAY_SERVICES.AGENTS).toBe('api/v1/agents');
+    expect(GATEWAY_SERVICES.ACCOUNTS).toBe('api/v1/accounts');
+    expect(GATEWAY_SERVICES.SESSIONS).toBe('api/v1/sessions');
+    expect(GATEWAY_SERVICES.AUTH).toBe('api/v1/auth');
   });
 });
 
@@ -74,7 +74,7 @@ describe('requiresAuth', () => {
 
   test('other endpoints require auth', () => {
     expect(requiresAuth('/api/v1/agents/chat')).toBe(true);
-    expect(requiresAuth('/api/v1/users/me')).toBe(true);
+    expect(requiresAuth('/api/v1/accounts/me')).toBe(true);
   });
 });
 

--- a/src/config/__tests__/gatewayIntegration.test.ts
+++ b/src/config/__tests__/gatewayIntegration.test.ts
@@ -65,8 +65,8 @@ describe('Gateway endpoint construction', () => {
   });
 
   test('ACCOUNTS endpoints include user paths', () => {
-    expect(GATEWAY_ENDPOINTS.ACCOUNTS.ME).toContain('/api/v1/users/me');
-    expect(GATEWAY_ENDPOINTS.ACCOUNTS.ENSURE).toContain('/api/v1/users/ensure');
+    expect(GATEWAY_ENDPOINTS.ACCOUNTS.ME).toContain('/api/v1/accounts/me');
+    expect(GATEWAY_ENDPOINTS.ACCOUNTS.ENSURE).toContain('/api/v1/accounts/ensure');
     expect(GATEWAY_ENDPOINTS.ACCOUNTS.CREDITS).toContain('{userId}');
   });
 

--- a/src/stores/__tests__/useArtifactManager.test.ts
+++ b/src/stores/__tests__/useArtifactManager.test.ts
@@ -212,5 +212,5 @@ describe('useArtifactManager', () => {
     expect(artifact?.contentType).toBe('a2ui_surface');
     expect(getActiveVersion(artifact!).content).toBe(JSON.stringify({ title: 'Interactive answer' }, null, 2));
     expect(getActiveVersion(artifact!).a2uiState).toEqual(surfaceState);
-  });
+  }, 15000);
 });

--- a/src/stores/__tests__/useCalendarStore.test.ts
+++ b/src/stores/__tests__/useCalendarStore.test.ts
@@ -74,6 +74,20 @@ function makeStoreEvent(overrides: Record<string, any> = {}) {
   };
 }
 
+function offsetIso(daysFromNow: number, hour = 9, durationHours = 1) {
+  const start = new Date();
+  start.setDate(start.getDate() + daysFromNow);
+  start.setHours(hour, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setHours(end.getHours() + durationHours);
+
+  return {
+    startTime: start.toISOString(),
+    endTime: end.toISOString(),
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -135,12 +149,12 @@ describe('useCalendarStore', () => {
 
   test('creates events optimistically and replaces the temporary event with SDK response', async () => {
     const pending = deferred<any>();
+    const todaySlot = offsetIso(0, 10);
     mockCreateEvent.mockReturnValue(pending.promise);
 
     const createPromise = useCalendarStore.getState().createEvent({
       title: 'Planning',
-      startTime: '2026-04-23T10:00:00Z',
-      endTime: '2026-04-23T11:00:00Z',
+      ...todaySlot,
     });
 
     expect(useCalendarStore.getState().events[0].id).toMatch(/^optimistic-/);
@@ -153,8 +167,8 @@ describe('useCalendarStore', () => {
       expect.objectContaining({
         user_id: 'user-1',
         title: 'Planning',
-        start_time: '2026-04-23T10:00:00Z',
-        end_time: '2026-04-23T11:00:00Z',
+        start_time: todaySlot.startTime,
+        end_time: todaySlot.endTime,
       }),
     );
     expect(created.id).toBe('evt-created');
@@ -252,16 +266,15 @@ describe('useCalendarStore', () => {
       events: [
         makeStoreEvent({
           id: 'today',
-          startTime: new Date().toISOString(),
-          endTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          ...offsetIso(0, 9),
         }),
         makeStoreEvent({
           id: 'next-week',
-          startTime: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+          ...offsetIso(10, 9),
         }),
         makeStoreEvent({
           id: 'tomorrow',
-          startTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+          ...offsetIso(1, 9),
         }),
       ],
     };


### PR DESCRIPTION
## Summary
- align account and gateway test expectations with the current `/api/v1/accounts` and APISIX service contracts
- make calendar store tests relative to the current date so they do not flip as the suite ages
- add explicit timeouts for slow-but-valid SDK and artifact manager integration tests

## Verification
- `npm test -- src/api/__tests__/userService.test.ts src/config/__tests__/gatewayConfig.test.ts src/stores/__tests__/useArtifactManager.test.ts src/config/__tests__/config.test.ts src/config/__tests__/gatewayIntegration.test.ts src/stores/__tests__/useCalendarStore.test.ts src/api/parsing/__tests__/StreamingSdkAdapters.test.ts`
  - 7 files passed, 104 tests passed
- `npm test`
  - 47 files passed, 608 tests passed