### PR TITLE
fix(task,alert): wire toolbars to backend state

### DIFF
--- a/src/components/ui/NotificationToolbar.tsx
+++ b/src/components/ui/NotificationToolbar.tsx
@@ -17,6 +17,7 @@
  */
 import React, { useState, useRef, useEffect } from 'react';
 import { createLogger } from '../../utils/logger';
+import { useAlertStore } from '../../stores/useAlertStore';
 const log = createLogger('NotificationToolbar');
 
 // Glass Button Style Creator for Notification Toolbar
@@ -56,21 +57,6 @@ const createGlassButtonHoverHandlers = (color: string, isDisabled: boolean = fal
   }
 });
 
-interface Notification {
-  id: string;
-  title: string;
-  message: string;
-  type: 'info' | 'warning' | 'success' | 'error' | 'assistant';
-  timestamp: Date;
-  read: boolean;
-  actionable?: boolean;
-  actions?: Array<{
-    id: string;
-    label: string;
-    action: () => void;
-  }>;
-}
-
 interface NotificationToolbarProps {
   className?: string;
 }
@@ -79,52 +65,21 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
   className = '' 
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [notifications, setNotifications] = useState<Notification[]>([
-    {
-      id: '1',
-      title: 'Task Reminder',
-      message: 'Review project proposal is due in 1 hour',
-      type: 'warning',
-      timestamp: new Date(Date.now() - 300000), // 5 minutes ago
-      read: false,
-      actionable: true,
-      actions: [
-        { id: 'complete', label: 'Mark Done', action: () => log.info('Mark done') },
-        { id: 'snooze', label: 'Snooze', action: () => log.info('Snooze') }
-      ]
-    },
-    {
-      id: '2',
-      title: 'AI Suggestion',
-      message: 'Based on your schedule, I recommend moving the 3pm meeting to tomorrow',
-      type: 'assistant',
-      timestamp: new Date(Date.now() - 600000), // 10 minutes ago
-      read: false,
-      actionable: true,
-      actions: [
-        { id: 'accept', label: 'Accept', action: () => log.info('Accept suggestion') },
-        { id: 'dismiss', label: 'Dismiss', action: () => log.info('Dismiss') }
-      ]
-    },
-    {
-      id: '3',
-      title: 'System Update',
-      message: 'Your widgets have been updated with new features',
-      type: 'success',
-      timestamp: new Date(Date.now() - 1800000), // 30 minutes ago
-      read: true
-    },
-    {
-      id: '4',
-      title: 'Meeting Starting',
-      message: 'Team Standup begins in 15 minutes',
-      type: 'info',
-      timestamp: new Date(Date.now() - 900000), // 15 minutes ago
-      read: false
-    }
-  ]);
+  const notifications = useAlertStore((state) => state.notifications);
+  const unreadCount = useAlertStore((state) => state.unreadCount);
+  const loading = useAlertStore((state) => state.loading);
+  const error = useAlertStore((state) => state.error);
+  const loadNotifications = useAlertStore((state) => state.loadNotifications);
+  const refreshUnreadCount = useAlertStore((state) => state.refreshUnreadCount);
+  const markAllAsRead = useAlertStore((state) => state.markAllAsRead);
+  const dismissNotification = useAlertStore((state) => state.dismissNotification);
+  const clearAllNotifications = useAlertStore((state) => state.clearAllNotifications);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    void refreshUnreadCount();
+  }, [refreshUnreadCount]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -146,10 +101,13 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
   }, [isOpen]);
 
   const toggleNotificationPanel = () => {
-    setIsOpen(prev => !prev);
-    // Mark all as read when opened
-    if (!isOpen) {
-      setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
+      void loadNotifications();
+      if (unreadCount > 0) {
+        void markAllAsRead();
+      }
     }
   };
 
@@ -159,7 +117,9 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
       case 'warning': return '⚠️';
       case 'success': return '✅';
       case 'error': return '❌';
-      case 'assistant': return '🤖';
+      case 'task': return '✅';
+      case 'calendar': return '📅';
+      case 'channel': return '🔔';
       default: return '📢';
     }
   };
@@ -170,12 +130,15 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
       case 'warning': return 'border-l-yellow-500';
       case 'success': return 'border-l-green-500';
       case 'error': return 'border-l-red-500';
-      case 'assistant': return 'border-l-purple-500';
+      case 'task': return 'border-l-green-500';
+      case 'calendar': return 'border-l-blue-500';
+      case 'channel': return 'border-l-purple-500';
       default: return 'border-l-gray-500';
     }
   };
 
-  const formatTime = (date: Date) => {
+  const formatTime = (dateLike: string) => {
+    const date = new Date(dateLike);
     const now = new Date();
     const diff = now.getTime() - date.getTime();
     const minutes = Math.floor(diff / 60000);
@@ -188,16 +151,10 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
     return `${days}d ago`;
   };
 
-  const deleteNotification = (notificationId: string) => {
-    setNotifications(prev => prev.filter(n => n.id !== notificationId));
-  };
-
-  const clearAllNotifications = () => {
-    setNotifications([]);
-  };
-
-  const unreadCount = notifications.filter(n => !n.read).length;
   const hasNotifications = notifications.length > 0;
+  const actionableNotifications = notifications.filter((notification) =>
+    notification.type === 'task' || notification.type === 'calendar',
+  ).length;
 
   return (
     <div className={`relative ${className}`}>
@@ -256,7 +213,7 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
                 <div>
                   <h3 className="text-sm font-semibold text-white">Notifications</h3>
                   <p className="text-xs text-gray-400">
-                    {hasNotifications ? `${notifications.length} total` : 'No notifications'}
+                    {loading ? 'Loading…' : hasNotifications ? `${notifications.length} total` : 'No notifications'}
                   </p>
                 </div>
               </div>
@@ -264,7 +221,7 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
               <div className="flex items-center gap-1">
                 {hasNotifications && (
                   <button
-                    onClick={clearAllNotifications}
+                    onClick={() => void clearAllNotifications()}
                     className="text-xs text-gray-400 hover:text-white transition-colors mr-2"
                   >
                     Clear All
@@ -286,7 +243,11 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
 
             {/* Notification List */}
             <div className="max-h-96 overflow-y-auto">
-              {notifications.length === 0 ? (
+              {error ? (
+                <div className="p-4 text-center text-red-300 text-sm">
+                  <div>{error}</div>
+                </div>
+              ) : notifications.length === 0 ? (
                 <div className="p-4 text-center text-gray-400 text-sm">
                   <div className="text-2xl mb-2">🔕</div>
                   <div>No notifications</div>
@@ -314,33 +275,34 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
                               {notification.title}
                             </span>
                             <span className="text-xs text-gray-400 flex-shrink-0 ml-2">
-                              {formatTime(notification.timestamp)}
+                              {formatTime(notification.createdAt)}
                             </span>
                           </div>
                           
                           <p className="text-xs text-gray-300 mb-2 line-clamp-2">
-                            {notification.message}
+                            {notification.body}
                           </p>
 
                           {/* Actions */}
-                          {notification.actionable && notification.actions && (
+                          {notification.route && (
                             <div className="flex items-center gap-2">
-                              {notification.actions.map((action) => (
-                                <button
-                                  key={action.id}
-                                  onClick={action.action}
-                                  className="px-2 py-1 bg-gray-700/50 hover:bg-gray-600/50 rounded text-xs text-gray-300 transition-colors"
-                                >
-                                  {action.label}
-                                </button>
-                              ))}
+                              <button
+                                onClick={() => {
+                                  if (typeof window !== 'undefined') {
+                                    window.location.href = notification.route!;
+                                  }
+                                }}
+                                className="px-2 py-1 bg-gray-700/50 hover:bg-gray-600/50 rounded text-xs text-gray-300 transition-colors"
+                              >
+                                Open
+                              </button>
                             </div>
                           )}
                         </div>
 
                         {/* Delete Button */}
                         <button
-                          onClick={() => deleteNotification(notification.id)}
+                          onClick={() => void dismissNotification(notification.id)}
                           className="w-6 h-6 flex items-center justify-center hover:bg-red-500/20 rounded text-gray-400 hover:text-red-400 transition-colors flex-shrink-0"
                         >
                           ✕
@@ -372,7 +334,7 @@ export const NotificationToolbar: React.FC<NotificationToolbarProps> = ({
                 <div>
                   {hasNotifications ? (
                     <span>
-                      {notifications.filter(n => n.type === 'assistant').length} AI suggestions
+                      {actionableNotifications} actionable alerts
                     </span>
                   ) : (
                     <span className="text-green-400">All clear</span>

--- a/src/components/ui/TaskToolbar.tsx
+++ b/src/components/ui/TaskToolbar.tsx
@@ -16,6 +16,7 @@
  * - Non-intrusive but highly functional
  */
 import React, { useState, useRef, useEffect } from 'react';
+import { useTaskStore } from '../../stores/useTaskStore';
 
 // Glass Button Style Creator for Task Toolbar
 const createGlassButtonStyle = (color: string, size: 'sm' | 'md' = 'md', isDisabled: boolean = false) => ({
@@ -54,16 +55,6 @@ const createGlassButtonHoverHandlers = (color: string, isDisabled: boolean = fal
   }
 });
 
-interface Task {
-  id: string;
-  title: string;
-  completed: boolean;
-  priority: 'low' | 'medium' | 'high';
-  dueDate?: Date;
-  createdAt: Date;
-  assistantGenerated?: boolean;
-}
-
 interface TaskToolbarProps {
   className?: string;
 }
@@ -72,31 +63,11 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
   className = '' 
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [tasks, setTasks] = useState<Task[]>([
-    {
-      id: '1',
-      title: 'Review project proposal',
-      completed: false,
-      priority: 'high',
-      dueDate: new Date(Date.now() + 86400000), // Tomorrow
-      createdAt: new Date(),
-      assistantGenerated: true
-    },
-    {
-      id: '2', 
-      title: 'Schedule team meeting',
-      completed: false,
-      priority: 'medium',
-      createdAt: new Date()
-    },
-    {
-      id: '3',
-      title: 'Update documentation',
-      completed: true,
-      priority: 'low',
-      createdAt: new Date()
-    }
-  ]);
+  const tasks = useTaskStore((state) => state.tasks);
+  const syncTasks = useTaskStore((state) => state.syncTasks);
+  const createBackendTask = useTaskStore((state) => state.createBackendTask);
+  const syncTaskStatus = useTaskStore((state) => state.syncTaskStatus);
+  const deleteBackendTask = useTaskStore((state) => state.deleteBackendTask);
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -129,45 +100,56 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
   }, [isOpen]);
 
   const toggleTaskPanel = () => {
-    setIsOpen(prev => !prev);
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
+      void syncTasks();
+    }
   };
 
-  const addTask = () => {
+  const addTask = async () => {
     if (!newTaskTitle.trim()) return;
-    
-    const newTask: Task = {
-      id: Date.now().toString(),
+
+    const createdTask = await createBackendTask({
       title: newTaskTitle.trim(),
-      completed: false,
-      priority: 'medium',
-      createdAt: new Date()
-    };
-    
-    setTasks(prev => [newTask, ...prev]);
-    setNewTaskTitle('');
+      priority: 'normal',
+    });
+    if (createdTask) {
+      setNewTaskTitle('');
+    }
   };
 
-  const toggleTask = (taskId: string) => {
-    setTasks(prev => prev.map(task => 
-      task.id === taskId ? { ...task, completed: !task.completed } : task
-    ));
+  const toggleTask = async (taskId: string) => {
+    const task = tasks.find((item) => item.id === taskId);
+    if (!task) {
+      return;
+    }
+
+    const nextStatus = task.status === 'completed' ? 'pending' : 'completed';
+    await syncTaskStatus(taskId, nextStatus);
   };
 
-  const deleteTask = (taskId: string) => {
-    setTasks(prev => prev.filter(task => task.id !== taskId));
+  const deleteTask = async (taskId: string) => {
+    await deleteBackendTask(taskId);
   };
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
       case 'high': return 'text-red-400';
-      case 'medium': return 'text-yellow-400';
+      case 'urgent': return 'text-red-300';
+      case 'normal': return 'text-yellow-400';
       case 'low': return 'text-green-400';
       default: return 'text-gray-400';
     }
   };
 
   const getPriorityIcon = (priority: string) => {
-    const color = priority === 'high' ? '239, 68, 68' : priority === 'medium' ? '251, 191, 36' : '34, 197, 94';
+    const color =
+      priority === 'high' || priority === 'urgent'
+        ? '239, 68, 68'
+        : priority === 'normal'
+          ? '251, 191, 36'
+          : '34, 197, 94';
     return (
       <div
         style={createGlassButtonStyle(color, 'sm')}
@@ -179,8 +161,14 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
     );
   };
 
-  const pendingTasksCount = tasks.filter(t => !t.completed).length;
-  const hasHighPriorityTasks = tasks.some(t => !t.completed && t.priority === 'high');
+  const pendingTasksCount = tasks.filter(
+    (task) => !['completed', 'failed', 'cancelled'].includes(task.status),
+  ).length;
+  const hasHighPriorityTasks = tasks.some(
+    (task) =>
+      !['completed', 'failed', 'cancelled'].includes(task.status)
+      && ['high', 'urgent'].includes(task.priority),
+  );
 
   return (
     <div className={`relative ${className}`}>
@@ -232,7 +220,7 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                 <div>
                   <h3 className="text-sm font-semibold text-white">Tasks</h3>
                   <p className="text-xs text-gray-400">
-                    {pendingTasksCount} pending, {tasks.filter(t => t.completed).length} completed
+                    {pendingTasksCount} pending, {tasks.filter(t => t.status === 'completed').length} completed
                   </p>
                 </div>
               </div>
@@ -295,11 +283,18 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                 </div>
               ) : (
                 <div className="divide-y divide-gray-700/50">
-                  {tasks.map((task) => (
+                  {tasks.map((task) => {
+                    const completed = task.status === 'completed';
+                    const dueAt = task.metadata?.dueAt
+                      ? new Date(task.metadata.dueAt as string)
+                      : null;
+                    const assistantGenerated = Boolean(task.metadata?.assistantGenerated);
+
+                    return (
                     <div
                       key={task.id}
                       className={`p-3 hover:bg-gray-800/30 transition-colors ${
-                        task.completed ? 'opacity-60' : ''
+                        completed ? 'opacity-60' : ''
                       }`}
                     >
                       <div className="flex items-start gap-3">
@@ -307,12 +302,12 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                         <button
                           onClick={() => toggleTask(task.id)}
                           className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
-                            task.completed
+                            completed
                               ? 'bg-green-500 border-green-500 text-white'
                               : 'border-gray-500 hover:border-gray-400'
                           }`}
                         >
-                          {task.completed && '✓'}
+                          {completed && '✓'}
                         </button>
 
                         {/* Task Content */}
@@ -321,14 +316,14 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                             {getPriorityIcon(task.priority)}
                             <span
                               className={`text-sm ${
-                                task.completed 
+                                completed 
                                   ? 'line-through text-gray-400' 
                                   : 'text-white'
                               }`}
                             >
                               {task.title}
                             </span>
-                            {task.assistantGenerated && (
+                            {assistantGenerated && (
                               <span className="text-xs bg-purple-500/20 text-purple-300 px-1 rounded">
                                 AI
                               </span>
@@ -336,9 +331,9 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                           </div>
                           
                           {/* Due Date */}
-                          {task.dueDate && (
+                          {dueAt && (
                             <div className="text-xs text-gray-400">
-                              Due: {task.dueDate.toLocaleDateString()}
+                              Due: {dueAt.toLocaleDateString()}
                             </div>
                           )}
                         </div>
@@ -356,7 +351,8 @@ export const TaskToolbar: React.FC<TaskToolbarProps> = ({
                         </button>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/src/modules/AlertModule.tsx
+++ b/src/modules/AlertModule.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { useCalendarStore } from '../stores/useCalendarStore';
 import { useTaskStore } from '../stores/useTaskStore';
+import * as NotificationAdapter from '../api/adapters/NotificationAdapter';
+import { useAlertStore } from '../stores/useAlertStore';
 
 const isElectron = typeof window !== 'undefined' && !!(window as any).isElectron;
 const electronAPI = typeof window !== 'undefined' ? (window as any).electronAPI : null;
@@ -10,6 +12,25 @@ function sendAlert(title: string, body: string, route?: string): void {
     electronAPI.send('notification:show', title, body, route);
   } else if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
     new Notification(title, { body });
+  }
+}
+
+async function persistAlert(
+  type: NotificationAdapter.Notification['type'],
+  title: string,
+  body: string,
+  route?: string,
+): Promise<void> {
+  try {
+    const notification = await NotificationAdapter.send({
+      type,
+      title,
+      body,
+      route,
+    });
+    useAlertStore.getState().recordNotification(notification);
+  } catch {
+    // Keep local/browser alerts working even if backend persistence fails.
   }
 }
 
@@ -35,7 +56,10 @@ export const AlertModule: React.FC = () => {
           const key = `${event.id}-${mins}`;
           if (minutesUntil <= mins && minutesUntil > mins - 1 && !firedReminders.current.has(key)) {
             firedReminders.current.add(key);
-            sendAlert(`${event.title} in ${Math.round(minutesUntil)} min`, event.description || 'Event starting soon', '/app?view=calendar');
+            const title = `${event.title} in ${Math.round(minutesUntil)} min`;
+            const body = event.description || 'Event starting soon';
+            sendAlert(title, body, '/app?view=calendar');
+            void persistAlert('calendar', title, body, '/app?view=calendar');
           }
         }
       }
@@ -50,7 +74,10 @@ export const AlertModule: React.FC = () => {
       const prevIds = new Set((prev as any).tasks?.filter((t: any) => t.status === 'completed').map((t: any) => t.id) ?? []);
       for (const task of state.tasks ?? []) {
         if (task.status === 'completed' && !prevIds.has(task.id)) {
-          sendAlert('Task completed', task.title || task.id, '/app');
+          const title = 'Task completed';
+          const body = task.title || task.id;
+          sendAlert(title, body, '/app');
+          void persistAlert('task', title, body, '/app');
         }
       }
     });

--- a/src/stores/__tests__/useAlertStore.test.ts
+++ b/src/stores/__tests__/useAlertStore.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useAlertStore } from '../useAlertStore';
+
+const {
+  mockGetNotifications,
+  mockGetUnreadCount,
+  mockMarkAsRead,
+  mockMarkAllAsRead,
+  mockDismiss,
+} = vi.hoisted(() => ({
+  mockGetNotifications: vi.fn(),
+  mockGetUnreadCount: vi.fn(),
+  mockMarkAsRead: vi.fn(),
+  mockMarkAllAsRead: vi.fn(),
+  mockDismiss: vi.fn(),
+}));
+
+vi.mock('../../api/adapters/NotificationAdapter', () => ({
+  getNotifications: mockGetNotifications,
+  getUnreadCount: mockGetUnreadCount,
+  markAsRead: mockMarkAsRead,
+  markAllAsRead: mockMarkAllAsRead,
+  dismiss: mockDismiss,
+}));
+
+describe('useAlertStore', () => {
+  beforeEach(() => {
+    useAlertStore.setState({
+      notifications: [],
+      unreadCount: 0,
+      loading: false,
+      error: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('loads notifications and derives unread count', async () => {
+    mockGetNotifications.mockResolvedValue([
+      {
+        id: 'notif-1',
+        type: 'calendar',
+        priority: 'normal',
+        title: 'Meeting soon',
+        body: 'Standup starts in 15 minutes',
+        read: false,
+        dismissed: false,
+        createdAt: '2026-04-29T00:00:00Z',
+      },
+      {
+        id: 'notif-2',
+        type: 'task',
+        priority: 'normal',
+        title: 'Task completed',
+        body: 'Review docs',
+        read: true,
+        dismissed: false,
+        createdAt: '2026-04-29T00:05:00Z',
+      },
+    ]);
+
+    await useAlertStore.getState().loadNotifications();
+
+    expect(useAlertStore.getState().notifications).toHaveLength(2);
+    expect(useAlertStore.getState().unreadCount).toBe(1);
+  });
+
+  test('marks a notification as read in backend and local state', async () => {
+    useAlertStore.setState({
+      notifications: [
+        {
+          id: 'notif-1',
+          type: 'calendar',
+          priority: 'normal',
+          title: 'Meeting soon',
+          body: 'Standup starts in 15 minutes',
+          read: false,
+          dismissed: false,
+          createdAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+      unreadCount: 1,
+    } as any);
+    mockMarkAsRead.mockResolvedValue(undefined);
+
+    await useAlertStore.getState().markAsRead('notif-1');
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith('notif-1');
+    expect(useAlertStore.getState().notifications[0]?.read).toBe(true);
+    expect(useAlertStore.getState().unreadCount).toBe(0);
+  });
+
+  test('marks all notifications as read', async () => {
+    useAlertStore.setState({
+      notifications: [
+        {
+          id: 'notif-1',
+          type: 'calendar',
+          priority: 'normal',
+          title: 'Meeting soon',
+          body: 'Standup starts in 15 minutes',
+          read: false,
+          dismissed: false,
+          createdAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+      unreadCount: 1,
+    } as any);
+    mockMarkAllAsRead.mockResolvedValue(undefined);
+
+    await useAlertStore.getState().markAllAsRead();
+
+    expect(mockMarkAllAsRead).toHaveBeenCalled();
+    expect(useAlertStore.getState().notifications[0]?.read).toBe(true);
+    expect(useAlertStore.getState().unreadCount).toBe(0);
+  });
+
+  test('dismisses a single notification', async () => {
+    useAlertStore.setState({
+      notifications: [
+        {
+          id: 'notif-1',
+          type: 'calendar',
+          priority: 'normal',
+          title: 'Meeting soon',
+          body: 'Standup starts in 15 minutes',
+          read: false,
+          dismissed: false,
+          createdAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+      unreadCount: 1,
+    } as any);
+    mockDismiss.mockResolvedValue(undefined);
+
+    await useAlertStore.getState().dismissNotification('notif-1');
+
+    expect(mockDismiss).toHaveBeenCalledWith('notif-1');
+    expect(useAlertStore.getState().notifications).toHaveLength(0);
+  });
+
+  test('refreshes unread count from backend', async () => {
+    mockGetUnreadCount.mockResolvedValue(4);
+
+    await useAlertStore.getState().refreshUnreadCount();
+
+    expect(useAlertStore.getState().unreadCount).toBe(4);
+  });
+});

--- a/src/stores/__tests__/useTaskStore.test.ts
+++ b/src/stores/__tests__/useTaskStore.test.ts
@@ -1,10 +1,33 @@
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { useTaskStore } from '../useTaskStore';
+
+const {
+  mockGetTasks,
+  mockCreateTask,
+  mockUpdateTask,
+  mockDeleteTask,
+  mockCompleteTask,
+} = vi.hoisted(() => ({
+  mockGetTasks: vi.fn(),
+  mockCreateTask: vi.fn(),
+  mockUpdateTask: vi.fn(),
+  mockDeleteTask: vi.fn(),
+  mockCompleteTask: vi.fn(),
+}));
+
+vi.mock('../../api/adapters/TaskAdapter', () => ({
+  getTasks: mockGetTasks,
+  createTask: mockCreateTask,
+  updateTask: mockUpdateTask,
+  deleteTask: mockDeleteTask,
+  completeTask: mockCompleteTask,
+}));
 
 describe('useTaskStore', () => {
   beforeEach(() => {
     // Reset store between tests
     useTaskStore.getState().clearTasks();
+    vi.clearAllMocks();
   });
 
   describe('createTask', () => {
@@ -140,6 +163,117 @@ describe('useTaskStore', () => {
       const task = useTaskStore.getState().getTask(id);
       expect(task!.progress.percentage).toBe(50);
       expect(task!.progress.currentStep).toBe(2);
+    });
+  });
+
+  describe('backend sync', () => {
+    test('syncTasks maps backend tasks into store state', async () => {
+      mockGetTasks.mockResolvedValue([
+        {
+          id: 'task-1',
+          title: 'Synced task',
+          status: 'in_progress',
+          priority: 'high',
+          createdAt: '2026-04-29T00:00:00Z',
+          updatedAt: '2026-04-29T00:10:00Z',
+        },
+      ]);
+
+      await useTaskStore.getState().syncTasks();
+
+      const task = useTaskStore.getState().getTask('task-1');
+      expect(task?.status).toBe('running');
+      expect(task?.priority).toBe('high');
+      expect(useTaskStore.getState().totalTasks).toBe(1);
+    });
+
+    test('createBackendTask persists a task and adds it to the store', async () => {
+      mockCreateTask.mockResolvedValue({
+        id: 'task-backend-1',
+        title: 'Backend task',
+        status: 'pending',
+        priority: 'normal',
+        createdAt: '2026-04-29T00:00:00Z',
+        metadata: {},
+      });
+
+      const created = await useTaskStore.getState().createBackendTask({
+        title: 'Backend task',
+      });
+
+      expect(mockCreateTask).toHaveBeenCalledWith({
+        title: 'Backend task',
+        description: undefined,
+        priority: undefined,
+        dueAt: undefined,
+        metadata: undefined,
+      });
+      expect(created?.id).toBe('task-backend-1');
+      expect(useTaskStore.getState().getTask('task-backend-1')?.title).toBe('Backend task');
+    });
+
+    test('syncTaskStatus completes a task through the backend', async () => {
+      useTaskStore.setState({
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Task',
+            type: 'background',
+            status: 'pending',
+            priority: 'normal',
+            progress: { currentStep: 0, totalSteps: 1, percentage: 0 },
+            createdAt: '2026-04-29T00:00:00Z',
+            updatedAt: '2026-04-29T00:00:00Z',
+            canPause: false,
+            canResume: false,
+            canCancel: true,
+            canRetry: false,
+            metadata: {},
+          },
+        ],
+      } as any);
+      mockCompleteTask.mockResolvedValue({
+        id: 'task-1',
+        title: 'Task',
+        status: 'completed',
+        priority: 'normal',
+        createdAt: '2026-04-29T00:00:00Z',
+        completedAt: '2026-04-29T00:10:00Z',
+        metadata: {},
+      });
+
+      await useTaskStore.getState().syncTaskStatus('task-1', 'completed');
+
+      expect(mockCompleteTask).toHaveBeenCalledWith('task-1');
+      expect(useTaskStore.getState().getTask('task-1')?.status).toBe('completed');
+    });
+
+    test('deleteBackendTask removes a task from the store', async () => {
+      useTaskStore.setState({
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Task',
+            type: 'background',
+            status: 'pending',
+            priority: 'normal',
+            progress: { currentStep: 0, totalSteps: 1, percentage: 0 },
+            createdAt: '2026-04-29T00:00:00Z',
+            updatedAt: '2026-04-29T00:00:00Z',
+            canPause: false,
+            canResume: false,
+            canCancel: true,
+            canRetry: false,
+            metadata: {},
+          },
+        ],
+      } as any);
+      mockDeleteTask.mockResolvedValue(undefined);
+
+      await useTaskStore.getState().deleteBackendTask('task-1');
+
+      expect(mockDeleteTask).toHaveBeenCalledWith('task-1');
+      expect(useTaskStore.getState().getTask('task-1')).toBeUndefined();
     });
   });
 

--- a/src/stores/useAlertStore.ts
+++ b/src/stores/useAlertStore.ts
@@ -1,0 +1,161 @@
+import { create } from 'zustand';
+import * as NotificationAdapter from '../api/adapters/NotificationAdapter';
+
+type AlertNotification = NotificationAdapter.Notification;
+
+interface AlertStoreState {
+  notifications: AlertNotification[];
+  unreadCount: number;
+  loading: boolean;
+  error: string | null;
+  loadNotifications: () => Promise<void>;
+  refreshUnreadCount: () => Promise<void>;
+  markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  dismissNotification: (id: string) => Promise<void>;
+  clearAllNotifications: () => Promise<void>;
+  recordNotification: (notification: AlertNotification) => void;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function unreadCountFor(notifications: AlertNotification[]): number {
+  return notifications.filter((notification) => !notification.read).length;
+}
+
+export const useAlertStore = create<AlertStoreState>((set, get) => ({
+  notifications: [],
+  unreadCount: 0,
+  loading: false,
+  error: null,
+
+  loadNotifications: async () => {
+    set({ loading: true, error: null });
+
+    try {
+      const notifications = await NotificationAdapter.getNotifications({ limit: 50 });
+      set({
+        notifications,
+        unreadCount: unreadCountFor(notifications),
+        loading: false,
+      });
+    } catch (error) {
+      set({
+        error: toErrorMessage(error),
+        loading: false,
+      });
+    }
+  },
+
+  refreshUnreadCount: async () => {
+    try {
+      const unreadCount = await NotificationAdapter.getUnreadCount();
+      set({ unreadCount });
+    } catch (error) {
+      set({ error: toErrorMessage(error) });
+    }
+  },
+
+  markAsRead: async (id) => {
+    try {
+      await NotificationAdapter.markAsRead(id);
+      set((state) => {
+        const notifications = state.notifications.map((notification) =>
+          notification.id === id
+            ? {
+                ...notification,
+                read: true,
+                readAt: notification.readAt || new Date().toISOString(),
+              }
+            : notification,
+        );
+
+        return {
+          notifications,
+          unreadCount: unreadCountFor(notifications),
+          error: null,
+        };
+      });
+    } catch (error) {
+      set({ error: toErrorMessage(error) });
+    }
+  },
+
+  markAllAsRead: async () => {
+    try {
+      await NotificationAdapter.markAllAsRead();
+      set((state) => {
+        const notifications = state.notifications.map((notification) =>
+          notification.read
+            ? notification
+            : {
+                ...notification,
+                read: true,
+                readAt: notification.readAt || new Date().toISOString(),
+              },
+        );
+
+        return {
+          notifications,
+          unreadCount: 0,
+          error: null,
+        };
+      });
+    } catch (error) {
+      set({ error: toErrorMessage(error) });
+    }
+  },
+
+  dismissNotification: async (id) => {
+    try {
+      await NotificationAdapter.dismiss(id);
+      set((state) => {
+        const notifications = state.notifications.filter(
+          (notification) => notification.id !== id,
+        );
+
+        return {
+          notifications,
+          unreadCount: unreadCountFor(notifications),
+          error: null,
+        };
+      });
+    } catch (error) {
+      set({ error: toErrorMessage(error) });
+    }
+  },
+
+  clearAllNotifications: async () => {
+    const ids = get().notifications.map((notification) => notification.id);
+
+    try {
+      await Promise.all(ids.map((id) => NotificationAdapter.dismiss(id)));
+      set({
+        notifications: [],
+        unreadCount: 0,
+        error: null,
+      });
+    } catch (error) {
+      set({ error: toErrorMessage(error) });
+    }
+  },
+
+  recordNotification: (notification) => {
+    set((state) => {
+      const notifications = [
+        notification,
+        ...state.notifications.filter(
+          (existingNotification) => existingNotification.id !== notification.id,
+        ),
+      ];
+
+      return {
+        notifications,
+        unreadCount: unreadCountFor(notifications),
+        error: null,
+      };
+    });
+  },
+}));

--- a/src/stores/useTaskStore.ts
+++ b/src/stores/useTaskStore.ts
@@ -30,6 +30,8 @@ import {
 import { logger, LogCategory } from '../utils/logger';
 import * as TaskAdapter from '../api/adapters/TaskAdapter';
 
+type BackendTask = TaskAdapter.BackendTask;
+
 // ================================================================================
 // 任务管理Actions接口
 // ================================================================================
@@ -37,6 +39,15 @@ import * as TaskAdapter from '../api/adapters/TaskAdapter';
 interface TaskActions {
   // Backend sync
   syncTasks: () => Promise<void>;
+  createBackendTask: (task: {
+    title: string;
+    description?: string;
+    priority?: BackendTask['priority'];
+    dueAt?: string;
+    metadata?: Record<string, any>;
+  }) => Promise<TaskItem | null>;
+  syncTaskStatus: (taskId: string, status: BackendTask['status']) => Promise<TaskItem | null>;
+  deleteBackendTask: (taskId: string) => Promise<void>;
   addTask: (task: { id: string; title: string; description?: string; status: string; dueAt?: string; createdAt: string }) => void;
 
   // 任务创建和管理
@@ -81,6 +92,56 @@ interface TaskActions {
 
 export type TaskStore = TaskManagerState & TaskActions;
 
+function mapBackendStatus(status: BackendTask['status']): TaskStatus {
+  if (status === 'in_progress') {
+    return 'running';
+  }
+
+  return status as TaskStatus;
+}
+
+function toTaskItem(task: BackendTask): TaskItem {
+  return {
+    id: task.id,
+    title: task.title,
+    type: 'background' as TaskType,
+    status: mapBackendStatus(task.status),
+    priority: (task.priority || 'normal') as TaskPriority,
+    progress: {
+      currentStep: 0,
+      totalSteps: 1,
+      percentage: task.status === 'completed' ? 100 : 0,
+      currentStepName: task.status === 'completed' ? 'Completed' : 'Pending sync',
+    },
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt || task.createdAt,
+    completedAt: task.completedAt,
+    canPause: false,
+    canResume: false,
+    canCancel: task.status === 'pending' || task.status === 'in_progress',
+    canRetry: task.status === 'failed',
+    metadata: {
+      ...task.metadata,
+      description: task.description,
+      dueAt: task.dueAt,
+      synced: true,
+    },
+  };
+}
+
+function applyTaskCollection(taskItems: TaskItem[]) {
+  return {
+    tasks: taskItems,
+    totalTasks: taskItems.length,
+    activeTasks: taskItems.filter((task) => ['running', 'pending'].includes(task.status)),
+    completedTasks: taskItems.filter((task) =>
+      ['completed', 'failed', 'cancelled'].includes(task.status),
+    ),
+    completedTasksCount: taskItems.filter((task) => task.status === 'completed').length,
+    failedTasksCount: taskItems.filter((task) => task.status === 'failed').length,
+  };
+}
+
 // ================================================================================
 // 任务管理Store实现
 // ================================================================================
@@ -106,33 +167,78 @@ export const useTaskStore = create<TaskStore>()(
     syncTasks: async () => {
       try {
         const backendTasks = await TaskAdapter.getTasks();
-        const mapped: TaskItem[] = backendTasks.map((bt) => ({
-          id: bt.id,
-          title: bt.title,
-          type: 'background' as TaskType,
-          status: (bt.status === 'in_progress' ? 'running' : bt.status) as TaskStatus,
-          priority: (bt.priority || 'normal') as TaskPriority,
-          progress: { currentStep: 0, totalSteps: 1, percentage: bt.status === 'completed' ? 100 : 0 },
-          createdAt: bt.createdAt,
-          updatedAt: bt.updatedAt || bt.createdAt,
-          completedAt: bt.completedAt,
-          canPause: false,
-          canResume: false,
-          canCancel: bt.status === 'pending' || bt.status === 'in_progress',
-          canRetry: bt.status === 'failed',
-          metadata: { ...bt.metadata, description: bt.description, dueAt: bt.dueAt, synced: true },
-        }));
-        set({
-          tasks: mapped,
-          totalTasks: mapped.length,
-          activeTasks: mapped.filter((t) => ['running', 'pending'].includes(t.status)),
-          completedTasks: mapped.filter((t) => ['completed', 'failed', 'cancelled'].includes(t.status)),
-          completedTasksCount: mapped.filter((t) => t.status === 'completed').length,
-          failedTasksCount: mapped.filter((t) => t.status === 'failed').length,
-        });
+        const mapped = backendTasks.map(toTaskItem);
+        set(applyTaskCollection(mapped));
         logger.info(LogCategory.TASK_MANAGEMENT, 'Tasks synced from backend', { count: mapped.length });
       } catch (err) {
         logger.warn(LogCategory.TASK_MANAGEMENT, 'Failed to sync tasks from backend', { error: err });
+      }
+    },
+
+    createBackendTask: async ({ title, description, priority, dueAt, metadata }) => {
+      try {
+        const backendTask = await TaskAdapter.createTask({
+          title,
+          description,
+          priority,
+          dueAt,
+          metadata,
+        });
+        const mapped = toTaskItem(backendTask);
+        set((state) => applyTaskCollection([mapped, ...state.tasks.filter((task) => task.id !== mapped.id)]));
+        logger.info(LogCategory.TASK_MANAGEMENT, 'Task created on backend', {
+          taskId: mapped.id,
+          title,
+        });
+        return mapped;
+      } catch (err) {
+        logger.warn(LogCategory.TASK_MANAGEMENT, 'Failed to create backend task', {
+          title,
+          error: err,
+        });
+        return null;
+      }
+    },
+
+    syncTaskStatus: async (taskId, status) => {
+      try {
+        const backendTask =
+          status === 'completed'
+            ? await TaskAdapter.completeTask(taskId)
+            : await TaskAdapter.updateTask(taskId, { status });
+        const mapped = toTaskItem(backendTask);
+        set((state) =>
+          applyTaskCollection(
+            state.tasks.some((task) => task.id === mapped.id)
+              ? state.tasks.map((task) => (task.id === mapped.id ? mapped : task))
+              : [mapped, ...state.tasks],
+          ),
+        );
+        logger.info(LogCategory.TASK_MANAGEMENT, 'Task status synced to backend', {
+          taskId,
+          status,
+        });
+        return mapped;
+      } catch (err) {
+        logger.warn(LogCategory.TASK_MANAGEMENT, 'Failed to sync task status', {
+          taskId,
+          status,
+          error: err,
+        });
+        return null;
+      }
+    },
+
+    deleteBackendTask: async (taskId) => {
+      try {
+        await TaskAdapter.deleteTask(taskId);
+        set((state) => applyTaskCollection(state.tasks.filter((task) => task.id !== taskId)));
+        logger.info(LogCategory.TASK_MANAGEMENT, 'Task deleted on backend', { taskId });
+      } catch (err) {
+        logger.warn(LogCategory.TASK_MANAGEMENT, 'Failed to delete backend task', {
+          taskId,
+          error: err,
+        });
       }
     },
 
@@ -143,7 +249,12 @@ export const useTaskStore = create<TaskStore>()(
         type: 'background' as TaskType,
         status: (task.status === 'in_progress' ? 'running' : task.status || 'pending') as TaskStatus,
         priority: 'normal',
-        progress: { currentStep: 0, totalSteps: 1, percentage: 0 },
+        progress: {
+          currentStep: 0,
+          totalSteps: 1,
+          percentage: 0,
+          currentStepName: 'Pending sync',
+        },
         createdAt: task.createdAt || new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         canPause: false,
@@ -571,6 +682,10 @@ export const useSelectedTaskId = () => useTaskStore(state => state.selectedTaskI
 
 // 操作选择器
 export const useTaskActions = () => useTaskStore(state => ({
+  syncTasks: state.syncTasks,
+  createBackendTask: state.createBackendTask,
+  syncTaskStatus: state.syncTaskStatus,
+  deleteBackendTask: state.deleteBackendTask,
   createTask: state.createTask,
   updateTask: state.updateTask,
   removeTask: state.removeTask,


### PR DESCRIPTION
## Summary
- replace hardcoded task toolbar state with real `useTaskStore` backend sync actions
- replace hardcoded notification toolbar state with a real `useAlertStore` backed by `NotificationAdapter`
- persist calendar/task alerts through the notification adapter so alert UI can display real reminders and completions

## Changes
- add backend-aware task store actions for create/status sync/delete
- add `useAlertStore` with load/read/dismiss/clear flows
- wire `TaskToolbar` to backend task state instead of demo data
- wire `NotificationToolbar` to backend notifications instead of demo data
- persist `AlertModule` calendar/task alerts via notification APIs
- add regression tests for task backend sync and alert store behavior

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | `src/stores/__tests__/useTaskStore.test.ts`, `src/stores/__tests__/useAlertStore.test.ts`, `src/api/adapters/__tests__/NotificationAdapter.test.ts` | Pass |
| L2 Component | N/A | — |
| L3 Integration | N/A | — |
| L4 API | adapter contract tests included above | Pass |
| L5 Smoke/E2E | N/A for this slice | — |

## Related Issues
Related to #355

## Remaining for #355
- Mate chat scheduling for tasks/calendar items is still missing on `main`
- external calendar sync still needs real end-to-end verification or follow-up split
