### PR TITLE
feat(project): add project knowledge file manager

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ const nextConfig = {
       '@isa/ui-web': path.join(sdkRoot, 'ui-web/src'),
       '@isa/theme': path.join(sdkRoot, 'theme/src'),
       '@isa/transport': path.join(sdkRoot, 'transport/src'),
-      '@isa/hooks': path.join(sdkRoot, 'hooks/src'),
+      '@isa/hooks': path.join(__dirname, 'src/hooks/isaSdkHooks.web.ts'),
     };
 
     config.resolve.fallback = {

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
   webpack: (config) => {
     const path = require('path');
     const sdkRoot = path.resolve(__dirname, '../isA_App_SDK/packages');
+    const appNodeModules = path.join(__dirname, 'node_modules');
 
     // Resolve @isa/* packages to source (dist may not be built)
     config.resolve.alias = {
@@ -23,6 +24,13 @@ const nextConfig = {
       '@isa/theme': path.join(sdkRoot, 'theme/src'),
       '@isa/transport': path.join(sdkRoot, 'transport/src'),
       '@isa/hooks': path.join(__dirname, 'src/hooks/isaSdkHooks.web.ts'),
+      // SDK source lives outside this repo and otherwise resolves a second
+      // copy of React from isA_App_SDK/node_modules, which breaks hooks at
+      // runtime with a null dispatcher.
+      react: path.join(appNodeModules, 'react'),
+      'react-dom': path.join(appNodeModules, 'react-dom'),
+      'react/jsx-runtime': path.join(appNodeModules, 'react/jsx-runtime'),
+      'react/jsx-dev-runtime': path.join(appNodeModules, 'react/jsx-dev-runtime'),
     };
 
     config.resolve.fallback = {

--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -622,12 +622,22 @@ describe('ChatService', () => {
   // ==========================================================================
 
   describe('sendMessageViaMate', () => {
-    const mateMetadata = { session_id: 'mate-session-1' };
+    const mateMetadata = {
+      session_id: 'mate-session-1',
+      prompt_args: {
+        project_context: {
+          project_id: 'project-1',
+          project_name: 'Alpha',
+          knowledge_file_ids: ['file-1'],
+        },
+      },
+    };
 
     beforeEach(() => {
       mockBuildMateRequest.mockReturnValue({
         prompt: 'Hello mate',
         session_id: 'mate-session-1',
+        prompt_args: mateMetadata.prompt_args,
       });
       mockCreateMateStreamContext.mockReturnValue({
         startEvent: { type: 'run_started', message_id: 'mate-run-1' },
@@ -635,17 +645,21 @@ describe('ChatService', () => {
       });
     });
 
-    test('calls buildMateRequest with message and session_id', async () => {
+    test('calls buildMateRequest with message, session_id, and prompt_args', async () => {
       mockConnection.stream.mockReturnValue(
         createAsyncIterable(['data: [DONE]'])
       );
 
       await service.sendMessageViaMate('Hello mate', mateMetadata, defaultToken, callbacks);
 
-      expect(mockBuildMateRequest).toHaveBeenCalledWith('Hello mate', 'mate-session-1');
+      expect(mockBuildMateRequest).toHaveBeenCalledWith(
+        'Hello mate',
+        'mate-session-1',
+        mateMetadata.prompt_args,
+      );
     });
 
-    test('builds Mate request format with prompt and session_id', async () => {
+    test('builds Mate request format with prompt, session_id, and prompt_args', async () => {
       mockConnection.stream.mockReturnValue(
         createAsyncIterable(['data: [DONE]'])
       );
@@ -653,7 +667,11 @@ describe('ChatService', () => {
       await service.sendMessageViaMate('Hello mate', mateMetadata, defaultToken, callbacks);
 
       const body = JSON.parse(mockTransport.connect.mock.calls[0][1].body);
-      expect(body).toEqual({ prompt: 'Hello mate', session_id: 'mate-session-1' });
+      expect(body).toEqual({
+        prompt: 'Hello mate',
+        session_id: 'mate-session-1',
+        prompt_args: mateMetadata.prompt_args,
+      });
     });
 
     test('uses MATE.CHAT gateway endpoint', async () => {

--- a/src/api/__tests__/projectService.test.ts
+++ b/src/api/__tests__/projectService.test.ts
@@ -110,4 +110,106 @@ describe('projectService', () => {
       'Prefer strict TypeScript',
     );
   });
+
+  test('lists project knowledge files through the gateway wrapper', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          files: [
+            {
+              id: 'file-1',
+              project_id: 'project-1',
+              filename: 'architecture.md',
+              file_type: 'text/markdown',
+              file_size: 512,
+              storage_path: 'storage/project-1/architecture.md',
+            },
+          ],
+          total: 1,
+        }),
+      }),
+    );
+    const service = new ProjectService();
+
+    const result = await service.listProjectKnowledgeFiles('project-1');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:9080/api/v1/projects/project-1/files',
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      }),
+    );
+    expect(result.total).toBe(1);
+    expect(result.files[0]?.filename).toBe('architecture.md');
+  });
+
+  test('uploads knowledge files through the gateway wrapper without forcing JSON content type', async () => {
+    const uploaded = {
+      id: 'file-2',
+      project_id: 'project-1',
+      filename: 'brief.pdf',
+      file_type: 'application/pdf',
+      file_size: 1024,
+      storage_path: 'storage/project-1/brief.pdf',
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => uploaded,
+      }),
+    );
+    const service = new ProjectService();
+    const file = new File(['brief'], 'brief.pdf', {
+      type: 'application/pdf',
+    });
+
+    const result = await service.uploadProjectKnowledgeFile('project-1', file);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, request] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:9080/api/v1/projects/project-1/files',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      }),
+    );
+    expect(request.body).toBeInstanceOf(FormData);
+    expect((request.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    expect(result).toEqual(uploaded);
+  });
+
+  test('removes knowledge files through the gateway wrapper', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+      }),
+    );
+    const service = new ProjectService();
+
+    await service.deleteProjectKnowledgeFile('project-1', 'file-9');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:9080/api/v1/projects/project-1/files/file-9',
+      expect.objectContaining({
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      }),
+    );
+  });
 });

--- a/src/api/adapters/MateEventAdapter.ts
+++ b/src/api/adapters/MateEventAdapter.ts
@@ -500,12 +500,29 @@ export function createMateStreamContext(sessionId: string): {
 /**
  * Build the request payload for Mate's /v1/chat endpoint.
  */
-export function buildMateRequest(message: string, sessionId?: string): {
+export function buildMateRequest(
+  message: string,
+  sessionId?: string,
+  promptArgs?: Record<string, unknown>,
+): {
   prompt: string;
   session_id?: string;
+  prompt_args?: Record<string, unknown>;
+}
+export function buildMateRequest(
+  message: string,
+  sessionId?: string,
+  promptArgs?: Record<string, unknown>,
+): {
+  prompt: string;
+  session_id?: string;
+  prompt_args?: Record<string, unknown>;
 } {
   return {
     prompt: message,
     ...(sessionId && { session_id: sessionId }),
+    ...(promptArgs && Object.keys(promptArgs).length > 0
+      ? { prompt_args: promptArgs }
+      : {}),
   };
 }

--- a/src/api/adapters/__tests__/MateEventAdapter.test.ts
+++ b/src/api/adapters/__tests__/MateEventAdapter.test.ts
@@ -22,6 +22,28 @@ describe('buildMateRequest', () => {
     expect(req).toEqual({ prompt: 'hello' });
     expect('session_id' in req).toBe(false);
   });
+
+  test('includes prompt_args when project context is provided', () => {
+    const req = buildMateRequest('hello', 'sess_123', {
+      project_context: {
+        project_id: 'project-1',
+        project_name: 'Alpha',
+        knowledge_file_ids: ['file-1'],
+      },
+    });
+
+    expect(req).toEqual({
+      prompt: 'hello',
+      session_id: 'sess_123',
+      prompt_args: {
+        project_context: {
+          project_id: 'project-1',
+          project_name: 'Alpha',
+          knowledge_file_ids: ['file-1'],
+        },
+      },
+    });
+  });
 });
 
 describe('createMateStreamContext', () => {

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -728,14 +728,18 @@ export class ChatService {
    */
   async sendMessageViaMate(
     message: string,
-    metadata: { session_id: string },
+    metadata: { session_id: string; prompt_args?: Record<string, unknown> },
     token: string,
     callbacks: ChatServiceCallbacks
   ): Promise<void> {
     log.info('Sending message via Mate backend');
 
     try {
-      const payload = buildMateRequest(message, metadata.session_id);
+      const payload = buildMateRequest(
+        message,
+        metadata.session_id,
+        metadata.prompt_args,
+      );
       const endpoint = GATEWAY_ENDPOINTS.MATE.CHAT;
 
       const transport = createSSETransport({

--- a/src/api/projectService.ts
+++ b/src/api/projectService.ts
@@ -21,6 +21,21 @@ export interface ProjectListResponse {
   total: number;
 }
 
+export interface ProjectFile {
+  id: string;
+  project_id: string;
+  filename: string;
+  file_type?: string;
+  file_size?: number;
+  storage_path: string;
+  created_at?: string;
+}
+
+export interface ProjectFileListResponse {
+  files: ProjectFile[];
+  total: number;
+}
+
 const buildProjectsBaseUrl = () =>
   `${GATEWAY_CONFIG.BASE_URL.replace(/\/$/, '')}/api/v1/projects`;
 
@@ -53,12 +68,39 @@ export const getProjectErrorMessage = (
 
 export class ProjectService {
   private coreProjectService: CoreProjectService;
+  private baseUrl: string;
+  private authorizedFetch: typeof fetch;
 
   constructor(baseUrl: string = buildProjectsBaseUrl()) {
+    this.baseUrl = baseUrl;
+    this.authorizedFetch = buildAuthorizedFetch();
     this.coreProjectService = new CoreProjectService(
       baseUrl,
-      buildAuthorizedFetch(),
+      this.authorizedFetch,
     );
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.authorizedFetch(`${this.baseUrl}${path}`, init);
+
+    if (!response.ok) {
+      let detail = response.statusText;
+
+      try {
+        const body = await response.json();
+        detail = body?.detail ?? body?.error ?? detail;
+      } catch {
+        // response may not be JSON
+      }
+
+      throw new Error(detail || 'Project request failed');
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
   }
 
   async listProjects(limit = 50, offset = 0): Promise<ProjectListResponse> {
@@ -75,6 +117,28 @@ export class ProjectService {
 
   async setProjectInstructions(projectId: string, instructions: string): Promise<void> {
     await this.coreProjectService.setInstructions(projectId, instructions);
+  }
+
+  async listProjectKnowledgeFiles(projectId: string): Promise<ProjectFileListResponse> {
+    return this.request<ProjectFileListResponse>(`/${projectId}/files`, {
+      method: 'GET',
+    });
+  }
+
+  async uploadProjectKnowledgeFile(projectId: string, file: File): Promise<ProjectFile> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return this.request<ProjectFile>(`/${projectId}/files`, {
+      method: 'POST',
+      body: formData,
+    });
+  }
+
+  async deleteProjectKnowledgeFile(projectId: string, fileId: string): Promise<void> {
+    await this.request<void>(`/${projectId}/files/${fileId}`, {
+      method: 'DELETE',
+    });
   }
 }
 

--- a/src/components/ui/settings/ProjectSettings.tsx
+++ b/src/components/ui/settings/ProjectSettings.tsx
@@ -66,14 +66,6 @@ export const ProjectSettings: React.FC = () => {
     return () => window.clearTimeout(timeout);
   }, [message]);
 
-  useEffect(() => {
-    if (!activeProjectId) {
-      return;
-    }
-
-    void loadProjectKnowledgeFiles(activeProjectId);
-  }, [activeProjectId, loadProjectKnowledgeFiles]);
-
   const handleSave = useCallback(async () => {
     if (!activeProjectId) return;
     clearError();

--- a/src/components/ui/settings/ProjectSettings.tsx
+++ b/src/components/ui/settings/ProjectSettings.tsx
@@ -5,6 +5,18 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useProjects } from '../../../hooks/useProjects';
 
+export const formatProjectKnowledgeFileSize = (fileSize?: number): string => {
+  if (!fileSize || fileSize < 1024) {
+    return fileSize ? `${fileSize} B` : 'Unknown size';
+  }
+
+  if (fileSize < 1024 * 1024) {
+    return `${(fileSize / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(fileSize / (1024 * 1024)).toFixed(1)} MB`;
+};
+
 export const ProjectSettings: React.FC = () => {
   const {
     activeProject,
@@ -12,6 +24,13 @@ export const ProjectSettings: React.FC = () => {
     loading,
     savingInstructions,
     saveProjectInstructions,
+    knowledgeFiles,
+    loadingKnowledgeFiles,
+    uploadingKnowledgeFile,
+    deletingKnowledgeFileId,
+    loadProjectKnowledgeFiles,
+    uploadProjectKnowledgeFile,
+    deleteProjectKnowledgeFile,
     error,
     clearError,
   } = useProjects();
@@ -19,6 +38,7 @@ export const ProjectSettings: React.FC = () => {
   const [saved, setSaved] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const previousProjectIdRef = useRef<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (activeProject?.custom_instructions) {
@@ -46,6 +66,14 @@ export const ProjectSettings: React.FC = () => {
     return () => window.clearTimeout(timeout);
   }, [message]);
 
+  useEffect(() => {
+    if (!activeProjectId) {
+      return;
+    }
+
+    void loadProjectKnowledgeFiles(activeProjectId);
+  }, [activeProjectId, loadProjectKnowledgeFiles]);
+
   const handleSave = useCallback(async () => {
     if (!activeProjectId) return;
     clearError();
@@ -59,6 +87,51 @@ export const ProjectSettings: React.FC = () => {
     setSaved(instructions);
     setMessage('Project instructions saved');
   }, [activeProjectId, instructions, clearError, saveProjectInstructions]);
+
+  const handleFileSelection = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+
+      if (files.length === 0) {
+        return;
+      }
+
+      clearError();
+      setMessage(null);
+
+      let uploadedCount = 0;
+      for (const file of files) {
+        const uploaded = await uploadProjectKnowledgeFile(file);
+        if (uploaded) {
+          uploadedCount += 1;
+        }
+      }
+
+      if (uploadedCount > 0) {
+        setMessage(
+          uploadedCount === 1
+            ? 'Knowledge file uploaded'
+            : `${uploadedCount} knowledge files uploaded`,
+        );
+      }
+
+      event.target.value = '';
+    },
+    [clearError, uploadProjectKnowledgeFile],
+  );
+
+  const handleDeleteKnowledgeFile = useCallback(
+    async (fileId: string) => {
+      clearError();
+      setMessage(null);
+
+      const deleted = await deleteProjectKnowledgeFile(fileId);
+      if (deleted) {
+        setMessage('Knowledge file removed');
+      }
+    },
+    [clearError, deleteProjectKnowledgeFile],
+  );
 
   if (loading && !activeProject) {
     return (
@@ -109,18 +182,73 @@ export const ProjectSettings: React.FC = () => {
         </div>
       </div>
 
-      {/* Knowledge Base placeholder */}
       <div>
         <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Knowledge Base</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-          Knowledge file management is landing in the next `#347` slice. This first fix makes project selection and instructions shared across the app.
+          Upload files for Mate to reference in this project. Files stay attached to the active project after reload.
         </p>
-        <div className="border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl p-8 text-center">
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileSelection}
+          accept=".pdf,.txt,.md,.doc,.docx,.csv,.ts,.tsx,.js,.jsx,.json,.py,.sql,.html,.css,.yaml,.yml"
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploadingKnowledgeFile}
+          className="w-full border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl p-8 text-center hover:border-blue-300 dark:hover:border-blue-500 transition-colors disabled:opacity-60"
+        >
           <svg className="w-8 h-8 mx-auto text-gray-300 dark:text-gray-600 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
-          <p className="text-sm text-gray-400">Upload and file management will be enabled in the next subtask.</p>
-          <p className="text-xs text-gray-400 mt-1">This slice focuses on shared project state and instruction persistence.</p>
+          <p className="text-sm text-gray-500 dark:text-gray-300">
+            {uploadingKnowledgeFile ? 'Uploading files...' : 'Click to upload project files'}
+          </p>
+          <p className="text-xs text-gray-400 mt-1">PDF, DOCX, TXT, CSV, and code files up to 30MB</p>
+        </button>
+
+        <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+          {loadingKnowledgeFiles ? (
+            <div className="space-y-3 p-4">
+              <div className="h-4 w-1/2 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+              <div className="h-12 rounded-lg bg-gray-50 dark:bg-gray-800 animate-pulse" />
+            </div>
+          ) : knowledgeFiles.length === 0 ? (
+            <div className="p-4 text-sm text-gray-500 dark:text-gray-400">
+              No knowledge files uploaded yet.
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {knowledgeFiles.map(file => (
+                <li
+                  key={file.id}
+                  className="flex items-center justify-between gap-3 px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {file.filename}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {[file.file_type, formatProjectKnowledgeFileSize(file.file_size)]
+                        .filter(Boolean)
+                        .join(' • ')}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleDeleteKnowledgeFile(file.id)}
+                    disabled={deletingKnowledgeFileId === file.id}
+                    className="text-xs font-medium text-red-600 dark:text-red-400 hover:text-red-700 disabled:opacity-60"
+                  >
+                    {deletingKnowledgeFileId === file.id ? 'Removing...' : 'Remove'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
     </div>

--- a/src/config/__tests__/runtimeEnv.test.ts
+++ b/src/config/__tests__/runtimeEnv.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('runtimeEnv', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PUBLIC_CHAT_BACKEND;
+    delete process.env.NEXT_PUBLIC_MATE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('defaults to the agent backend with Mate features disabled', async () => {
+    const { getChatBackend, isMateConfigured } = await import('../runtimeEnv');
+
+    expect(getChatBackend()).toBe('agent');
+    expect(isMateConfigured()).toBe(false);
+  });
+
+  test('enables Mate features when the chat backend is explicitly mate', async () => {
+    process.env.NEXT_PUBLIC_CHAT_BACKEND = 'mate';
+
+    const { getChatBackend, isMateConfigured } = await import('../runtimeEnv');
+
+    expect(getChatBackend()).toBe('mate');
+    expect(isMateConfigured()).toBe(true);
+  });
+
+  test('enables Mate features when a direct Mate URL is configured', async () => {
+    process.env.NEXT_PUBLIC_MATE_URL = 'http://localhost:18789';
+
+    const { getChatBackend, isMateConfigured } = await import('../runtimeEnv');
+
+    expect(getChatBackend()).toBe('agent');
+    expect(isMateConfigured()).toBe(true);
+  });
+});

--- a/src/config/__tests__/sdkResolution.test.ts
+++ b/src/config/__tests__/sdkResolution.test.ts
@@ -41,4 +41,27 @@ describe('SDK package resolution config', () => {
       path.join(process.cwd(), 'src/hooks/isaSdkHooks.web.ts'),
     );
   });
+
+  test('next forces SDK source imports to use the app React runtime', () => {
+    const config = nextConfig.webpack(
+      {
+        resolve: {
+          alias: {},
+          fallback: {},
+        },
+      },
+      {},
+    );
+
+    expect(config.resolve.alias.react).toBe(path.join(process.cwd(), 'node_modules/react'));
+    expect(config.resolve.alias['react-dom']).toBe(
+      path.join(process.cwd(), 'node_modules/react-dom'),
+    );
+    expect(config.resolve.alias['react/jsx-runtime']).toBe(
+      path.join(process.cwd(), 'node_modules/react/jsx-runtime'),
+    );
+    expect(config.resolve.alias['react/jsx-dev-runtime']).toBe(
+      path.join(process.cwd(), 'node_modules/react/jsx-dev-runtime'),
+    );
+  });
 });

--- a/src/config/__tests__/sdkResolution.test.ts
+++ b/src/config/__tests__/sdkResolution.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, test } from 'vitest';
+import path from 'path';
 import tsconfig from '../../../tsconfig.json';
 import nextConfig from '../../../next.config.js';
 
 describe('SDK package resolution config', () => {
-  test('typescript paths resolve SDK packages to source entrypoints', () => {
+  test('typescript paths resolve SDK packages to the web-safe entrypoints the app expects', () => {
     const paths = tsconfig.compilerOptions.paths;
 
     expect(paths['@isa/core']).toEqual(['../isA_App_SDK/packages/core/src/index.ts']);
     expect(paths['@isa/transport']).toEqual(['../isA_App_SDK/packages/transport/src/index.ts']);
     expect(paths['@isa/ui-web']).toEqual(['../isA_App_SDK/packages/ui-web/src/index.ts']);
     expect(paths['@isa/theme']).toEqual(['../isA_App_SDK/packages/theme/src/index.ts']);
-    expect(paths['@isa/hooks']).toEqual(['../isA_App_SDK/packages/hooks/src/index.ts']);
+    expect(paths['@isa/hooks']).toEqual(['./src/hooks/isaSdkHooks.web.ts']);
   });
 
   test('next transpiles the same direct SDK packages the app imports', () => {
@@ -22,6 +23,22 @@ describe('SDK package resolution config', () => {
         '@isa/theme',
         '@isa/hooks',
       ]),
+    );
+  });
+
+  test('next aliases @isa/hooks to the local web shim instead of the native-capable SDK root entry', () => {
+    const config = nextConfig.webpack(
+      {
+        resolve: {
+          alias: {},
+          fallback: {},
+        },
+      },
+      {},
+    );
+
+    expect(config.resolve.alias['@isa/hooks']).toBe(
+      path.join(process.cwd(), 'src/hooks/isaSdkHooks.web.ts'),
     );
   });
 });

--- a/src/config/runtimeEnv.ts
+++ b/src/config/runtimeEnv.ts
@@ -42,3 +42,19 @@ export const getChatBackend = (): 'mate' | 'agent' => {
   const value = process.env.NEXT_PUBLIC_CHAT_BACKEND;
   return value === 'mate' ? 'mate' : 'agent';
 };
+
+/**
+ * Whether Mate-specific capabilities should be treated as configured in the
+ * current frontend runtime.
+ *
+ * Local dev frequently runs the default agent path without a Mate backend.
+ * In that case, Mate-only health probes and pollers should stay dormant
+ * instead of spamming 404/502 noise on page load.
+ */
+export const isMateConfigured = (): boolean => {
+  if (getChatBackend() === 'mate') {
+    return true;
+  }
+
+  return Boolean(process.env.NEXT_PUBLIC_MATE_URL?.trim());
+};

--- a/src/hooks/isaSdkHooks.web.ts
+++ b/src/hooks/isaSdkHooks.web.ts
@@ -1,0 +1,21 @@
+/**
+ * Web compatibility shim for @isa/hooks.
+ *
+ * isA_ aliases @isa/hooks directly to SDK source so local changes are visible
+ * without rebuilding the SDK packages. The SDK root entry exports native-only
+ * hooks that pull react-native into the Next.js web bundle, so this shim keeps
+ * resolution on the web-safe surface while restoring the cross-platform hooks
+ * the app currently imports.
+ */
+
+export * from '../../../isA_App_SDK/packages/hooks/src/index.web';
+
+// The SDK web entry currently omits these cross-platform exports even though
+// isA_ consumes them on the web.
+export * from '../../../isA_App_SDK/packages/hooks/src/useAgentEvents';
+export * from '../../../isA_App_SDK/packages/hooks/src/useAgentState';
+export * from '../../../isA_App_SDK/packages/hooks/src/useAgentMemory';
+export * from '../../../isA_App_SDK/packages/hooks/src/useApprovalPolicy';
+export * from '../../../isA_App_SDK/packages/hooks/src/useCancellation';
+export * from '../../../isA_App_SDK/packages/hooks/src/useNotifications';
+export * from '../../../isA_App_SDK/packages/hooks/src/tracker';

--- a/src/hooks/useMatePresence.ts
+++ b/src/hooks/useMatePresence.ts
@@ -19,6 +19,7 @@ import { useState, useEffect } from 'react';
 import { getMateService } from '../api/mateService';
 import { useMessageStore } from '../stores/useMessageStore';
 import type { MateHealthResponse } from '../types/mateTypes';
+import { isMateConfigured } from '../config/runtimeEnv';
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -92,6 +93,10 @@ async function poll() {
 
 function startPolling() {
   if (intervalId !== null) return;
+  if (!isMateConfigured()) {
+    emit(INITIAL_STATE);
+    return;
+  }
   void poll();
   intervalId = setInterval(() => void poll(), POLL_INTERVAL_MS);
   delegationUnsub = useMessageStore.subscribe(
@@ -122,6 +127,11 @@ export function useMatePresence(): MatePresenceState {
   const [state, setState] = useState<MatePresenceState>(currentState);
 
   useEffect(() => {
+    if (!isMateConfigured()) {
+      setState(INITIAL_STATE);
+      return;
+    }
+
     listeners.add(setState);
     if (listeners.size === 1) {
       startPolling();

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,8 +1,10 @@
 import { useEffect } from 'react';
-import type { Project } from '../api/projectService';
+import type { Project, ProjectFile } from '../api/projectService';
 import { useProjectStore } from '../stores/useProjectStore';
+import { buildProjectChatContext } from '../utils/projectContext';
+import type { ProjectChatContext } from '../utils/projectContext';
 
-export type { Project };
+export type { Project, ProjectFile, ProjectChatContext };
 
 export function useProjects() {
   const projects = useProjectStore(state => state.projects);
@@ -14,6 +16,31 @@ export function useProjects() {
   const loading = useProjectStore(state => state.loading);
   const creatingProject = useProjectStore(state => state.creating);
   const savingInstructions = useProjectStore(state => state.savingInstructions);
+  const knowledgeFiles = useProjectStore(state => {
+    if (!state.activeProjectId) {
+      return [];
+    }
+
+    return state.knowledgeFilesByProjectId[state.activeProjectId] ?? [];
+  });
+  const activeProjectContext = useProjectStore(state => {
+    const activeProject =
+      state.projects.find(project => project.id === state.activeProjectId) ?? null;
+    const files = state.activeProjectId
+      ? state.knowledgeFilesByProjectId[state.activeProjectId] ?? []
+      : [];
+
+    return buildProjectChatContext(activeProject, files);
+  });
+  const loadingKnowledgeFiles = useProjectStore(
+    state => state.loadingKnowledgeFiles,
+  );
+  const uploadingKnowledgeFile = useProjectStore(
+    state => state.uploadingKnowledgeFile,
+  );
+  const deletingKnowledgeFileId = useProjectStore(
+    state => state.deletingKnowledgeFileId,
+  );
   const error = useProjectStore(state => state.error);
   const ensureLoaded = useProjectStore(state => state.ensureLoaded);
   const refresh = useProjectStore(state => state.refresh);
@@ -22,6 +49,15 @@ export function useProjects() {
   const deleteProject = useProjectStore(state => state.deleteProject);
   const saveProjectInstructions = useProjectStore(
     state => state.saveProjectInstructions,
+  );
+  const loadProjectKnowledgeFiles = useProjectStore(
+    state => state.loadProjectKnowledgeFiles,
+  );
+  const uploadProjectKnowledgeFile = useProjectStore(
+    state => state.uploadProjectKnowledgeFile,
+  );
+  const deleteProjectKnowledgeFile = useProjectStore(
+    state => state.deleteProjectKnowledgeFile,
   );
   const clearError = useProjectStore(state => state.clearError);
 
@@ -36,11 +72,19 @@ export function useProjects() {
     loading,
     creatingProject,
     savingInstructions,
+    loadingKnowledgeFiles,
+    uploadingKnowledgeFile,
+    deletingKnowledgeFileId,
+    knowledgeFiles,
     error,
     selectProject,
     createProject,
     deleteProject,
     saveProjectInstructions,
+    loadProjectKnowledgeFiles,
+    uploadProjectKnowledgeFile,
+    deleteProjectKnowledgeFile,
+    getActiveProjectContext: () => activeProjectContext,
     clearError,
     refresh,
   };

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -3,10 +3,12 @@ import type { Project, ProjectFile } from '../api/projectService';
 import { useProjectStore } from '../stores/useProjectStore';
 import { buildProjectChatContext } from '../utils/projectContext';
 import type { ProjectChatContext } from '../utils/projectContext';
+import { useAuth } from './useAuth';
 
 export type { Project, ProjectFile, ProjectChatContext };
 
 export function useProjects() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const projects = useProjectStore(state => state.projects);
   const activeProjectId = useProjectStore(state => state.activeProjectId);
   const activeProject = useProjectStore(
@@ -62,8 +64,12 @@ export function useProjects() {
   const clearError = useProjectStore(state => state.clearError);
 
   useEffect(() => {
+    if (authLoading || !isAuthenticated) {
+      return;
+    }
+
     void ensureLoaded();
-  }, [ensureLoaded]);
+  }, [authLoading, isAuthenticated, ensureLoaded]);
 
   return {
     projects,

--- a/src/modules/ChatModule.tsx
+++ b/src/modules/ChatModule.tsx
@@ -50,6 +50,7 @@ import { useChatStore } from '../stores/useChatStore';
 import { useAuth } from '../hooks/useAuth';
 import { useCurrentSession, useSessionActions } from '../stores/useSessionStore';
 import { logger, LogCategory, createLogger } from '../utils/logger';
+import { getChatBackend, isMateConfigured } from '../config/runtimeEnv';
 const log = createLogger('ChatModule');
 import { useUserModule } from './UserModule';
 import { UpgradeModal } from '../components/ui/UpgradeModal';
@@ -524,6 +525,12 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
 
         // REMOVED: HIL回调注册 - SSEParser已删除
 
+        // Skip Mate-only health probing when Mate isn't configured for this env.
+        if (!isMateConfigured()) {
+          log.debug('Mate HIL probe skipped — Mate is not configured for this environment');
+          return;
+        }
+
         // 检查HIL服务是否可用 (xenoISA/isA_Mate#404 → /v1/interactive/health)
         const isServiceAvailable = await executionControlService.isServiceAvailable();
         if (!isServiceAvailable) {
@@ -587,11 +594,10 @@ export const ChatModule: React.FC<ChatModuleProps> = (props) => {
   useEffect(() => {
     // Skip execution monitoring when using Mate backend — Mate doesn't have
     // the /agents/execution/status endpoint. HIL is handled via SSE events instead.
-    const isMateBackend = (() => {
-      try { const { getChatBackend } = require('../config/runtimeEnv'); return getChatBackend() === 'mate'; } catch { return false; }
-    })();
+    const isMateBackend = getChatBackend() === 'mate';
+    const hasServerBackedThreadId = currentSession?.id && currentSession.id !== 'default';
 
-    if (currentSession && hilMonitoringActive && !isMateBackend) {
+    if (currentSession && hilMonitoringActive && !isMateBackend && hasServerBackedThreadId) {
       const threadId = currentSession.id;
 
       // 清理之前会话的监控以避免重复polling

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -18,6 +18,8 @@ import { CreditConsumption } from '../../types/userTypes';
 import { isDelegationTool } from '../../constants/delegationTeams';
 import { MessageTimingTracker, formatTimingLog } from '../../utils/messageTiming';
 import { emitObservabilityRefresh } from '../../utils/observabilityEvents';
+import { useProjectStore } from '../../stores/useProjectStore';
+import { mergeProjectPromptArgs } from '../../utils/projectContext';
 
 const log = createLogger('ChatModule:Message');
 
@@ -137,7 +139,11 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
     const enrichedMetadata = {
       ...metadata,
       user_id: authUserSub || (() => { throw new Error('User not authenticated') })(),
-      session_id: sessionId
+      session_id: sessionId,
+      prompt_args: mergeProjectPromptArgs(
+        metadata?.prompt_args,
+        useProjectStore.getState().getActiveProjectContext(),
+      ),
     };
 
     const userMessage = {
@@ -237,7 +243,10 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
 
         // Include selected model in the request (wiring gap fix — #194)
         const selectedModel = typeof window !== 'undefined' ? localStorage.getItem('isa_selected_model') : null;
-        const matePayload: Record<string, any> = { session_id: enrichedMetadata.session_id };
+        const matePayload: Record<string, any> = {
+          session_id: enrichedMetadata.session_id,
+          prompt_args: enrichedMetadata.prompt_args,
+        };
         if (selectedModel) matePayload.model = selectedModel;
 
         const sendFn = useMate

--- a/src/stores/__tests__/useProjectStore.test.ts
+++ b/src/stores/__tests__/useProjectStore.test.ts
@@ -220,6 +220,58 @@ describe('useProjectStore', () => {
     });
   });
 
+  test('refresh hydrates knowledge files for the persisted active project', async () => {
+    localStorageMock.setItem(PROJECT_ACTIVE_STORAGE_KEY, 'project-1');
+    const service = createService();
+    service.listProjects.mockResolvedValue({
+      projects: [createProject({ id: 'project-1', name: 'Alpha' })],
+      total: 1,
+    });
+    service.listProjectKnowledgeFiles.mockResolvedValue({
+      files: [createProjectFile()],
+      total: 1,
+    });
+    const store = createProjectStore(service);
+
+    await store.getState().refresh();
+
+    expect(service.listProjectKnowledgeFiles).toHaveBeenCalledWith('project-1');
+    expect(store.getState().getActiveProjectKnowledgeFiles()).toEqual([
+      createProjectFile(),
+    ]);
+  });
+
+  test('selecting a project loads its knowledge files for chat context', async () => {
+    const service = createService();
+    service.listProjectKnowledgeFiles.mockResolvedValue({
+      files: [createProjectFile()],
+      total: 1,
+    });
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject({ id: 'project-1', name: 'Alpha' })],
+      activeProjectId: null,
+    });
+
+    store.getState().selectProject('project-1');
+    await Promise.resolve();
+
+    expect(service.listProjectKnowledgeFiles).toHaveBeenCalledWith('project-1');
+    expect(store.getState().getActiveProjectContext()).toEqual({
+      project_id: 'project-1',
+      project_name: 'Alpha',
+      knowledge_file_ids: ['file-1'],
+      knowledge_files: [
+        {
+          id: 'file-1',
+          filename: 'architecture.md',
+          file_type: 'text/markdown',
+          file_size: 512,
+        },
+      ],
+    });
+  });
+
   test('uploads a knowledge file into the active project state', async () => {
     const uploadedFile = createProjectFile({
       id: 'file-9',

--- a/src/stores/__tests__/useProjectStore.test.ts
+++ b/src/stores/__tests__/useProjectStore.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PROJECT_ACTIVE_STORAGE_KEY, createProjectStore } from '../useProjectStore';
+import type { ProjectFile } from '../../api/projectService';
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -29,6 +30,21 @@ const createService = () => ({
   createProject: vi.fn(),
   deleteProject: vi.fn(),
   setProjectInstructions: vi.fn(),
+  listProjectKnowledgeFiles: vi.fn(),
+  uploadProjectKnowledgeFile: vi.fn(),
+  deleteProjectKnowledgeFile: vi.fn(),
+});
+
+const createProjectFile = (
+  overrides: Partial<ProjectFile> = {},
+): ProjectFile => ({
+  id: overrides.id ?? 'file-1',
+  project_id: overrides.project_id ?? 'project-1',
+  filename: overrides.filename ?? 'architecture.md',
+  file_type: overrides.file_type ?? 'text/markdown',
+  file_size: overrides.file_size ?? 512,
+  storage_path: overrides.storage_path ?? 'storage/project-1/architecture.md',
+  created_at: overrides.created_at ?? '2026-04-24T00:00:00Z',
 });
 
 describe('useProjectStore', () => {
@@ -149,5 +165,128 @@ describe('useProjectStore', () => {
     expect(result).toBe(false);
     expect(store.getState().error).toBe('Gateway unavailable');
     expect(store.getState().savingInstructions).toBe(false);
+  });
+
+  test('loads active project knowledge files and exposes project chat context', async () => {
+    const service = createService();
+    service.listProjectKnowledgeFiles.mockResolvedValue({
+      files: [
+        createProjectFile(),
+        createProjectFile({
+          id: 'file-2',
+          filename: 'brief.pdf',
+          file_type: 'application/pdf',
+          file_size: 2048,
+          storage_path: 'storage/project-1/brief.pdf',
+        }),
+      ],
+      total: 2,
+    });
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [
+        createProject({
+          id: 'project-1',
+          name: 'Alpha',
+          custom_instructions: 'Use strict TypeScript',
+        }),
+      ],
+      activeProjectId: 'project-1',
+    });
+
+    await store.getState().loadProjectKnowledgeFiles();
+
+    expect(service.listProjectKnowledgeFiles).toHaveBeenCalledWith('project-1');
+    expect(store.getState().getActiveProjectKnowledgeFiles()).toHaveLength(2);
+    expect(store.getState().getActiveProjectContext()).toEqual({
+      project_id: 'project-1',
+      project_name: 'Alpha',
+      custom_instructions: 'Use strict TypeScript',
+      knowledge_file_ids: ['file-1', 'file-2'],
+      knowledge_files: [
+        {
+          id: 'file-1',
+          filename: 'architecture.md',
+          file_type: 'text/markdown',
+          file_size: 512,
+        },
+        {
+          id: 'file-2',
+          filename: 'brief.pdf',
+          file_type: 'application/pdf',
+          file_size: 2048,
+        },
+      ],
+    });
+  });
+
+  test('uploads a knowledge file into the active project state', async () => {
+    const uploadedFile = createProjectFile({
+      id: 'file-9',
+      filename: 'roadmap.txt',
+      file_type: 'text/plain',
+      file_size: 128,
+      storage_path: 'storage/project-1/roadmap.txt',
+    });
+    const service = createService();
+    service.uploadProjectKnowledgeFile.mockResolvedValue(uploadedFile);
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject()],
+      activeProjectId: 'project-1',
+    });
+
+    const file = new File(['roadmap'], 'roadmap.txt', { type: 'text/plain' });
+    const result = await store.getState().uploadProjectKnowledgeFile(file);
+
+    expect(result).toBe(true);
+    expect(service.uploadProjectKnowledgeFile).toHaveBeenCalledWith(
+      'project-1',
+      file,
+    );
+    expect(store.getState().getActiveProjectKnowledgeFiles()).toEqual([uploadedFile]);
+    expect(store.getState().uploadingKnowledgeFile).toBe(false);
+  });
+
+  test('captures actionable errors when knowledge upload fails', async () => {
+    const service = createService();
+    service.uploadProjectKnowledgeFile.mockRejectedValue(new Error('Upload failed'));
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject()],
+      activeProjectId: 'project-1',
+    });
+
+    const file = new File(['roadmap'], 'roadmap.txt', { type: 'text/plain' });
+    const result = await store.getState().uploadProjectKnowledgeFile(file);
+
+    expect(result).toBe(false);
+    expect(store.getState().error).toBe('Upload failed');
+    expect(store.getState().uploadingKnowledgeFile).toBe(false);
+  });
+
+  test('removes a knowledge file from the active project state', async () => {
+    const service = createService();
+    service.deleteProjectKnowledgeFile.mockResolvedValue(undefined);
+    const store = createProjectStore(service);
+    store.setState({
+      projects: [createProject()],
+      activeProjectId: 'project-1',
+      knowledgeFilesByProjectId: {
+        'project-1': [createProjectFile(), createProjectFile({ id: 'file-2' })],
+      },
+    });
+
+    const result = await store.getState().deleteProjectKnowledgeFile('file-2');
+
+    expect(result).toBe(true);
+    expect(service.deleteProjectKnowledgeFile).toHaveBeenCalledWith(
+      'project-1',
+      'file-2',
+    );
+    expect(store.getState().getActiveProjectKnowledgeFiles()).toEqual([
+      createProjectFile(),
+    ]);
+    expect(store.getState().deletingKnowledgeFileId).toBeNull();
   });
 });

--- a/src/stores/useProjectStore.ts
+++ b/src/stores/useProjectStore.ts
@@ -134,6 +134,10 @@ export const createProjectStore = (
           activeProjectId: nextActiveProjectId,
           initialized: true,
         });
+
+        if (nextActiveProjectId) {
+          await get().loadProjectKnowledgeFiles(nextActiveProjectId);
+        }
       } catch (error) {
         set({
           error: getProjectErrorMessage(error, 'Failed to load projects'),
@@ -147,6 +151,10 @@ export const createProjectStore = (
     selectProject: (projectId) => {
       persistActiveProjectId(projectId);
       set({ activeProjectId: projectId, error: null });
+
+      if (projectId) {
+        void get().loadProjectKnowledgeFiles(projectId);
+      }
     },
 
     createProject: async (name, description) => {

--- a/src/stores/useProjectStore.ts
+++ b/src/stores/useProjectStore.ts
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 import {
   type CreateProjectParams,
   type Project,
+  type ProjectFile,
   projectService,
   getProjectErrorMessage,
 } from '../api/projectService';
+import { buildProjectChatContext, type ProjectChatContext } from '../utils/projectContext';
 
 export const PROJECT_ACTIVE_STORAGE_KEY = 'isa_active_project';
 
@@ -16,14 +18,24 @@ export interface ProjectStoreService {
   createProject: (params: CreateProjectParams) => Promise<Project>;
   deleteProject: (projectId: string) => Promise<void>;
   setProjectInstructions: (projectId: string, instructions: string) => Promise<void>;
+  listProjectKnowledgeFiles: (projectId: string) => Promise<{
+    files: ProjectFile[];
+    total: number;
+  }>;
+  uploadProjectKnowledgeFile: (projectId: string, file: File) => Promise<ProjectFile>;
+  deleteProjectKnowledgeFile: (projectId: string, fileId: string) => Promise<void>;
 }
 
 export interface ProjectStoreState {
   projects: Project[];
+  knowledgeFilesByProjectId: Record<string, ProjectFile[]>;
   activeProjectId: string | null;
   loading: boolean;
   creating: boolean;
   savingInstructions: boolean;
+  loadingKnowledgeFiles: boolean;
+  uploadingKnowledgeFile: boolean;
+  deletingKnowledgeFileId: string | null;
   initialized: boolean;
   error: string | null;
   ensureLoaded: () => Promise<void>;
@@ -32,6 +44,11 @@ export interface ProjectStoreState {
   createProject: (name: string, description?: string) => Promise<Project | null>;
   deleteProject: (projectId: string) => Promise<void>;
   saveProjectInstructions: (instructions: string) => Promise<boolean>;
+  loadProjectKnowledgeFiles: (projectId?: string | null) => Promise<void>;
+  uploadProjectKnowledgeFile: (file: File) => Promise<boolean>;
+  deleteProjectKnowledgeFile: (fileId: string) => Promise<boolean>;
+  getActiveProjectKnowledgeFiles: () => ProjectFile[];
+  getActiveProjectContext: () => ProjectChatContext | null;
   clearError: () => void;
 }
 
@@ -82,10 +99,14 @@ export const createProjectStore = (
 ) =>
   create<ProjectStoreState>()((set, get) => ({
     projects: [],
+    knowledgeFilesByProjectId: {},
     activeProjectId: readStoredActiveProjectId(),
     loading: false,
     creating: false,
     savingInstructions: false,
+    loadingKnowledgeFiles: false,
+    uploadingKnowledgeFile: false,
+    deletingKnowledgeFileId: null,
     initialized: false,
     error: null,
 
@@ -161,6 +182,11 @@ export const createProjectStore = (
 
           return {
             projects: state.projects.filter(project => project.id !== projectId),
+            knowledgeFilesByProjectId: Object.fromEntries(
+              Object.entries(state.knowledgeFilesByProjectId).filter(
+                ([existingProjectId]) => existingProjectId !== projectId,
+              ),
+            ),
             activeProjectId: nextActiveProjectId,
             error: null,
           };
@@ -202,6 +228,124 @@ export const createProjectStore = (
       } finally {
         set({ savingInstructions: false });
       }
+    },
+
+    loadProjectKnowledgeFiles: async (projectId) => {
+      const targetProjectId = projectId ?? get().activeProjectId;
+
+      if (!targetProjectId) {
+        return;
+      }
+
+      set({ loadingKnowledgeFiles: true, error: null });
+
+      try {
+        const { files } = await service.listProjectKnowledgeFiles(targetProjectId);
+        set(state => ({
+          knowledgeFilesByProjectId: {
+            ...state.knowledgeFilesByProjectId,
+            [targetProjectId]: files,
+          },
+        }));
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(
+            error,
+            'Failed to load project knowledge files',
+          ),
+        });
+      } finally {
+        set({ loadingKnowledgeFiles: false });
+      }
+    },
+
+    uploadProjectKnowledgeFile: async (file) => {
+      const targetProjectId = get().activeProjectId;
+
+      if (!targetProjectId) {
+        return false;
+      }
+
+      set({ uploadingKnowledgeFile: true, error: null });
+
+      try {
+        const uploadedFile = await service.uploadProjectKnowledgeFile(
+          targetProjectId,
+          file,
+        );
+        set(state => ({
+          knowledgeFilesByProjectId: {
+            ...state.knowledgeFilesByProjectId,
+            [targetProjectId]: [
+              uploadedFile,
+              ...(state.knowledgeFilesByProjectId[targetProjectId] ?? []),
+            ],
+          },
+        }));
+        return true;
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(
+            error,
+            'Failed to upload project knowledge file',
+          ),
+        });
+        return false;
+      } finally {
+        set({ uploadingKnowledgeFile: false });
+      }
+    },
+
+    deleteProjectKnowledgeFile: async (fileId) => {
+      const targetProjectId = get().activeProjectId;
+
+      if (!targetProjectId) {
+        return false;
+      }
+
+      set({ deletingKnowledgeFileId: fileId, error: null });
+
+      try {
+        await service.deleteProjectKnowledgeFile(targetProjectId, fileId);
+        set(state => ({
+          knowledgeFilesByProjectId: {
+            ...state.knowledgeFilesByProjectId,
+            [targetProjectId]: (
+              state.knowledgeFilesByProjectId[targetProjectId] ?? []
+            ).filter(file => file.id !== fileId),
+          },
+        }));
+        return true;
+      } catch (error) {
+        set({
+          error: getProjectErrorMessage(
+            error,
+            'Failed to delete project knowledge file',
+          ),
+        });
+        return false;
+      } finally {
+        set({ deletingKnowledgeFileId: null });
+      }
+    },
+
+    getActiveProjectKnowledgeFiles: () => {
+      const activeProjectId = get().activeProjectId;
+
+      if (!activeProjectId) {
+        return [];
+      }
+
+      return get().knowledgeFilesByProjectId[activeProjectId] ?? [];
+    },
+
+    getActiveProjectContext: () => {
+      const state = get();
+      const activeProject =
+        state.projects.find(project => project.id === state.activeProjectId) ?? null;
+      const knowledgeFiles = state.getActiveProjectKnowledgeFiles();
+
+      return buildProjectChatContext(activeProject, knowledgeFiles);
     },
 
     clearError: () => {

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -46,6 +46,8 @@ import {
   ArtifactMessage,
   getMessageContent,
 } from '../types/chatTypes';
+import { useProjectStore } from './useProjectStore';
+import { buildProjectSessionMetadata } from '../utils/projectContext';
 
 // Re-export types for backward compatibility
 export type { ChatMessage, ChatSession, ArtifactMessage };
@@ -135,6 +137,7 @@ export const useSessionStore = create<SessionStore>()(
     // Session CRUD operations
     createSession: (title = 'New Chat') => {
       const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      const projectContext = useProjectStore.getState().getActiveProjectContext();
       const newSession: ChatSession = {
         id: sessionId,
         title,
@@ -143,11 +146,14 @@ export const useSessionStore = create<SessionStore>()(
         messageCount: 0,
         artifacts: [],
         messages: [],
-        metadata: {
-          apps_used: [],
-          total_messages: 0,
-          last_activity: new Date().toISOString()
-        }
+        metadata: buildProjectSessionMetadata(
+          {
+            apps_used: [],
+            total_messages: 0,
+            last_activity: new Date().toISOString(),
+          },
+          projectContext,
+        ),
       };
       
       set((state) => ({

--- a/src/utils/__tests__/projectContext.test.ts
+++ b/src/utils/__tests__/projectContext.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildProjectChatContext,
+  buildProjectSessionMetadata,
+  mergeProjectPromptArgs,
+} from '../projectContext';
+
+describe('projectContext helpers', () => {
+  test('builds a compact project chat context from project metadata and knowledge files', () => {
+    const context = buildProjectChatContext(
+      {
+        id: 'project-1',
+        name: 'Alpha',
+        custom_instructions: 'Use strict TypeScript',
+      },
+      [
+        {
+          id: 'file-1',
+          project_id: 'project-1',
+          filename: 'architecture.md',
+          file_type: 'text/markdown',
+          file_size: 512,
+          storage_path: 'storage/project-1/architecture.md',
+        },
+      ],
+    );
+
+    expect(context).toEqual({
+      project_id: 'project-1',
+      project_name: 'Alpha',
+      custom_instructions: 'Use strict TypeScript',
+      knowledge_file_ids: ['file-1'],
+      knowledge_files: [
+        {
+          id: 'file-1',
+          filename: 'architecture.md',
+          file_type: 'text/markdown',
+          file_size: 512,
+        },
+      ],
+    });
+  });
+
+  test('merges project context into prompt args without dropping existing values', () => {
+    const promptArgs = mergeProjectPromptArgs(
+      { template_id: 'knowledge_prompt', depth: 'high' },
+      {
+        project_id: 'project-1',
+        project_name: 'Alpha',
+        knowledge_file_ids: ['file-1'],
+        knowledge_files: [],
+      },
+    );
+
+    expect(promptArgs).toEqual({
+      template_id: 'knowledge_prompt',
+      depth: 'high',
+      project_context: {
+        project_id: 'project-1',
+        project_name: 'Alpha',
+        knowledge_file_ids: ['file-1'],
+        knowledge_files: [],
+      },
+    });
+  });
+
+  test('adds project metadata to new session metadata', () => {
+    const metadata = buildProjectSessionMetadata(
+      { title: 'New Chat' },
+      {
+        project_id: 'project-1',
+        project_name: 'Alpha',
+        custom_instructions: 'Use strict TypeScript',
+        knowledge_file_ids: ['file-1'],
+        knowledge_files: [],
+      },
+    );
+
+    expect(metadata).toEqual({
+      title: 'New Chat',
+      project_id: 'project-1',
+      project_name: 'Alpha',
+      custom_instructions: 'Use strict TypeScript',
+      knowledge_file_ids: ['file-1'],
+      project_context: {
+        project_id: 'project-1',
+        project_name: 'Alpha',
+        custom_instructions: 'Use strict TypeScript',
+        knowledge_file_ids: ['file-1'],
+        knowledge_files: [],
+      },
+    });
+  });
+});

--- a/src/utils/projectContext.ts
+++ b/src/utils/projectContext.ts
@@ -1,0 +1,74 @@
+import type { Project, ProjectFile } from '../api/projectService';
+
+export interface ProjectChatContext {
+  project_id: string;
+  project_name: string;
+  custom_instructions?: string;
+  knowledge_file_ids: string[];
+  knowledge_files: Array<{
+    id: string;
+    filename: string;
+    file_type?: string;
+    file_size?: number;
+  }>;
+}
+
+export const buildProjectChatContext = (
+  project: Project | null,
+  knowledgeFiles: ProjectFile[],
+): ProjectChatContext | null => {
+  if (!project) {
+    return null;
+  }
+
+  const normalizedInstructions = project.custom_instructions?.trim();
+
+  return {
+    project_id: project.id,
+    project_name: project.name,
+    ...(normalizedInstructions
+      ? { custom_instructions: normalizedInstructions }
+      : {}),
+    knowledge_file_ids: knowledgeFiles.map(file => file.id),
+    knowledge_files: knowledgeFiles.map(file => ({
+      id: file.id,
+      filename: file.filename,
+      file_type: file.file_type,
+      file_size: file.file_size,
+    })),
+  };
+};
+
+export const mergeProjectPromptArgs = (
+  promptArgs: Record<string, unknown> | undefined,
+  projectContext: ProjectChatContext | null,
+): Record<string, unknown> => {
+  if (!projectContext) {
+    return promptArgs ?? {};
+  }
+
+  return {
+    ...(promptArgs ?? {}),
+    project_context: projectContext,
+  };
+};
+
+export const buildProjectSessionMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  projectContext: ProjectChatContext | null,
+): Record<string, unknown> => {
+  if (!projectContext) {
+    return metadata ?? {};
+  }
+
+  return {
+    ...(metadata ?? {}),
+    project_id: projectContext.project_id,
+    project_name: projectContext.project_name,
+    ...(projectContext.custom_instructions
+      ? { custom_instructions: projectContext.custom_instructions }
+      : {}),
+    knowledge_file_ids: projectContext.knowledge_file_ids,
+    project_context: projectContext,
+  };
+};

--- a/tests/e2e/project-settings-context.spec.ts
+++ b/tests/e2e/project-settings-context.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+
+const UPLOAD_PATH = '/tmp/isA_347_knowledge_ui/package.json';
+const AUTH_BASE = 'http://127.0.0.1:8201/api/v1/auth';
+
+test('project settings and chat request carry project context', async ({ page, request }) => {
+  const projectName = `Codex Project ${Date.now()}`;
+  const instructions = 'Answer with concise TypeScript guidance.';
+  const chatPrompt = 'Confirm the active project context.';
+  const password = 'TestPass123!';
+  const email = `codex347verify+${Date.now()}@example.com`;
+
+  const registerResponse = await request.post(`${AUTH_BASE}/register`, {
+    data: {
+      email,
+      password,
+      name: 'Codex Verify',
+    },
+  });
+  expect(registerResponse.ok()).toBeTruthy();
+  const registerPayload = await registerResponse.json();
+
+  const pendingResponse = await request.get(
+    `${AUTH_BASE}/dev/pending-registration/${registerPayload.pending_registration_id}`,
+  );
+  expect(pendingResponse.ok()).toBeTruthy();
+  const pendingPayload = await pendingResponse.json();
+
+  const verifyResponse = await request.post(`${AUTH_BASE}/verify`, {
+    data: {
+      pending_registration_id: registerPayload.pending_registration_id,
+      code: pendingPayload.verification_code,
+    },
+  });
+  expect(verifyResponse.ok()).toBeTruthy();
+  const verifyPayload = await verifyResponse.json();
+  expect(verifyPayload.success).toBeTruthy();
+  expect(verifyPayload.access_token).toBeTruthy();
+
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('isa_dev_token', token);
+  }, verifyPayload.access_token);
+
+  await page.route('**/api/v1/credits/balance?*', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        available_balance: 25,
+        total_balance: 25,
+      }),
+    });
+  });
+
+  await page.goto('/app');
+  await page.waitForLoadState('networkidle');
+
+  const projectTrigger = page.getByRole('button', { name: /All Conversations/i }).first();
+  await expect(projectTrigger).toBeVisible({ timeout: 15_000 });
+
+  await projectTrigger.click();
+  await page.getByRole('button', { name: /New Project/i }).click();
+  await page.getByPlaceholder('Project name').fill(projectName);
+  await page.getByRole('button', { name: /^Create$/i }).click();
+  await expect(
+    page.getByRole('button', { name: new RegExp(projectName, 'i') }).first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page.keyboard.press('Control+,');
+  await expect(page.getByRole('heading', { name: /^Settings$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByRole('button', { name: /^Project$/i }).click();
+  await expect(
+    page.getByRole('heading', { name: new RegExp(`${projectName}.*Instructions`, 'i') }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  const instructionsInput = page.getByPlaceholder(/Always use TypeScript/i);
+  await instructionsInput.fill(instructions);
+  await page.getByRole('button', { name: /^Save$/i }).click();
+  await expect(page.getByText(/Project instructions saved/i)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles(UPLOAD_PATH);
+  await expect(page.getByText(/Knowledge file uploaded/i)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText('package.json')).toBeVisible({ timeout: 15_000 });
+
+  await page.locator('.fixed.inset-0.z-50 button.absolute.top-4.right-4').click();
+  await expect(page.getByRole('heading', { name: /^Settings$/i })).toHaveCount(0);
+
+  const requestPromise = page.waitForRequest(request => {
+    return (
+      request.method() === 'POST'
+      && (
+        request.url().includes('/v1/chat')
+        || request.url().includes('/agents/chat')
+      )
+    );
+  });
+
+  const chatInput = page.getByPlaceholder('Type your message...');
+  await chatInput.fill(chatPrompt);
+  await chatInput.press('Enter');
+
+  const chatRequest = await requestPromise;
+  const payload = chatRequest.postDataJSON() as {
+    message?: string;
+    prompt?: string;
+    prompt_args?: {
+      project_context?: {
+        project_id?: string;
+        project_name?: string;
+        custom_instructions?: string;
+        knowledge_file_ids?: string[];
+        knowledge_files?: Array<{ filename?: string }>;
+      };
+    };
+  };
+
+  expect(payload.prompt ?? payload.message).toBe(chatPrompt);
+  expect(payload.prompt_args?.project_context?.project_name).toBe(projectName);
+  expect(payload.prompt_args?.project_context?.custom_instructions).toBe(instructions);
+  expect(
+    payload.prompt_args?.project_context?.knowledge_file_ids?.length ?? 0,
+  ).toBeGreaterThan(0);
+  expect(
+    payload.prompt_args?.project_context?.knowledge_files?.some(
+      file => file.filename === 'package.json',
+    ),
+  ).toBeTruthy();
+
+  await page.keyboard.press('Control+,');
+  await page.getByRole('button', { name: /^Project$/i }).click();
+  await page.getByRole('button', { name: /^Remove$/i }).click();
+  await expect(page.getByText(/Knowledge file removed/i)).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText('package.json')).toHaveCount(0);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
       "@isa/transport": ["../isA_App_SDK/packages/transport/src/index.ts"],
       "@isa/ui-web": ["../isA_App_SDK/packages/ui-web/src/index.ts"],
       "@isa/theme": ["../isA_App_SDK/packages/theme/src/index.ts"],
-      "@isa/hooks": ["../isA_App_SDK/packages/hooks/src/index.ts"]
+      "@isa/hooks": ["./src/hooks/isaSdkHooks.web.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add real project knowledge-file list, upload, and delete support through the shared project store
- replace the project settings placeholder with a working knowledge manager UI and persist files per project after reload
- inject active project context into new sessions and Mate prompt args so project instructions and file references flow into new conversations

## Testing
-   - `npm test -- src/api/__tests__/projectService.test.ts src/stores/__tests__/useProjectStore.test.ts src/api/adapters/__tests__/MateEventAdapter.test.ts src/api/__tests__/chatService.test.ts src/utils/__tests__/projectContext.test.ts`
- `npm test`

## Notes
- `npm run build` is still blocked by pre-existing ESLint rule-definition errors in `ArtifactPanel.tsx`, `CodeSandboxPanel.tsx`, and `UserButtonContainer.tsx`; this branch does not add new build blockers.

Refs #347