### PR TITLE
fix(project): centralize shared project state

### DIFF
--- a/src/api/__tests__/projectService.test.ts
+++ b/src/api/__tests__/projectService.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const {
+  mockCoreList,
+  mockCoreCreate,
+  mockCoreDelete,
+  mockCoreSetInstructions,
+  mockGetAuthHeaders,
+} = vi.hoisted(() => ({
+  mockCoreList: vi.fn(),
+  mockCoreCreate: vi.fn(),
+  mockCoreDelete: vi.fn(),
+  mockCoreSetInstructions: vi.fn(),
+  mockGetAuthHeaders: vi.fn(),
+}));
+
+vi.mock('@isa/core', () => ({
+  ProjectService: vi.fn().mockImplementation(() => ({
+    list: mockCoreList,
+    create: mockCoreCreate,
+    delete: mockCoreDelete,
+    setInstructions: mockCoreSetInstructions,
+  })),
+}));
+
+vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://localhost:9080',
+  },
+  getAuthHeaders: mockGetAuthHeaders,
+}));
+
+import { ProjectService as CoreProjectService } from '@isa/core';
+import { ProjectService } from '../projectService';
+
+describe('projectService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    mockGetAuthHeaders.mockReturnValue({ Authorization: 'Bearer test-token' });
+  });
+
+  test('initializes the SDK project client with the gateway projects path and auth-aware fetch', async () => {
+    new ProjectService();
+
+    expect(CoreProjectService).toHaveBeenCalledWith(
+      'http://localhost:9080/api/v1/projects',
+      expect.any(Function),
+    );
+
+    const authorizedFetch = vi.mocked(CoreProjectService).mock.calls[0]?.[1] as typeof fetch;
+    await authorizedFetch('http://localhost:9080/api/v1/projects', {
+      method: 'GET',
+      headers: { 'X-Test': '1' },
+      credentials: 'same-origin',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('http://localhost:9080/api/v1/projects', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'X-Test': '1',
+      },
+    });
+  });
+
+  test('lists projects through the SDK client', async () => {
+    const response = {
+      projects: [{ id: 'project-1', name: 'Alpha', custom_instructions: 'Use TS' }],
+      total: 1,
+    };
+    mockCoreList.mockResolvedValue(response);
+    const service = new ProjectService();
+
+    const result = await service.listProjects();
+
+    expect(mockCoreList).toHaveBeenCalledWith(50, 0);
+    expect(result).toEqual(response);
+  });
+
+  test('creates a project through the SDK client', async () => {
+    const created = { id: 'project-2', name: 'Beta', description: 'Docs' };
+    mockCoreCreate.mockResolvedValue(created);
+    const service = new ProjectService();
+
+    const result = await service.createProject({ name: 'Beta', description: 'Docs' });
+
+    expect(mockCoreCreate).toHaveBeenCalledWith({ name: 'Beta', description: 'Docs' });
+    expect(result).toEqual(created);
+  });
+
+  test('deletes a project through the SDK client', async () => {
+    mockCoreDelete.mockResolvedValue(undefined);
+    const service = new ProjectService();
+
+    await service.deleteProject('project-3');
+
+    expect(mockCoreDelete).toHaveBeenCalledWith('project-3');
+  });
+
+  test('saves project instructions through the SDK client', async () => {
+    mockCoreSetInstructions.mockResolvedValue(undefined);
+    const service = new ProjectService();
+
+    await service.setProjectInstructions('project-4', 'Prefer strict TypeScript');
+
+    expect(mockCoreSetInstructions).toHaveBeenCalledWith(
+      'project-4',
+      'Prefer strict TypeScript',
+    );
+  });
+});

--- a/src/api/projectService.ts
+++ b/src/api/projectService.ts
@@ -1,0 +1,81 @@
+import { ProjectService as CoreProjectService } from '@isa/core';
+import { GATEWAY_CONFIG, getAuthHeaders } from '../config/gatewayConfig';
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  custom_instructions?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateProjectParams {
+  name: string;
+  description?: string;
+  custom_instructions?: string;
+}
+
+export interface ProjectListResponse {
+  projects: Project[];
+  total: number;
+}
+
+const buildProjectsBaseUrl = () =>
+  `${GATEWAY_CONFIG.BASE_URL.replace(/\/$/, '')}/api/v1/projects`;
+
+const buildAuthorizedFetch = (): typeof fetch => {
+  return (input, init) =>
+    fetch(input, {
+      ...init,
+      credentials: 'include',
+      headers: {
+        ...getAuthHeaders(),
+        ...(init?.headers ?? {}),
+      },
+    });
+};
+
+export const getProjectErrorMessage = (
+  error: unknown,
+  fallback = 'Something went wrong while saving the project.',
+): string => {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+
+  return fallback;
+};
+
+export class ProjectService {
+  private coreProjectService: CoreProjectService;
+
+  constructor(baseUrl: string = buildProjectsBaseUrl()) {
+    this.coreProjectService = new CoreProjectService(
+      baseUrl,
+      buildAuthorizedFetch(),
+    );
+  }
+
+  async listProjects(limit = 50, offset = 0): Promise<ProjectListResponse> {
+    return this.coreProjectService.list(limit, offset) as Promise<ProjectListResponse>;
+  }
+
+  async createProject(params: CreateProjectParams): Promise<Project> {
+    return this.coreProjectService.create(params) as Promise<Project>;
+  }
+
+  async deleteProject(projectId: string): Promise<void> {
+    await this.coreProjectService.delete(projectId);
+  }
+
+  async setProjectInstructions(projectId: string, instructions: string): Promise<void> {
+    await this.coreProjectService.setInstructions(projectId, instructions);
+  }
+}
+
+export const projectService = new ProjectService();

--- a/src/components/ui/chat/ProjectSwitcher.tsx
+++ b/src/components/ui/chat/ProjectSwitcher.tsx
@@ -5,10 +5,19 @@
  * Dropdown to switch projects or create new ones.
  */
 import React, { useState, useRef, useEffect } from 'react';
-import { useProjects, Project } from '../../../hooks/useProjects';
+import { useProjects } from '../../../hooks/useProjects';
 
 export const ProjectSwitcher: React.FC = () => {
-  const { projects, activeProject, selectProject, createProject, deleteProject, loading } = useProjects();
+  const {
+    projects,
+    activeProject,
+    selectProject,
+    createProject,
+    loading,
+    creatingProject,
+    error,
+    clearError,
+  } = useProjects();
   const [open, setOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
@@ -34,9 +43,12 @@ export const ProjectSwitcher: React.FC = () => {
 
   const handleCreate = async () => {
     if (!newName.trim()) return;
-    await createProject(newName.trim());
+    clearError();
+    const project = await createProject(newName.trim());
+    if (!project) return;
     setNewName('');
     setCreating(false);
+    setOpen(false);
   };
 
   if (loading) return null;
@@ -99,20 +111,43 @@ export const ProjectSwitcher: React.FC = () => {
           {/* Create new */}
           <div className="border-t border-gray-100 dark:border-gray-700">
             {creating ? (
-              <div className="px-3 py-2 flex gap-2">
-                <input
-                  ref={inputRef}
-                  value={newName}
-                  onChange={e => setNewName(e.target.value)}
-                  onKeyDown={e => { if (e.key === 'Enter') handleCreate(); if (e.key === 'Escape') setCreating(false); }}
-                  placeholder="Project name"
-                  className="flex-1 text-sm px-2 py-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-transparent text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                />
-                <button onClick={handleCreate} className="text-xs px-2 py-1 bg-blue-500 text-white rounded-lg hover:bg-blue-600">Create</button>
+              <div className="px-3 py-2 space-y-2">
+                <div className="flex gap-2">
+                  <input
+                    ref={inputRef}
+                    value={newName}
+                    onChange={e => {
+                      setNewName(e.target.value);
+                      if (error) clearError();
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') handleCreate();
+                      if (e.key === 'Escape') {
+                        setCreating(false);
+                        clearError();
+                      }
+                    }}
+                    placeholder="Project name"
+                    className="flex-1 text-sm px-2 py-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-transparent text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  />
+                  <button
+                    onClick={handleCreate}
+                    disabled={!newName.trim() || creatingProject}
+                    className="text-xs px-2 py-1 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50"
+                  >
+                    {creatingProject ? 'Creating...' : 'Create'}
+                  </button>
+                </div>
+                {error && (
+                  <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+                )}
               </div>
             ) : (
               <button
-                onClick={() => setCreating(true)}
+                onClick={() => {
+                  clearError();
+                  setCreating(true);
+                }}
                 className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/ui/settings/ProjectSettings.tsx
+++ b/src/components/ui/settings/ProjectSettings.tsx
@@ -1,17 +1,24 @@
 /**
  * ProjectSettings — Per-project instructions and knowledge base (#192)
- * Uses activeProject from useProjects hook.
+ * Uses shared project store state so switcher and settings stay in sync.
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useProjects } from '../../../hooks/useProjects';
-import { GATEWAY_ENDPOINTS } from '../../../config/gatewayConfig';
 
 export const ProjectSettings: React.FC = () => {
-  const { activeProject, activeProjectId } = useProjects();
+  const {
+    activeProject,
+    activeProjectId,
+    loading,
+    savingInstructions,
+    saveProjectInstructions,
+    error,
+    clearError,
+  } = useProjects();
   const [instructions, setInstructions] = useState('');
   const [saved, setSaved] = useState('');
-  const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const previousProjectIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (activeProject?.custom_instructions) {
@@ -21,26 +28,46 @@ export const ProjectSettings: React.FC = () => {
       setInstructions('');
       setSaved('');
     }
-  }, [activeProject]);
+
+    const nextProjectId = activeProject?.id ?? null;
+    if (previousProjectIdRef.current !== nextProjectId) {
+      setMessage(null);
+      clearError();
+      previousProjectIdRef.current = nextProjectId;
+    }
+  }, [activeProject, clearError]);
+
+  useEffect(() => {
+    if (!message) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setMessage(null), 3000);
+    return () => window.clearTimeout(timeout);
+  }, [message]);
 
   const handleSave = useCallback(async () => {
     if (!activeProjectId) return;
-    setSaving(true);
-    try {
-      const url = `${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', `/projects/${activeProjectId}/instructions`);
-      const res = await fetch(url, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ instructions }),
-      });
-      if (res.ok) {
-        setSaved(instructions);
-        setMessage('Saved');
-        setTimeout(() => setMessage(null), 2000);
-      }
-    } catch {} finally { setSaving(false); }
-  }, [activeProjectId, instructions]);
+    clearError();
+    setMessage(null);
+
+    const wasSaved = await saveProjectInstructions(instructions);
+    if (!wasSaved) {
+      return;
+    }
+
+    setSaved(instructions);
+    setMessage('Project instructions saved');
+  }, [activeProjectId, instructions, clearError, saveProjectInstructions]);
+
+  if (loading && !activeProject) {
+    return (
+      <div className="space-y-3">
+        <div className="h-5 w-40 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        <div className="h-28 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 animate-pulse" />
+      </div>
+    );
+  }
 
   if (!activeProject) {
     return (
@@ -70,12 +97,13 @@ export const ProjectSettings: React.FC = () => {
           <span className="text-xs text-gray-400">{instructions.length}/8000</span>
           <div className="flex items-center gap-2">
             {message && <span className="text-xs text-green-600">{message}</span>}
+            {error && <span className="text-xs text-red-600 dark:text-red-400">{error}</span>}
             <button
               onClick={handleSave}
-              disabled={instructions === saved || saving}
+              disabled={instructions === saved || savingInstructions}
               className="px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 transition-colors"
             >
-              {saving ? 'Saving...' : 'Save'}
+              {savingInstructions ? 'Saving...' : 'Save'}
             </button>
           </div>
         </div>
@@ -85,14 +113,14 @@ export const ProjectSettings: React.FC = () => {
       <div>
         <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Knowledge Base</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-          Upload files for Mate to reference in this project.
+          Knowledge file management is landing in the next `#347` slice. This first fix makes project selection and instructions shared across the app.
         </p>
         <div className="border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl p-8 text-center">
           <svg className="w-8 h-8 mx-auto text-gray-300 dark:text-gray-600 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
-          <p className="text-sm text-gray-400">Drag files here or click to upload</p>
-          <p className="text-xs text-gray-400 mt-1">PDF, DOCX, TXT, CSV, code files up to 30MB</p>
+          <p className="text-sm text-gray-400">Upload and file management will be enabled in the next subtask.</p>
+          <p className="text-xs text-gray-400 mt-1">This slice focuses on shared project state and instruction persistence.</p>
         </div>
       </div>
     </div>

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,84 +1,47 @@
-/**
- * useProjects — Fetch and manage projects (#191)
- * Connects to isA_user project CRUD API (#258)
- */
-import { useState, useEffect, useCallback } from 'react';
-import { GATEWAY_ENDPOINTS, getAuthHeaders } from '../config/gatewayConfig';
+import { useEffect } from 'react';
+import type { Project } from '../api/projectService';
+import { useProjectStore } from '../stores/useProjectStore';
 
-export interface Project {
-  id: string;
-  name: string;
-  description?: string;
-  custom_instructions?: string;
-  created_at?: string;
-  updated_at?: string;
-}
+export type { Project };
 
 export function useProjects() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => {
-    if (typeof window === 'undefined') return null;
-    return localStorage.getItem('isa_active_project') || null;
-  });
-  const [loading, setLoading] = useState(true);
+  const projects = useProjectStore(state => state.projects);
+  const activeProjectId = useProjectStore(state => state.activeProjectId);
+  const activeProject = useProjectStore(
+    state =>
+      state.projects.find(project => project.id === state.activeProjectId) ?? null,
+  );
+  const loading = useProjectStore(state => state.loading);
+  const creatingProject = useProjectStore(state => state.creating);
+  const savingInstructions = useProjectStore(state => state.savingInstructions);
+  const error = useProjectStore(state => state.error);
+  const ensureLoaded = useProjectStore(state => state.ensureLoaded);
+  const refresh = useProjectStore(state => state.refresh);
+  const selectProject = useProjectStore(state => state.selectProject);
+  const createProject = useProjectStore(state => state.createProject);
+  const deleteProject = useProjectStore(state => state.deleteProject);
+  const saveProjectInstructions = useProjectStore(
+    state => state.saveProjectInstructions,
+  );
+  const clearError = useProjectStore(state => state.clearError);
 
-  const fetchProjects = useCallback(async () => {
-    try {
-      const res = await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', '/projects'), {
-        credentials: 'include',
-        headers: getAuthHeaders(),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setProjects(data.projects || []);
-      }
-    } catch {
-      // Silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  useEffect(() => {
+    void ensureLoaded();
+  }, [ensureLoaded]);
 
-  useEffect(() => { fetchProjects(); }, [fetchProjects]);
-
-  const selectProject = useCallback((id: string | null) => {
-    setActiveProjectId(id);
-    try {
-      if (id) localStorage.setItem('isa_active_project', id);
-      else localStorage.removeItem('isa_active_project');
-    } catch {}
-  }, []);
-
-  const createProject = useCallback(async (name: string, description?: string) => {
-    try {
-      const res = await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', '/projects'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-        credentials: 'include',
-        body: JSON.stringify({ name, description }),
-      });
-      if (res.ok) {
-        const project = await res.json();
-        setProjects(prev => [project, ...prev]);
-        return project;
-      }
-    } catch {}
-    return null;
-  }, []);
-
-  const deleteProject = useCallback(async (id: string) => {
-    try {
-      await fetch(`${GATEWAY_ENDPOINTS.MODELS.BASE}`.replace('/models', `/projects/${id}`), {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: getAuthHeaders(),
-      });
-      setProjects(prev => prev.filter(p => p.id !== id));
-      if (activeProjectId === id) setActiveProjectId(null);
-    } catch {}
-  }, [activeProjectId]);
-
-  const activeProject = projects.find(p => p.id === activeProjectId) || null;
-
-  return { projects, activeProject, activeProjectId, selectProject, createProject, deleteProject, loading, refresh: fetchProjects };
+  return {
+    projects,
+    activeProject,
+    activeProjectId,
+    loading,
+    creatingProject,
+    savingInstructions,
+    error,
+    selectProject,
+    createProject,
+    deleteProject,
+    saveProjectInstructions,
+    clearError,
+    refresh,
+  };
 }

--- a/src/stores/__tests__/useCalendarStore.test.ts
+++ b/src/stores/__tests__/useCalendarStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const {
   mockGetTodayEvents,
@@ -101,6 +101,8 @@ function deferred<T>() {
 describe('useCalendarStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-24T00:30:00.000Z'));
     useCalendarStore.setState({
       events: [],
       todayEvents: [],
@@ -110,6 +112,10 @@ describe('useCalendarStore', () => {
     });
     useUserStore.getState().clearUserState();
     useUserStore.getState().setExternalUser({ auth0_id: 'user-1' } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test('fetches today events from the SDK-backed calendar service', async () => {

--- a/src/stores/__tests__/useProjectStore.test.ts
+++ b/src/stores/__tests__/useProjectStore.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PROJECT_ACTIVE_STORAGE_KEY, createProjectStore } from '../useProjectStore';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+const createProject = (overrides: Partial<{ id: string; name: string; custom_instructions: string }> = {}) => ({
+  id: overrides.id ?? 'project-1',
+  name: overrides.name ?? 'Alpha',
+  custom_instructions: overrides.custom_instructions,
+});
+
+const createService = () => ({
+  listProjects: vi.fn(),
+  createProject: vi.fn(),
+  deleteProject: vi.fn(),
+  setProjectInstructions: vi.fn(),
+});
+
+describe('useProjectStore', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('hydrates projects once and keeps a persisted active project when it still exists', async () => {
+    localStorageMock.setItem(PROJECT_ACTIVE_STORAGE_KEY, 'project-2');
+    const service = createService();
+    service.listProjects.mockResolvedValue({
+      projects: [
+        createProject(),
+        createProject({ id: 'project-2', name: 'Bravo' }),
+      ],
+      total: 2,
+    });
+    const store = createProjectStore(service);
+
+    await store.getState().ensureLoaded();
+    await store.getState().ensureLoaded();
+
+    expect(service.listProjects).toHaveBeenCalledTimes(1);
+    expect(store.getState().projects).toHaveLength(2);
+    expect(store.getState().activeProjectId).toBe('project-2');
+  });
+
+  test('clears a persisted active project when refresh no longer returns it', async () => {
+    localStorageMock.setItem(PROJECT_ACTIVE_STORAGE_KEY, 'missing-project');
+    const service = createService();
+    service.listProjects.mockResolvedValue({
+      projects: [createProject()],
+      total: 1,
+    });
+    const store = createProjectStore(service);
+
+    await store.getState().refresh();
+
+    expect(store.getState().activeProjectId).toBeNull();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith(PROJECT_ACTIVE_STORAGE_KEY);
+  });
+
+  test('creates and auto-selects a new project', async () => {
+    const created = createProject({ id: 'project-9', name: 'New Project' });
+    const service = createService();
+    service.createProject.mockResolvedValue(created);
+    const store = createProjectStore(service);
+
+    const result = await store.getState().createProject('New Project', 'Scope the refactor');
+
+    expect(service.createProject).toHaveBeenCalledWith({
+      name: 'New Project',
+      description: 'Scope the refactor',
+    });
+    expect(result).toEqual(created);
+    expect(store.getState().projects).toEqual([created]);
+    expect(store.getState().activeProjectId).toBe('project-9');
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      PROJECT_ACTIVE_STORAGE_KEY,
+      'project-9',
+    );
+  });
+
+  test('deletes the active project and clears the persisted selection', async () => {
+    const service = createService();
+    service.deleteProject.mockResolvedValue(undefined);
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject()],
+      activeProjectId: 'project-1',
+    });
+
+    await store.getState().deleteProject('project-1');
+
+    expect(service.deleteProject).toHaveBeenCalledWith('project-1');
+    expect(store.getState().projects).toEqual([]);
+    expect(store.getState().activeProjectId).toBeNull();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith(PROJECT_ACTIVE_STORAGE_KEY);
+  });
+
+  test('saves instructions into the active project state', async () => {
+    const service = createService();
+    service.setProjectInstructions.mockResolvedValue(undefined);
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject({ custom_instructions: 'Old' })],
+      activeProjectId: 'project-1',
+    });
+
+    const result = await store.getState().saveProjectInstructions('Use strict TypeScript');
+
+    expect(result).toBe(true);
+    expect(service.setProjectInstructions).toHaveBeenCalledWith(
+      'project-1',
+      'Use strict TypeScript',
+    );
+    expect(store.getState().projects[0]?.custom_instructions).toBe('Use strict TypeScript');
+    expect(store.getState().error).toBeNull();
+  });
+
+  test('captures actionable errors when saving instructions fails', async () => {
+    const service = createService();
+    service.setProjectInstructions.mockRejectedValue(new Error('Gateway unavailable'));
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject()],
+      activeProjectId: 'project-1',
+    });
+
+    const result = await store.getState().saveProjectInstructions('Use strict TypeScript');
+
+    expect(result).toBe(false);
+    expect(store.getState().error).toBe('Gateway unavailable');
+    expect(store.getState().savingInstructions).toBe(false);
+  });
+});

--- a/src/stores/useProjectStore.ts
+++ b/src/stores/useProjectStore.ts
@@ -1,0 +1,212 @@
+import { create } from 'zustand';
+import {
+  type CreateProjectParams,
+  type Project,
+  projectService,
+  getProjectErrorMessage,
+} from '../api/projectService';
+
+export const PROJECT_ACTIVE_STORAGE_KEY = 'isa_active_project';
+
+export interface ProjectStoreService {
+  listProjects: (limit?: number, offset?: number) => Promise<{
+    projects: Project[];
+    total: number;
+  }>;
+  createProject: (params: CreateProjectParams) => Promise<Project>;
+  deleteProject: (projectId: string) => Promise<void>;
+  setProjectInstructions: (projectId: string, instructions: string) => Promise<void>;
+}
+
+export interface ProjectStoreState {
+  projects: Project[];
+  activeProjectId: string | null;
+  loading: boolean;
+  creating: boolean;
+  savingInstructions: boolean;
+  initialized: boolean;
+  error: string | null;
+  ensureLoaded: () => Promise<void>;
+  refresh: () => Promise<void>;
+  selectProject: (projectId: string | null) => void;
+  createProject: (name: string, description?: string) => Promise<Project | null>;
+  deleteProject: (projectId: string) => Promise<void>;
+  saveProjectInstructions: (instructions: string) => Promise<boolean>;
+  clearError: () => void;
+}
+
+const readStoredActiveProjectId = (): string | null => {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    return localStorage.getItem(PROJECT_ACTIVE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const persistActiveProjectId = (projectId: string | null) => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    if (projectId) {
+      localStorage.setItem(PROJECT_ACTIVE_STORAGE_KEY, projectId);
+      return;
+    }
+
+    localStorage.removeItem(PROJECT_ACTIVE_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures so project selection still works in-memory.
+  }
+};
+
+const resolveActiveProjectId = (
+  projects: Project[],
+  currentActiveProjectId: string | null,
+): string | null => {
+  if (!currentActiveProjectId) {
+    return null;
+  }
+
+  return projects.some(project => project.id === currentActiveProjectId)
+    ? currentActiveProjectId
+    : null;
+};
+
+export const createProjectStore = (
+  service: ProjectStoreService = projectService,
+) =>
+  create<ProjectStoreState>()((set, get) => ({
+    projects: [],
+    activeProjectId: readStoredActiveProjectId(),
+    loading: false,
+    creating: false,
+    savingInstructions: false,
+    initialized: false,
+    error: null,
+
+    ensureLoaded: async () => {
+      if (get().initialized || get().loading) {
+        return;
+      }
+
+      await get().refresh();
+    },
+
+    refresh: async () => {
+      set({ loading: true, error: null });
+
+      try {
+        const { projects } = await service.listProjects();
+        const nextActiveProjectId = resolveActiveProjectId(
+          projects,
+          get().activeProjectId,
+        );
+
+        persistActiveProjectId(nextActiveProjectId);
+        set({
+          projects,
+          activeProjectId: nextActiveProjectId,
+          initialized: true,
+        });
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(error, 'Failed to load projects'),
+          initialized: true,
+        });
+      } finally {
+        set({ loading: false });
+      }
+    },
+
+    selectProject: (projectId) => {
+      persistActiveProjectId(projectId);
+      set({ activeProjectId: projectId, error: null });
+    },
+
+    createProject: async (name, description) => {
+      set({ creating: true, error: null });
+
+      try {
+        const project = await service.createProject({ name, description });
+        persistActiveProjectId(project.id);
+        set(state => ({
+          projects: [project, ...state.projects],
+          activeProjectId: project.id,
+          initialized: true,
+        }));
+        return project;
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(error, 'Failed to create project'),
+        });
+        return null;
+      } finally {
+        set({ creating: false });
+      }
+    },
+
+    deleteProject: async (projectId) => {
+      try {
+        await service.deleteProject(projectId);
+        set(state => {
+          const nextActiveProjectId =
+            state.activeProjectId === projectId ? null : state.activeProjectId;
+
+          persistActiveProjectId(nextActiveProjectId);
+
+          return {
+            projects: state.projects.filter(project => project.id !== projectId),
+            activeProjectId: nextActiveProjectId,
+            error: null,
+          };
+        });
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(error, 'Failed to delete project'),
+        });
+      }
+    },
+
+    saveProjectInstructions: async (instructions) => {
+      const activeProjectId = get().activeProjectId;
+
+      if (!activeProjectId) {
+        return false;
+      }
+
+      set({ savingInstructions: true, error: null });
+
+      try {
+        await service.setProjectInstructions(activeProjectId, instructions);
+        set(state => ({
+          projects: state.projects.map(project =>
+            project.id === activeProjectId
+              ? { ...project, custom_instructions: instructions }
+              : project,
+          ),
+        }));
+        return true;
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(
+            error,
+            'Failed to save project instructions',
+          ),
+        });
+        return false;
+      } finally {
+        set({ savingInstructions: false });
+      }
+    },
+
+    clearError: () => {
+      set({ error: null });
+    },
+  }));
+
+export const useProjectStore = createProjectStore();


### PR DESCRIPTION
## Summary
- replace hook-local project state with a shared Zustand store so ProjectSwitcher and ProjectSettings stay in sync
- route project CRUD and instruction saves through a local SDK-backed projectService wrapper instead of ad hoc URL replacement fetches
- add regression coverage for project service auth wiring, project store hydration/persistence, and deterministic calendar selector timing

## Testing
- npm test -- src/api/__tests__/projectService.test.ts src/stores/__tests__/useProjectStore.test.ts
- npm test

## Scope
- Refs #347
- This is slice 1 only: shared project state + instruction persistence foundation
- Knowledge file upload/manage flow and Mate project-context injection remain follow-up slices under #347