### PR TITLE
fix(mate): wire task and schedule confirmations

### DIFF
--- a/src/api/__tests__/chatService.test.ts
+++ b/src/api/__tests__/chatService.test.ts
@@ -28,6 +28,9 @@ vi.mock('../parsing/AGUIEventParser', () => ({
 }));
 
 vi.mock('../../config/gatewayConfig', () => ({
+  GATEWAY_CONFIG: {
+    BASE_URL: 'http://localhost:9080',
+  },
   GATEWAY_ENDPOINTS: {
     AGENTS: {
       CHAT: 'http://localhost:9080/agents/chat',
@@ -136,6 +139,8 @@ describe('ChatService', () => {
       onResumeStart: vi.fn(),
       onResumeEnd: vi.fn(),
       onTaskProgress: vi.fn(),
+      onTaskCreated: vi.fn(),
+      onScheduleCreated: vi.fn(),
       onHILInterruptDetected: vi.fn(),
       onHILCheckpointCreated: vi.fn(),
       onBrowserScreenshot: vi.fn(),
@@ -539,6 +544,47 @@ describe('ChatService', () => {
           target: 'https://example.com',
         }),
       );
+    });
+
+    test('custom schedule_created forwards schedule confirmation payload', async () => {
+      await streamEvent({
+        type: 'custom_event',
+        thread_id: 'session-1',
+        metadata: {
+          custom_type: 'schedule_created',
+          job_id: 'job-1',
+          name: 'Daily digest',
+          cron_expression: '0 9 * * *',
+          next_run_at: '2026-04-30T01:00:00Z',
+        },
+      });
+
+      expect(callbacks.onScheduleCreated).toHaveBeenCalledWith({
+        jobId: 'job-1',
+        name: 'Daily digest',
+        cronExpression: '0 9 * * *',
+        nextRunAt: '2026-04-30T01:00:00Z',
+        description: undefined,
+      });
+    });
+
+    test('custom task_created forwards task payload', async () => {
+      await streamEvent({
+        type: 'custom_event',
+        metadata: {
+          custom_type: 'task_created',
+          task_id: 'task-1',
+          title: 'Follow up with design',
+          due_at: '2026-04-30T09:00:00Z',
+        },
+      });
+
+      expect(callbacks.onTaskCreated).toHaveBeenCalledWith({
+        id: 'task-1',
+        title: 'Follow up with design',
+        description: undefined,
+        dueAt: '2026-04-30T09:00:00Z',
+      });
     });
 
     test('browser hil_approval_required also creates pending browser action', async () => {

--- a/src/api/adapters/__tests__/MateEventAdapter.test.ts
+++ b/src/api/adapters/__tests__/MateEventAdapter.test.ts
@@ -289,6 +289,52 @@ describe('adaptMateEvent — lifecycle events', () => {
   });
 });
 
+describe('adaptMateEvent — scheduling events', () => {
+  const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
+
+  test('schedule_created maps to a schedule confirmation custom event', () => {
+    const event: MateSSEEvent = {
+      type: 'schedule_created',
+      job_id: 'job-1',
+      metadata: {
+        name: 'Daily digest',
+        cron_expression: '0 9 * * *',
+        next_run_at: '2026-04-30T01:00:00Z',
+      },
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('custom_event');
+    expect(events[0].metadata).toMatchObject({
+      custom_type: 'schedule_created',
+      job_id: 'job-1',
+      name: 'Daily digest',
+      cron_expression: '0 9 * * *',
+      next_run_at: '2026-04-30T01:00:00Z',
+    });
+  });
+
+  test('task_created maps to a task confirmation custom event', () => {
+    const event: MateSSEEvent = {
+      type: 'task_created',
+      task_id: 'task-1',
+      title: 'Follow up with design',
+      due_at: '2026-04-30T09:00:00Z',
+    };
+    const { events } = adaptMateEvent(event, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('custom_event');
+    expect(events[0].metadata).toMatchObject({
+      custom_type: 'task_created',
+      task_id: 'task-1',
+      title: 'Follow up with design',
+      due_at: '2026-04-30T09:00:00Z',
+    });
+  });
+});
+
 describe('adaptMateEvent — informational events', () => {
   const ctx = { runId: 'run_1', sessionId: 'sess_1', currentMessageId: null };
 

--- a/src/api/chatService.ts
+++ b/src/api/chatService.ts
@@ -59,6 +59,14 @@ export interface ChatServiceCallbacks {
   onTaskProgress?: (progress: any) => void;
   onTaskListUpdate?: (tasks: any[]) => void;
   onTaskStatusUpdate?: (taskId: string, status: string, result?: any) => void;
+  onTaskCreated?: (task: { id: string; title: string; description?: string; dueAt?: string }) => void;
+  onScheduleCreated?: (schedule: {
+    jobId: string;
+    name: string;
+    cronExpression: string;
+    nextRunAt?: string;
+    description?: string;
+  }) => void;
   
   // HIL回调
   onHILInterruptDetected?: (hilEvent: any) => void;
@@ -614,16 +622,26 @@ export class ChatService {
       }
 
       case 'task_created': {
-        const { useTaskStore } = require('../stores/useTaskStore');
-        useTaskStore.getState().addTask({
+        callbacks.onTaskCreated?.({
           id: event.metadata?.task_id || `task-${Date.now()}`,
           title: event.metadata?.title || 'New task',
           description: event.metadata?.description,
-          status: 'pending',
           dueAt: event.metadata?.due_at,
-          createdAt: new Date().toISOString(),
         });
         log.info('Task created from conversation', { taskId: event.metadata?.task_id });
+        break;
+      }
+
+      case 'schedule_created': {
+        const scheduleData = {
+          jobId: event.metadata?.job_id || customData.job_id || `job-${Date.now()}`,
+          name: event.metadata?.name || customData.name || 'Scheduled Task',
+          cronExpression: event.metadata?.cron_expression || customData.cron_expression || '',
+          nextRunAt: event.metadata?.next_run_at || customData.next_run_at,
+          description: event.metadata?.description || customData.description,
+        };
+        callbacks.onScheduleCreated?.(scheduleData);
+        log.info('Schedule created from conversation', { jobId: scheduleData.jobId });
         break;
       }
 

--- a/src/modules/handlers/messageHandlers.ts
+++ b/src/modules/handlers/messageHandlers.ts
@@ -12,7 +12,7 @@ import { usePerformanceStore } from '../../stores/usePerformanceStore';
 import { useStreamingStore } from '../../stores/useStreamingStore';
 import { logger, LogCategory, createLogger } from '../../utils/logger';
 import { detectPluginTrigger, executePlugin } from '../../plugins';
-import { ArtifactMessage } from '../../types/chatTypes';
+import { ArtifactMessage, RegularMessage, ScheduleConfirmationData } from '../../types/chatTypes';
 import { AppId } from '../../types/appTypes';
 import { CreditConsumption } from '../../types/userTypes';
 import { isDelegationTool } from '../../constants/delegationTeams';
@@ -20,6 +20,7 @@ import { MessageTimingTracker, formatTimingLog } from '../../utils/messageTiming
 import { emitObservabilityRefresh } from '../../utils/observabilityEvents';
 import { useProjectStore } from '../../stores/useProjectStore';
 import { mergeProjectPromptArgs } from '../../utils/projectContext';
+import { useTaskStore } from '../../stores/useTaskStore';
 
 const log = createLogger('ChatModule:Message');
 
@@ -322,6 +323,58 @@ export function createMessageHandlers(deps: MessageHandlerDeps) {
               useMessageStore.getState().completeDelegation(active.toolCallId, result, error);
             }
             refreshObservability('tool_completed');
+          },
+          onTaskCreated: (task: { id: string; title: string; description?: string; dueAt?: string }) => {
+            const taskStore = useTaskStore.getState();
+            taskStore.ingestBackendTask({
+              ...task,
+              status: 'pending',
+              createdAt: new Date().toISOString(),
+            });
+            void taskStore.syncTasks();
+            refreshObservability('task_created');
+          },
+          onScheduleCreated: (schedule: ScheduleConfirmationData) => {
+            const chatStore = useChatStore.getState();
+            const lastAssistantMessage = [...chatStore.messages]
+              .reverse()
+              .find((message): message is RegularMessage => message.role === 'assistant' && message.type === 'regular');
+
+            if (lastAssistantMessage) {
+              chatStore.addMessage({
+                ...lastAssistantMessage,
+                jobId: schedule.jobId,
+                scheduleData: schedule,
+                metadata: {
+                  ...(lastAssistantMessage.metadata || {}),
+                  job_id: schedule.jobId,
+                  job_name: schedule.name,
+                  cron_expression: schedule.cronExpression,
+                  next_run_at: schedule.nextRunAt,
+                  description: schedule.description,
+                },
+              });
+            } else {
+              const scheduleMessage: RegularMessage = {
+                id: `assistant-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+                type: 'regular',
+                role: 'assistant',
+                content: `Scheduled ${schedule.name}`,
+                timestamp: new Date().toISOString(),
+                sessionId: sessionId || 'default',
+                jobId: schedule.jobId,
+                scheduleData: schedule,
+                metadata: {
+                  job_id: schedule.jobId,
+                  job_name: schedule.name,
+                  cron_expression: schedule.cronExpression,
+                  next_run_at: schedule.nextRunAt,
+                  description: schedule.description,
+                },
+              };
+              chatStore.addMessage(scheduleMessage);
+            }
+            refreshObservability('schedule_created');
           },
           onLLMCompleted: () => refreshObservability('llm_completed'),
           onBillingUpdate: () => refreshObservability('billing_update'),

--- a/src/stores/__tests__/useTaskStore.test.ts
+++ b/src/stores/__tests__/useTaskStore.test.ts
@@ -212,6 +212,19 @@ describe('useTaskStore', () => {
       expect(useTaskStore.getState().getTask('task-backend-1')?.title).toBe('Backend task');
     });
 
+    test('ingestBackendTask updates local state without creating a duplicate backend task', () => {
+      useTaskStore.getState().ingestBackendTask({
+        id: 'task-event-1',
+        title: 'Task from Mate',
+        status: 'pending',
+        createdAt: '2026-04-29T00:00:00Z',
+      });
+
+      expect(mockCreateTask).not.toHaveBeenCalled();
+      expect(useTaskStore.getState().getTask('task-event-1')?.title).toBe('Task from Mate');
+      expect(useTaskStore.getState().totalTasks).toBe(1);
+    });
+
     test('syncTaskStatus completes a task through the backend', async () => {
       useTaskStore.setState({
         tasks: [

--- a/src/stores/useTaskStore.ts
+++ b/src/stores/useTaskStore.ts
@@ -48,6 +48,14 @@ interface TaskActions {
   }) => Promise<TaskItem | null>;
   syncTaskStatus: (taskId: string, status: BackendTask['status']) => Promise<TaskItem | null>;
   deleteBackendTask: (taskId: string) => Promise<void>;
+  ingestBackendTask: (task: {
+    id: string;
+    title: string;
+    description?: string;
+    status: string;
+    dueAt?: string;
+    createdAt: string;
+  }) => void;
   addTask: (task: { id: string; title: string; description?: string; status: string; dueAt?: string; createdAt: string }) => void;
 
   // 任务创建和管理
@@ -126,6 +134,36 @@ function toTaskItem(task: BackendTask): TaskItem {
       dueAt: task.dueAt,
       synced: true,
     },
+  };
+}
+
+function toExternalTaskItem(task: {
+  id: string;
+  title: string;
+  description?: string;
+  status: string;
+  dueAt?: string;
+  createdAt: string;
+}): TaskItem {
+  return {
+    id: task.id,
+    title: task.title,
+    type: 'background' as TaskType,
+    status: (task.status === 'in_progress' ? 'running' : task.status || 'pending') as TaskStatus,
+    priority: 'normal',
+    progress: {
+      currentStep: 0,
+      totalSteps: 1,
+      percentage: 0,
+      currentStepName: 'Pending sync',
+    },
+    createdAt: task.createdAt || new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    canPause: false,
+    canResume: false,
+    canCancel: true,
+    canRetry: false,
+    metadata: { description: task.description, dueAt: task.dueAt },
   };
 }
 
@@ -242,32 +280,21 @@ export const useTaskStore = create<TaskStore>()(
       }
     },
 
+    ingestBackendTask: (task) => {
+      const ingestedTask = toExternalTaskItem(task);
+      set((state) =>
+        applyTaskCollection([ingestedTask, ...state.tasks.filter((item) => item.id !== ingestedTask.id)]),
+      );
+      logger.info(LogCategory.TASK_MANAGEMENT, 'Task ingested from backend event', {
+        taskId: ingestedTask.id,
+      });
+    },
+
     addTask: (task) => {
-      const newTask: TaskItem = {
-        id: task.id,
-        title: task.title,
-        type: 'background' as TaskType,
-        status: (task.status === 'in_progress' ? 'running' : task.status || 'pending') as TaskStatus,
-        priority: 'normal',
-        progress: {
-          currentStep: 0,
-          totalSteps: 1,
-          percentage: 0,
-          currentStepName: 'Pending sync',
-        },
-        createdAt: task.createdAt || new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        canPause: false,
-        canResume: false,
-        canCancel: true,
-        canRetry: false,
-        metadata: { description: task.description, dueAt: task.dueAt },
-      };
-      set((state) => ({
-        tasks: [...state.tasks, newTask],
-        totalTasks: state.totalTasks + 1,
-        activeTasks: [...state.activeTasks, newTask],
-      }));
+      const newTask = toExternalTaskItem(task);
+      set((state) =>
+        applyTaskCollection([newTask, ...state.tasks.filter((item) => item.id !== newTask.id)]),
+      );
       // Fire-and-forget backend create
       TaskAdapter.createTask({ title: task.title, description: task.description, dueAt: task.dueAt }).catch(() => {});
       logger.info(LogCategory.TASK_MANAGEMENT, 'Task added (from chat)', { taskId: task.id });


### PR DESCRIPTION
## Summary
- move Mate task and schedule side effects onto explicit chat callbacks instead of mutating stores inside ChatService
- attach schedule_created confirmations to assistant messages in the chat module and ingest task_created events without duplicating backend tasks
- add regression coverage for Mate schedule/task events and the backend-ingest task path

## Testing
- npm test -- src/api/__tests__/chatService.test.ts src/api/adapters/__tests__/MateEventAdapter.test.ts src/stores/__tests__/useTaskStore.test.ts
- npm test
- ./node_modules/.bin/eslint src/api/chatService.ts src/modules/handlers/messageHandlers.ts src/stores/useTaskStore.ts src/api/__tests__/chatService.test.ts src/api/adapters/__tests__/MateEventAdapter.test.ts src/stores/__tests__/useTaskStore.test.ts

Refs #355