### PR TITLE
fix(calendar): wire toolbar to real event workflows

### DIFF
--- a/src/components/ui/CalendarToolbar.tsx
+++ b/src/components/ui/CalendarToolbar.tsx
@@ -2,20 +2,25 @@
  * ============================================================================
  * Calendar Toolbar (CalendarToolbar.tsx) - macOS-style Calendar Management
  * ============================================================================
- * 
+ *
  * Core Responsibilities:
  * - Calendar and event management for header toolbar
  * - Quick event viewing and scheduling
  * - Integration with assistant for AI-powered scheduling
  * - Similar to macOS Calendar app in toolbar
- * 
+ *
  * Design Philosophy:
  * - Quick access to schedule information
  * - Clean, focused interface for time management
  * - Assistant-powered scheduling intelligence
  * - Non-intrusive but highly functional
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCalendar } from '../../hooks/useCalendar';
+import type { CalendarEvent } from '../../stores/useCalendarStore';
+
+const UPCOMING_WINDOW_DAYS = 7;
+const UPCOMING_LIMIT = 5;
 
 // Glass Button Style Creator for Calendar Toolbar
 const createGlassButtonStyle = (color: string, size: 'sm' | 'md' = 'md', isDisabled: boolean = false) => ({
@@ -32,84 +37,263 @@ const createGlassButtonStyle = (color: string, size: 'sm' | 'md' = 'md', isDisab
   boxShadow: `0 2px 8px rgba(${color}, 0.15)`,
   width: size === 'sm' ? '20px' : '24px',
   height: size === 'sm' ? '20px' : '24px',
-  color: `rgb(${color})`
+  color: `rgb(${color})`,
 });
-
-const createGlassButtonHoverHandlers = (color: string, isDisabled: boolean = false) => ({
-  onMouseEnter: (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (!isDisabled) {
-      e.currentTarget.style.background = `rgba(${color}, 0.2)`;
-      e.currentTarget.style.borderColor = `rgba(${color}, 0.4)`;
-      e.currentTarget.style.transform = 'scale(1.05)';
-      e.currentTarget.style.boxShadow = `0 4px 12px rgba(${color}, 0.25)`;
-    }
-  },
-  onMouseLeave: (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (!isDisabled) {
-      e.currentTarget.style.background = `rgba(${color}, 0.1)`;
-      e.currentTarget.style.borderColor = `rgba(${color}, 0.2)`;
-      e.currentTarget.style.transform = 'scale(1)';
-      e.currentTarget.style.boxShadow = `0 2px 8px rgba(${color}, 0.15)`;
-    }
-  }
-});
-
-interface CalendarEvent {
-  id: string;
-  title: string;
-  startTime: Date;
-  endTime: Date;
-  type: 'meeting' | 'reminder' | 'task' | 'personal';
-  attendees?: string[];
-  assistantGenerated?: boolean;
-}
 
 interface CalendarToolbarProps {
   className?: string;
 }
 
-export const CalendarToolbar: React.FC<CalendarToolbarProps> = ({ 
-  className = '' 
+export interface CalendarToolbarDraft {
+  title: string;
+  startInput: string;
+  endInput: string;
+}
+
+export type CalendarToolbarEventType = 'meeting' | 'reminder' | 'task' | 'personal';
+
+function roundToNextSlot(now: Date): Date {
+  const next = new Date(now);
+  next.setSeconds(0, 0);
+
+  const minutes = next.getMinutes();
+  if (minutes === 0 || minutes === 30) {
+    return next;
+  }
+
+  if (minutes < 30) {
+    next.setMinutes(30, 0, 0);
+    return next;
+  }
+
+  next.setHours(next.getHours() + 1, 0, 0, 0);
+  return next;
+}
+
+export function toDateTimeLocalValue(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+export function buildDefaultEventDraft(now: Date = new Date()): CalendarToolbarDraft {
+  const start = roundToNextSlot(now);
+  const end = new Date(start);
+  end.setHours(end.getHours() + 1);
+
+  return {
+    title: '',
+    startInput: toDateTimeLocalValue(start),
+    endInput: toDateTimeLocalValue(end),
+  };
+}
+
+export function selectToolbarUpcomingEvents(
+  events: CalendarEvent[],
+  now: number = Date.now(),
+  limit: number = UPCOMING_LIMIT,
+): CalendarEvent[] {
+  return [...events]
+    .filter((event) => new Date(event.endTime).getTime() >= now)
+    .sort((left, right) => new Date(left.startTime).getTime() - new Date(right.startTime).getTime())
+    .slice(0, limit);
+}
+
+export function getCalendarToolbarEventType(event: CalendarEvent): CalendarToolbarEventType {
+  const metadata = event.metadata ?? {};
+  const candidates = [
+    metadata.type,
+    metadata.eventType,
+    metadata.kind,
+    metadata.category,
+    metadata.source_type,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.toLowerCase());
+
+  if (candidates.some((value) => value.includes('task') || value.includes('todo'))) {
+    return 'task';
+  }
+
+  if (candidates.some((value) => value.includes('reminder') || value.includes('alert'))) {
+    return 'reminder';
+  }
+
+  if (candidates.some((value) => value.includes('personal') || value.includes('private'))) {
+    return 'personal';
+  }
+
+  if (event.title.toLowerCase().includes('remind')) {
+    return 'reminder';
+  }
+
+  return 'meeting';
+}
+
+export function isAssistantGeneratedEvent(event: CalendarEvent): boolean {
+  const metadata = event.metadata ?? {};
+  return Boolean(
+    metadata.assistantGenerated
+    || metadata.aiGenerated
+    || metadata.createdBy === 'mate'
+    || metadata.createdBy === 'assistant'
+    || metadata.source === 'mate'
+    || metadata.source === 'assistant',
+  );
+}
+
+export function getEventAttendees(event: CalendarEvent): string[] {
+  const attendees = event.metadata?.attendees;
+  if (!Array.isArray(attendees)) {
+    return [];
+  }
+
+  return attendees
+    .map((attendee) => {
+      if (typeof attendee === 'string') return attendee;
+      if (attendee && typeof attendee === 'object') {
+        const name = attendee.name;
+        const email = attendee.email;
+        if (typeof name === 'string' && name.trim()) return name;
+        if (typeof email === 'string' && email.trim()) return email;
+      }
+      return null;
+    })
+    .filter((attendee): attendee is string => Boolean(attendee));
+}
+
+function toIsoOrNull(value: string): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function formatTime(dateLike: string) {
+  return new Date(dateLike).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function getTimeLabel(dateLike: string, now: Date = new Date()) {
+  const date = new Date(dateLike);
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  const target = new Date(date);
+  target.setHours(0, 0, 0, 0);
+
+  if (target.getTime() === today.getTime()) return 'Today';
+  if (target.getTime() === tomorrow.getTime()) return 'Tomorrow';
+  return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function eventTypeIcon(type: CalendarToolbarEventType) {
+  switch (type) {
+    case 'meeting':
+      return '👥';
+    case 'reminder':
+      return '⏰';
+    case 'task':
+      return '✅';
+    case 'personal':
+      return '🗓️';
+    default:
+      return '📅';
+  }
+}
+
+function eventTypeColor(type: CalendarToolbarEventType) {
+  switch (type) {
+    case 'meeting':
+      return 'bg-blue-500/20 text-blue-300 border-blue-500/30';
+    case 'reminder':
+      return 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30';
+    case 'task':
+      return 'bg-green-500/20 text-green-300 border-green-500/30';
+    case 'personal':
+      return 'bg-purple-500/20 text-purple-300 border-purple-500/30';
+    default:
+      return 'bg-gray-500/20 text-gray-300 border-gray-500/30';
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildDraftFromEvent(event: CalendarEvent): CalendarToolbarDraft {
+  return {
+    title: event.title,
+    startInput: toDateTimeLocalValue(event.startTime),
+    endInput: toDateTimeLocalValue(event.endTime),
+  };
+}
+
+function draftIsValid(draft: CalendarToolbarDraft): boolean {
+  const startIso = toIsoOrNull(draft.startInput);
+  const endIso = toIsoOrNull(draft.endInput);
+  return Boolean(
+    draft.title.trim()
+    && startIso
+    && endIso
+    && new Date(startIso).getTime() < new Date(endIso).getTime(),
+  );
+}
+
+export const CalendarToolbar: React.FC<CalendarToolbarProps> = ({
+  className = '',
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [events, setEvents] = useState<CalendarEvent[]>([
-    {
-      id: '1',
-      title: 'Team Standup',
-      startTime: new Date(Date.now() + 3600000), // 1 hour from now
-      endTime: new Date(Date.now() + 5400000), // 1.5 hours from now
-      type: 'meeting',
-      attendees: ['Alice', 'Bob', 'Charlie'],
-      assistantGenerated: false
-    },
-    {
-      id: '2',
-      title: 'Project Review',
-      startTime: new Date(Date.now() + 86400000), // Tomorrow
-      endTime: new Date(Date.now() + 90000000),
-      type: 'meeting',
-      assistantGenerated: true
-    },
-    {
-      id: '3',
-      title: 'Lunch Break',
-      startTime: new Date(Date.now() + 7200000), // 2 hours from now
-      endTime: new Date(Date.now() + 10800000), // 3 hours from now
-      type: 'personal'
-    }
-  ]);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerDraft, setComposerDraft] = useState<CalendarToolbarDraft>(() => buildDefaultEventDraft());
+  const [editingEventId, setEditingEventId] = useState<string | null>(null);
+  const [editingDraft, setEditingDraft] = useState<CalendarToolbarDraft>(() => buildDefaultEventDraft());
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [busyEventId, setBusyEventId] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  // Close dropdown when clicking outside
+  const {
+    upcomingEvents,
+    providers,
+    isLoading,
+    error,
+    fetchEvents,
+    fetchProviders,
+    createEvent,
+    updateEvent,
+    deleteEvent,
+  } = useCalendar();
+
+  const visibleEvents = useMemo(
+    () => selectToolbarUpcomingEvents(upcomingEvents),
+    [upcomingEvents],
+  );
+  const connectedProviders = providers.filter((provider) => provider.connected);
+  const nextEvent = visibleEvents[0];
+  const activeError = submissionError ?? error;
+
+  const refreshCalendarPanel = useCallback(async () => {
+    const start = new Date();
+    const end = new Date(start);
+    end.setDate(end.getDate() + UPCOMING_WINDOW_DAYS);
+
+    setSubmissionError(null);
+    await Promise.all([
+      fetchEvents(start.toISOString(), end.toISOString()),
+      fetchProviders(),
+    ]);
+  }, [fetchEvents, fetchProviders]);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
-        dropdownRef.current && 
-        buttonRef.current &&
-        !dropdownRef.current.contains(event.target as Node) &&
-        !buttonRef.current.contains(event.target as Node)
+        dropdownRef.current
+        && buttonRef.current
+        && !dropdownRef.current.contains(event.target as Node)
+        && !buttonRef.current.contains(event.target as Node)
       ) {
         setIsOpen(false);
       }
@@ -121,242 +305,424 @@ export const CalendarToolbar: React.FC<CalendarToolbarProps> = ({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (isOpen) {
+      void refreshCalendarPanel();
+    }
+  }, [isOpen, refreshCalendarPanel]);
+
   const toggleCalendarPanel = () => {
-    setIsOpen(prev => !prev);
+    setIsOpen((prev) => !prev);
   };
 
-  const getEventTypeIcon = (type: string) => {
-    switch (type) {
-      case 'meeting': return '👥';
-      case 'reminder': return '⏰';
-      case 'task': return '✅';
-      case 'personal': return '🗓️';
-      default: return '📅';
+  const openComposer = () => {
+    setEditingEventId(null);
+    setSubmissionError(null);
+    setComposerDraft(buildDefaultEventDraft());
+    setComposerOpen(true);
+  };
+
+  const closeComposer = () => {
+    setComposerOpen(false);
+    setComposerDraft(buildDefaultEventDraft());
+  };
+
+  const startEditing = (event: CalendarEvent) => {
+    setComposerOpen(false);
+    setSubmissionError(null);
+    setEditingEventId(event.id);
+    setEditingDraft(buildDraftFromEvent(event));
+  };
+
+  const cancelEditing = () => {
+    setEditingEventId(null);
+    setEditingDraft(buildDefaultEventDraft());
+  };
+
+  const handleCreateEvent = async () => {
+    if (!draftIsValid(composerDraft)) {
+      setSubmissionError('Enter a title and a valid time range.');
+      return;
+    }
+
+    const startTime = toIsoOrNull(composerDraft.startInput);
+    const endTime = toIsoOrNull(composerDraft.endInput);
+    if (!startTime || !endTime) {
+      setSubmissionError('Enter a valid start and end time.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmissionError(null);
+    try {
+      await createEvent({
+        title: composerDraft.title.trim(),
+        startTime,
+        endTime,
+        allDay: false,
+        metadata: { source: 'calendar_toolbar' },
+      });
+      closeComposer();
+    } catch (createError) {
+      setSubmissionError(errorMessage(createError));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  const getEventTypeColor = (type: string) => {
-    switch (type) {
-      case 'meeting': return 'bg-blue-500/20 text-blue-300 border-blue-500/30';
-      case 'reminder': return 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30';
-      case 'task': return 'bg-green-500/20 text-green-300 border-green-500/30';
-      case 'personal': return 'bg-purple-500/20 text-purple-300 border-purple-500/30';
-      default: return 'bg-gray-500/20 text-gray-300 border-gray-500/30';
+  const handleUpdateEvent = async () => {
+    if (!editingEventId) return;
+    if (!draftIsValid(editingDraft)) {
+      setSubmissionError('Enter a title and a valid time range.');
+      return;
+    }
+
+    const startTime = toIsoOrNull(editingDraft.startInput);
+    const endTime = toIsoOrNull(editingDraft.endInput);
+    if (!startTime || !endTime) {
+      setSubmissionError('Enter a valid start and end time.');
+      return;
+    }
+
+    setBusyEventId(editingEventId);
+    setSubmissionError(null);
+    try {
+      await updateEvent(editingEventId, {
+        title: editingDraft.title.trim(),
+        startTime,
+        endTime,
+      });
+      cancelEditing();
+    } catch (updateError) {
+      setSubmissionError(errorMessage(updateError));
+    } finally {
+      setBusyEventId(null);
     }
   };
 
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const handleDeleteEvent = async (eventId: string) => {
+    setBusyEventId(eventId);
+    setSubmissionError(null);
+    try {
+      await deleteEvent(eventId);
+      if (editingEventId === eventId) {
+        cancelEditing();
+      }
+    } catch (deleteError) {
+      setSubmissionError(errorMessage(deleteError));
+    } finally {
+      setBusyEventId(null);
+    }
   };
-
-  const isToday = (date: Date) => {
-    const today = new Date();
-    return date.toDateString() === today.toDateString();
-  };
-
-  const isTomorrow = (date: Date) => {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    return date.toDateString() === tomorrow.toDateString();
-  };
-
-  const getTimeLabel = (date: Date) => {
-    if (isToday(date)) return 'Today';
-    if (isTomorrow(date)) return 'Tomorrow';
-    return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
-  };
-
-  // Get upcoming events (next 7 days)
-  const upcomingEvents = events
-    .filter(event => event.startTime >= new Date())
-    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
-    .slice(0, 5);
-
-  const hasUpcomingEvents = upcomingEvents.length > 0;
-  const nextEvent = upcomingEvents[0];
 
   return (
     <div className={`relative ${className}`}>
-      {/* Calendar Toolbar Button */}
       <button
         ref={buttonRef}
         onClick={toggleCalendarPanel}
         className="relative flex items-center gap-2 px-3 py-1.5 bg-gray-800/30 border border-gray-700/50 rounded-lg text-white hover:bg-gray-700/50 transition-colors cursor-pointer"
         title="Calendar"
       >
-        {/* Calendar Icon with Badge */}
         <div className="relative">
           <div
             style={createGlassButtonStyle('107, 114, 128', 'md', true)}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2"/>
-              <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" strokeWidth="2"/>
-              <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" strokeWidth="2"/>
-              <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" strokeWidth="2"/>
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2" />
+              <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" strokeWidth="2" />
+              <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" strokeWidth="2" />
+              <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" strokeWidth="2" />
             </svg>
           </div>
-          {hasUpcomingEvents && (
-            <div className="absolute -top-1 -right-1 w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
+          {visibleEvents.length > 0 && (
+            <div className="absolute -top-1 -right-1 w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
           )}
         </div>
-        
-        {/* Label */}
+
         <span className="text-xs font-medium">Calendar</span>
       </button>
 
-      {/* Calendar Dropdown */}
       {isOpen && (
         <>
-          {/* Backdrop for mobile */}
           <div className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40 md:hidden" />
-          
-          {/* Dropdown Content */}
+
           <div
             ref={dropdownRef}
             className="absolute right-0 top-full mt-2 w-96 bg-gray-900/95 backdrop-blur-lg border border-gray-700 rounded-xl shadow-2xl z-50 overflow-hidden animate-in slide-in-from-top-2 duration-200"
           >
-            {/* Header */}
             <div className="flex items-center justify-between p-4 border-b border-gray-700/50">
               <div className="flex items-center gap-2">
                 <div
                   style={createGlassButtonStyle('59, 130, 246', 'md')}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2"/>
-                    <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" strokeWidth="2"/>
-                    <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" strokeWidth="2"/>
-                    <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" strokeWidth="2"/>
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" strokeWidth="2" />
+                    <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" strokeWidth="2" />
+                    <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" strokeWidth="2" />
                   </svg>
                 </div>
                 <div>
                   <h3 className="text-sm font-semibold text-white">Calendar</h3>
                   <p className="text-xs text-gray-400">
-                    {hasUpcomingEvents ? `${upcomingEvents.length} upcoming events` : 'No upcoming events'}
+                    {isLoading
+                      ? 'Loading schedule...'
+                      : visibleEvents.length > 0
+                        ? `${visibleEvents.length} upcoming events`
+                        : 'No upcoming events'}
                   </p>
                 </div>
               </div>
-              
+
               <button
                 onClick={() => setIsOpen(false)}
                 className="w-6 h-6 flex items-center justify-center hover:bg-gray-700/50 rounded text-gray-400 hover:text-white transition-colors"
                 title="Close"
               >
                 <svg width="8" height="8" viewBox="0 0 24 24" fill="none">
-                  <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                  <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                 </svg>
               </button>
             </div>
 
-            {/* Next Event Highlight */}
             {nextEvent && (
               <div className="p-4 border-b border-gray-700/50 bg-gradient-to-r from-blue-500/10 to-purple-500/10">
                 <div className="flex items-center gap-2 mb-2">
                   <span className="text-sm">⏰</span>
                   <span className="text-xs font-medium text-blue-300">Up Next</span>
                 </div>
-                <div className="flex items-center justify-between">
+                <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="text-sm font-medium text-white">{nextEvent.title}</div>
                     <div className="text-xs text-gray-400">
                       {getTimeLabel(nextEvent.startTime)} at {formatTime(nextEvent.startTime)}
                     </div>
                   </div>
-                  <div className={`px-2 py-1 rounded text-xs border ${getEventTypeColor(nextEvent.type)}`}>
-                    {getEventTypeIcon(nextEvent.type)} {nextEvent.type}
+                  <div className={`px-2 py-1 rounded text-xs border ${eventTypeColor(getCalendarToolbarEventType(nextEvent))}`}>
+                    {eventTypeIcon(getCalendarToolbarEventType(nextEvent))} {getCalendarToolbarEventType(nextEvent)}
                   </div>
                 </div>
               </div>
             )}
 
-            {/* Upcoming Events */}
+            {activeError && (
+              <div className="mx-4 mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+                {activeError}
+              </div>
+            )}
+
+            {composerOpen && (
+              <div className="p-4 border-b border-gray-700/50 space-y-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-gray-400">Quick Event</div>
+                <input
+                  type="text"
+                  value={composerDraft.title}
+                  onChange={(event) => setComposerDraft((draft) => ({ ...draft, title: event.target.value }))}
+                  placeholder="Event title"
+                  className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+                />
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="text-xs text-gray-400">
+                    <span className="mb-1 block">Start</span>
+                    <input
+                      type="datetime-local"
+                      value={composerDraft.startInput}
+                      onChange={(event) => setComposerDraft((draft) => ({ ...draft, startInput: event.target.value }))}
+                      className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                    />
+                  </label>
+                  <label className="text-xs text-gray-400">
+                    <span className="mb-1 block">End</span>
+                    <input
+                      type="datetime-local"
+                      value={composerDraft.endInput}
+                      onChange={(event) => setComposerDraft((draft) => ({ ...draft, endInput: event.target.value }))}
+                      className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                    />
+                  </label>
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    onClick={closeComposer}
+                    className="px-3 py-2 text-xs text-gray-300 hover:text-white transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => void handleCreateEvent()}
+                    disabled={isSubmitting}
+                    className="rounded-lg bg-blue-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isSubmitting ? 'Saving...' : 'Create Event'}
+                  </button>
+                </div>
+              </div>
+            )}
+
             <div className="max-h-80 overflow-y-auto">
-              {upcomingEvents.length === 0 ? (
+              {visibleEvents.length === 0 && !isLoading ? (
                 <div className="p-4 text-center text-gray-400 text-sm">
                   <div className="text-2xl mb-2">🗓️</div>
                   <div>No upcoming events</div>
-                  <div className="text-xs mt-2">Your schedule is clear!</div>
+                  <div className="text-xs mt-2">Your schedule is clear for the next week.</div>
                 </div>
               ) : (
                 <div className="divide-y divide-gray-700/50">
-                  {upcomingEvents.map((event, index) => (
-                    <div
-                      key={event.id}
-                      className={`p-3 hover:bg-gray-800/30 transition-colors ${
-                        index === 0 ? 'bg-blue-500/5' : ''
-                      }`}
-                    >
-                      <div className="flex items-start gap-3">
-                        {/* Event Type Icon */}
-                        <div className="w-8 h-8 flex items-center justify-center bg-gray-800 rounded-lg">
-                          <span className="text-sm">{getEventTypeIcon(event.type)}</span>
-                        </div>
+                  {visibleEvents.map((event, index) => {
+                    const eventType = getCalendarToolbarEventType(event);
+                    const attendees = getEventAttendees(event);
+                    const isEditing = editingEventId === event.id;
 
-                        {/* Event Content */}
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="text-sm font-medium text-white truncate">
-                              {event.title}
-                            </span>
-                            {event.assistantGenerated && (
-                              <span className="text-xs bg-purple-500/20 text-purple-300 px-1 rounded">
-                                AI
-                              </span>
-                            )}
-                          </div>
-                          
-                          <div className="text-xs text-gray-400 mb-1">
-                            {getTimeLabel(event.startTime)} • {formatTime(event.startTime)} - {formatTime(event.endTime)}
-                          </div>
-
-                          {event.attendees && event.attendees.length > 0 && (
-                            <div className="text-xs text-gray-500">
-                              👥 {event.attendees.slice(0, 2).join(', ')}
-                              {event.attendees.length > 2 && ` +${event.attendees.length - 2}`}
+                    return (
+                      <div
+                        key={event.id}
+                        className={`p-3 hover:bg-gray-800/30 transition-colors ${index === 0 ? 'bg-blue-500/5' : ''}`}
+                      >
+                        {isEditing ? (
+                          <div className="space-y-3">
+                            <input
+                              type="text"
+                              value={editingDraft.title}
+                              onChange={(editEvent) => setEditingDraft((draft) => ({ ...draft, title: editEvent.target.value }))}
+                              className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                            />
+                            <div className="grid grid-cols-2 gap-2">
+                              <label className="text-xs text-gray-400">
+                                <span className="mb-1 block">Start</span>
+                                <input
+                                  type="datetime-local"
+                                  value={editingDraft.startInput}
+                                  onChange={(editEvent) => setEditingDraft((draft) => ({ ...draft, startInput: editEvent.target.value }))}
+                                  className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                                />
+                              </label>
+                              <label className="text-xs text-gray-400">
+                                <span className="mb-1 block">End</span>
+                                <input
+                                  type="datetime-local"
+                                  value={editingDraft.endInput}
+                                  onChange={(editEvent) => setEditingDraft((draft) => ({ ...draft, endInput: editEvent.target.value }))}
+                                  className="w-full rounded-lg border border-gray-600 bg-gray-800/50 px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                                />
+                              </label>
                             </div>
-                          )}
-                        </div>
+                            <div className="flex items-center justify-end gap-2">
+                              <button
+                                onClick={cancelEditing}
+                                className="px-3 py-2 text-xs text-gray-300 hover:text-white transition-colors"
+                              >
+                                Cancel
+                              </button>
+                              <button
+                                onClick={() => void handleUpdateEvent()}
+                                disabled={busyEventId === event.id}
+                                className="rounded-lg bg-blue-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+                              >
+                                {busyEventId === event.id ? 'Saving...' : 'Save'}
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex items-start gap-3">
+                            <div className="w-8 h-8 flex items-center justify-center bg-gray-800 rounded-lg">
+                              <span className="text-sm">{eventTypeIcon(eventType)}</span>
+                            </div>
 
-                        {/* Event Type Badge */}
-                        <div className={`px-2 py-1 rounded text-xs border ${getEventTypeColor(event.type)}`}>
-                          {event.type}
-                        </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-2 mb-1">
+                                <span className="text-sm font-medium text-white truncate">
+                                  {event.title}
+                                </span>
+                                {isAssistantGeneratedEvent(event) && (
+                                  <span className="text-xs bg-purple-500/20 text-purple-300 px-1 rounded">
+                                    AI
+                                  </span>
+                                )}
+                              </div>
+
+                              <div className="text-xs text-gray-400 mb-1">
+                                {getTimeLabel(event.startTime)} • {formatTime(event.startTime)} - {formatTime(event.endTime)}
+                              </div>
+
+                              {attendees.length > 0 && (
+                                <div className="text-xs text-gray-500">
+                                  👥 {attendees.slice(0, 2).join(', ')}
+                                  {attendees.length > 2 && ` +${attendees.length - 2}`}
+                                </div>
+                              )}
+
+                              {event.provider && (
+                                <div className="text-xs text-gray-500 mt-1">
+                                  Source: {event.provider}
+                                </div>
+                              )}
+                            </div>
+
+                            <div className="flex flex-col items-end gap-2">
+                              <div className={`px-2 py-1 rounded text-xs border ${eventTypeColor(eventType)}`}>
+                                {eventType}
+                              </div>
+                              <div className="flex items-center gap-2 text-xs">
+                                <button
+                                  onClick={() => startEditing(event)}
+                                  className="text-blue-300 hover:text-blue-200 transition-colors"
+                                >
+                                  Edit
+                                </button>
+                                <button
+                                  onClick={() => void handleDeleteEvent(event.id)}
+                                  disabled={busyEventId === event.id}
+                                  className="text-red-300 hover:text-red-200 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  {busyEventId === event.id ? 'Deleting...' : 'Delete'}
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>
 
-            {/* Quick Actions */}
             <div className="p-3 border-t border-gray-700/50">
               <div className="grid grid-cols-2 gap-2 mb-3">
-                <button className="flex items-center gap-2 p-2 bg-gray-800/30 hover:bg-gray-700/50 border border-gray-700/50 rounded text-left transition-colors">
+                <button
+                  onClick={composerOpen ? closeComposer : openComposer}
+                  className="flex items-center gap-2 p-2 bg-gray-800/30 hover:bg-gray-700/50 border border-gray-700/50 rounded text-left transition-colors"
+                >
                   <span className="text-sm">➕</span>
-                  <span className="text-xs text-gray-300">Quick Event</span>
+                  <span className="text-xs text-gray-300">
+                    {composerOpen ? 'Close Composer' : 'Quick Event'}
+                  </span>
                 </button>
-                <button className="flex items-center gap-2 p-2 bg-gray-800/30 hover:bg-gray-700/50 border border-gray-700/50 rounded text-left transition-colors">
-                  <span className="text-sm">🔍</span>
-                  <span className="text-xs text-gray-300">Find Time</span>
+                <button
+                  onClick={() => void refreshCalendarPanel()}
+                  disabled={isLoading}
+                  className="flex items-center gap-2 p-2 bg-gray-800/30 hover:bg-gray-700/50 border border-gray-700/50 rounded text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <span className="text-sm">↻</span>
+                  <span className="text-xs text-gray-300">{isLoading ? 'Refreshing...' : 'Refresh'}</span>
                 </button>
               </div>
             </div>
 
-            {/* Footer */}
             <div className="p-3 border-t border-gray-700/50 bg-gray-800/30">
-              <div className="flex items-center justify-between text-xs text-gray-400">
+              <div className="flex items-center justify-between text-xs text-gray-400 gap-3">
                 <div>
-                  {hasUpcomingEvents ? (
-                    <span className="text-blue-400">
-                      Next: {formatTime(nextEvent.startTime)}
-                    </span>
+                  {connectedProviders.length > 0
+                    ? `${connectedProviders.length} calendar sync ${connectedProviders.length === 1 ? 'provider' : 'providers'} connected`
+                    : 'No calendar providers connected'}
+                </div>
+                <div className="text-right">
+                  {nextEvent ? (
+                    <span className="text-blue-400">Next: {formatTime(nextEvent.startTime)}</span>
                   ) : (
                     <span className="text-green-400">Schedule is clear</span>
                   )}
                 </div>
-                <button className="text-purple-400 hover:text-purple-300 transition-colors">
-                  Schedule with AI
-                </button>
               </div>
             </div>
           </div>

--- a/src/components/ui/__tests__/CalendarToolbar.test.ts
+++ b/src/components/ui/__tests__/CalendarToolbar.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  buildDefaultEventDraft,
+  getCalendarToolbarEventType,
+  getEventAttendees,
+  isAssistantGeneratedEvent,
+  selectToolbarUpcomingEvents,
+} from '../CalendarToolbar';
+import type { CalendarEvent } from '../../../stores/useCalendarStore';
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: 'evt-1',
+    title: 'Standup',
+    startTime: '2026-04-29T10:00:00.000Z',
+    endTime: '2026-04-29T10:30:00.000Z',
+    allDay: false,
+    provider: 'local',
+    reminders: [],
+    metadata: undefined,
+    ...overrides,
+  };
+}
+
+describe('CalendarToolbar helpers', () => {
+  test('builds a default quick-event draft on the next half-hour slot', () => {
+    const draft = buildDefaultEventDraft(new Date('2026-04-29T10:17:00'));
+
+    expect(draft.title).toBe('');
+    expect(draft.startInput).toBe('2026-04-29T10:30');
+    expect(draft.endInput).toBe('2026-04-29T11:30');
+  });
+
+  test('selects, sorts, and limits upcoming events', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T09:00:00.000Z'));
+
+    const events = [
+      makeEvent({ id: 'later', startTime: '2026-04-29T13:00:00.000Z', endTime: '2026-04-29T13:30:00.000Z' }),
+      makeEvent({ id: 'past', startTime: '2026-04-29T07:00:00.000Z', endTime: '2026-04-29T07:30:00.000Z' }),
+      makeEvent({ id: 'soon', startTime: '2026-04-29T09:30:00.000Z', endTime: '2026-04-29T10:00:00.000Z' }),
+      makeEvent({ id: 'latest', startTime: '2026-04-29T15:00:00.000Z', endTime: '2026-04-29T15:30:00.000Z' }),
+      makeEvent({ id: 'mid', startTime: '2026-04-29T11:00:00.000Z', endTime: '2026-04-29T11:30:00.000Z' }),
+      makeEvent({ id: 'cap', startTime: '2026-04-29T16:00:00.000Z', endTime: '2026-04-29T16:30:00.000Z' }),
+    ];
+
+    expect(selectToolbarUpcomingEvents(events, Date.now(), 4).map((event) => event.id)).toEqual([
+      'soon',
+      'mid',
+      'later',
+      'latest',
+    ]);
+
+    vi.useRealTimers();
+  });
+
+  test('derives calendar event types from metadata and title hints', () => {
+    expect(getCalendarToolbarEventType(makeEvent({ metadata: { type: 'task' } }))).toBe('task');
+    expect(getCalendarToolbarEventType(makeEvent({ metadata: { category: 'personal' } }))).toBe('personal');
+    expect(getCalendarToolbarEventType(makeEvent({ title: 'Reminder: send invoice' }))).toBe('reminder');
+    expect(getCalendarToolbarEventType(makeEvent())).toBe('meeting');
+  });
+
+  test('detects assistant-generated events and normalizes attendees', () => {
+    const event = makeEvent({
+      metadata: {
+        source: 'mate',
+        attendees: [
+          'Alice',
+          { name: 'Bob' },
+          { email: 'carol@example.com' },
+          { ignored: true },
+        ],
+      },
+    });
+
+    expect(isAssistantGeneratedEvent(event)).toBe(true);
+    expect(getEventAttendees(event)).toEqual(['Alice', 'Bob', 'carol@example.com']);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the demo-only calendar toolbar with real  store data
- add quick create, edit, delete, and refresh flows for upcoming events
- add focused helper tests for upcoming-event selection and draft shaping

## Testing
- npm test -- src/components/ui/__tests__/CalendarToolbar.test.ts src/stores/__tests__/useCalendarStore.test.ts src/hooks/__tests__/useCalendar.test.tsx
- npm test
- ./node_modules/.bin/eslint src/components/ui/CalendarToolbar.tsx src/components/ui/__tests__/CalendarToolbar.test.ts

Refs #355